### PR TITLE
Keep the rclone pin out of rclone's reserved namespace

### DIFF
--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -18,7 +18,12 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  RCLONE_VERSION: v1.75.0
+  # Deliberately not named RCLONE_VERSION: rclone maps every RCLONE_* environment
+  # variable onto the flag of the same name, so that name reaches it as
+  # "--version v1.75.0" and aborts the run. The RCLONE_CONFIG_GDRIVE_* variables
+  # further down are the documented remote-configuration form and are meant to be
+  # read that way.
+  SPEC_RCLONE_VERSION: v1.75.0
 
 jobs:
   sync:
@@ -48,9 +53,9 @@ jobs:
           set -euo pipefail
           cd "${RUNNER_TEMP}"
           curl -fsSL -o rclone.zip \
-            "https://downloads.rclone.org/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-amd64.zip"
+            "https://downloads.rclone.org/${SPEC_RCLONE_VERSION}/rclone-${SPEC_RCLONE_VERSION}-linux-amd64.zip"
           unzip -q rclone.zip
-          sudo install -m 0755 "rclone-${RCLONE_VERSION}-linux-amd64/rclone" /usr/local/bin/rclone
+          sudo install -m 0755 "rclone-${SPEC_RCLONE_VERSION}-linux-amd64/rclone" /usr/local/bin/rclone
           rclone version
 
       - name: Write service account credentials outside the workspace


### PR DESCRIPTION
Closes #6

## Achieved outcome

`spec-sync` gets past its `Install rclone` step. The version pin is renamed from
`RCLONE_VERSION` to `SPEC_RCLONE_VERSION`, with a comment recording why that name is
unusable.

## Tested revision

The head of this branch. Verified by re-dispatching the workflow after merge — see
"Not checked" below for what that means for this pull request.

## Changed artifacts

`.github/workflows/spec-sync.yml` only. One environment variable renamed, three
references updated, one comment added. No behavior other than the failing step.

## Acceptance criteria

- [x] The pin no longer uses a name in rclone's reserved `RCLONE_*` namespace
- [ ] `spec-sync` gets past `Install rclone` and reports the pinned version — cannot
      be checked before merge, see below
- [x] The rest of the workflow is unchanged

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `build-and-test` | see checks tab | unaffected by this change |
| `policy-guard` | see checks tab | policy-only diff, no product paths |
| `spec-sync` end to end | `not_run` | `workflow_dispatch` runs the copy of a workflow on the default branch, so this fix cannot be exercised from a branch |

## Not checked

The actual fix. GitHub dispatches the version of a workflow that exists on `master`,
so the corrected step runs for the first time only after this merges. If it fails
again, the evidence will be a new run, not this pull request.

## Assumptions and unknowns

- **Established:** the error message names the mechanism exactly — rclone parsed
  `RCLONE_VERSION` as `--version` and failed `ParseBool`.
- **Unknown:** whether the mirror step itself works. Nothing past `Install rclone` has
  ever executed, so the service account permissions, the Drive export formats, and the
  pull request creation are all still unproven.

## Highest-risk area for review

None in this diff. The risk sits in the steps after it, which remain unexercised.

## Remaining gate

No mandatory work remains for this Issue. The next run of `spec-sync` is what closes
the question, and it will surface the next failure if there is one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)