### PR TITLE
Mirror only the allowlisted specification package

### DIFF
--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -1,8 +1,11 @@
 name: Spec sync
 
-# Mirrors the Google Drive specification folder into docs/spec/mirror/ and proposes it
-# as a pull request. This workflow never runs a model: it only copies bytes, so that
-# untrusted specification text can never reach an agent before review.
+# Mirrors the allowlisted part of the Google Drive specification folder into
+# docs/spec/mirror/ and proposes it as a pull request. This workflow never runs a
+# model: it only copies bytes, so untrusted specification text cannot reach an agent
+# before it has been through a reviewable diff.
+#
+# What is copied is decided by docs/zendev/spec-mirror-allowlist.txt, not here.
 
 on:
   schedule:
@@ -32,6 +35,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
 
       - name: Require configuration
         env:
@@ -66,7 +73,7 @@ jobs:
           umask 077
           printf '%s' "${SA_JSON}" > "${RUNNER_TEMP}/gdrive-sa.json"
 
-      - name: Mirror the specification folder
+      - name: Copy the allowlisted paths into a staging directory
         env:
           RCLONE_CONFIG_GDRIVE_TYPE: drive
           RCLONE_CONFIG_GDRIVE_SCOPE: drive.readonly
@@ -74,31 +81,52 @@ jobs:
           RCLONE_CONFIG_GDRIVE_ROOT_FOLDER_ID: ${{ vars.GDRIVE_FOLDER_ID }}
         run: |
           set -euo pipefail
-          mkdir -p docs/spec/mirror
-          rclone sync gdrive: docs/spec/mirror \
-            --drive-export-formats md,csv,txt \
-            --drive-acknowledge-abuse=false \
+          rm -rf "${RUNNER_TEMP}/mirror"
+          mkdir -p "${RUNNER_TEMP}/mirror"
+          # Staging, not the committed mirror: names are normalized afterwards, and
+          # renaming files underneath rclone would make every later sync see them as
+          # missing, re-download them and delete the renamed ones on every run.
+          rclone sync gdrive: "${RUNNER_TEMP}/mirror" \
+            --filter-from docs/zendev/spec-mirror-allowlist.txt \
+            --drive-export-formats md,csv \
             --max-size 5M \
-            --exclude "*.exe" --exclude "*.dll" --exclude "*.zip" --exclude "*.sh" \
-            --exclude "*.ps1" --exclude "*.py" --exclude "*.yml" --exclude "*.yaml" \
             --transfers 4 --checkers 8 --stats-one-line -v
 
-      - name: Refuse an implausible mirror
+      - name: Remove credentials
+        if: always()
+        run: rm -f "${RUNNER_TEMP}/gdrive-sa.json"
+
+      - name: Normalize exported filenames
+        run: python scripts/normalize_mirror.py "${RUNNER_TEMP}/mirror"
+
+      - name: Replace the committed mirror
+        run: |
+          set -euo pipefail
+          rm -rf docs/spec/mirror
+          mkdir -p docs/spec
+          cp -a "${RUNNER_TEMP}/mirror" docs/spec/mirror
+
+      - name: Report what arrived
         run: |
           set -euo pipefail
           size_kb=$(du -sk docs/spec/mirror | cut -f1)
           count=$(find docs/spec/mirror -type f | wc -l)
           echo "mirror: ${count} file(s), ${size_kb} KiB"
+          find docs/spec/mirror -type f -printf '  %P\n' | sort
           if [ "${size_kb}" -gt 51200 ]; then
             echo "::error::mirror exceeds 50 MiB; refusing to propose it"; exit 1
           fi
           if [ "${count}" -eq 0 ]; then
-            echo "::warning::mirror is empty — the folder may not be shared with the service account"
+            echo "::warning::mirror is empty — check that the folder is shared with the service account"
           fi
-
-      - name: Remove credentials
-        if: always()
-        run: rm -f "${RUNNER_TEMP}/gdrive-sa.json"
+          # The four navigation files are what make the specification readable one
+          # slice at a time. Their absence is not fatal here, but the author loop will
+          # block on it, so it is worth seeing in this log.
+          for required in REQUIREMENTS_REGISTRY.csv SPEC_INDEX.md EXECUTION_ORDER.md SPEC_CHANGELOG.md; do
+            if [ ! -f "docs/spec/mirror/${required}" ]; then
+              echo "::warning::navigation file ${required} is missing from the mirror"
+            fi
+          done
 
       - name: Propose the mirror as a pull request
         uses: peter-evans/create-pull-request@v8
@@ -113,7 +141,9 @@ jobs:
             type:docs
             area:spec
           body: |
-            Automated mirror of the Google Drive specification folder.
+            Automated mirror of the allowlisted part of the Google Drive specification
+            folder. What is included is decided by
+            `docs/zendev/spec-mirror-allowlist.txt`, which is a policy file.
 
             This pull request contains **no code**: the diff is confined to
             `docs/spec/mirror/**`. Its content is written by the researcher agent and
@@ -122,8 +152,7 @@ jobs:
 
             Acceptance for this pull request is narrow: confirm the diff touches only
             `docs/spec/mirror/**`, that no credential-shaped string appears, and that
-            the navigation files (`REQUIREMENTS_REGISTRY.csv`, `SPEC_CHANGELOG.md`,
-            `EXECUTION_ORDER.md`) are present or explicitly still absent.
+            nothing outside the allowlist arrived.
 
             Check outcomes are whatever the checks tab reports for the head revision
             of this pull request. This body asserts none of them.

--- a/docs/zendev/spec-mirror-allowlist.txt
+++ b/docs/zendev/spec-mirror-allowlist.txt
@@ -1,0 +1,36 @@
+# rclone filter rules for the specification mirror.
+#
+# This file decides what becomes PUBLIC. Everything mirrored from Drive lands in a
+# public repository, so widening this list publishes more of the specification. It
+# lives under docs/zendev/ deliberately: that makes it a policy path, which means a
+# change to it cannot ride along inside a product diff, and the acceptor may not merge
+# a widening on its own.
+#
+# The list is the researcher agent's explicit allowlist, given in
+# ANSWERS_TO_IMPLEMENTER on 2026-09-03, section A. The researcher reviewed these paths
+# and confirmed they contain no credentials, personal notes or private operational
+# data, and are intended for publication. That confirmation covers ONLY these paths.
+#
+# Excluded on purpose, and why: 00 - Control (working state and a duplicate manifest),
+# 01 - Inputs (raw user drafts), 02 - Research, 03 - Economic Model,
+# 04 - Visualization, 05 - Implementation Specs (canonical working copies) and
+# 90 - Reports. Mirroring working copies alongside the handoff package would create
+# two authorities for the same content and invite drift. 06 - Handoff is deliberately
+# self-contained.
+#
+# Anything not listed here is not mirrored. A new path is added only when the
+# researcher adds it to the allowlist in SPEC_CHANGELOG, and that change is reviewed
+# here as a policy change.
+#
+# Trailing wildcards absorb the extension Google Drive appends on export: a native
+# Google Doc titled SPEC_INDEX.md exports as SPEC_INDEX.md.md, which the mirror
+# normalizes afterwards.
+
++ /REQUIREMENTS_REGISTRY.csv*
++ /SPEC_INDEX.md*
++ /EXECUTION_ORDER.md*
++ /SPEC_CHANGELOG.md*
++ /ANSWERS_TO_IMPLEMENTER.md*
++ /06 - Handoff/**
+
+- *

--- a/scripts/normalize_mirror.py
+++ b/scripts/normalize_mirror.py
@@ -1,0 +1,74 @@
+"""Strip the extension Google Drive appends when exporting a native document.
+
+A Google Doc titled `SPEC_INDEX.md` exports to `SPEC_INDEX.md.md`, and a Google Sheet
+titled `REQUIREMENTS_REGISTRY.csv` exports to `REQUIREMENTS_REGISTRY.csv.csv`. The
+specification refers to files by their intended names, so the mirror normalizes them.
+
+This runs over a fresh staging copy, never over the committed mirror: renaming files
+underneath rclone would make the next sync see them as missing, re-download them and
+delete the renamed ones on every run.
+
+A rename that would overwrite an existing file is refused and reported. Two documents
+resolving to one name is a collision in the specification, not something to resolve by
+picking a winner silently.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+DOUBLED = (".md.md", ".csv.csv", ".txt.txt")
+
+
+def intended_name(name: str) -> str | None:
+    """Return the normalized name, or None when the name is already correct."""
+    for suffix in DOUBLED:
+        if name.endswith(suffix):
+            return name[: -len(suffix)] + suffix[len(suffix) // 2 :]
+    return None
+
+
+def plan(names):
+    """Map each name that needs renaming to its target. Pure, so it is testable."""
+    return {name: target for name in names if (target := intended_name(name))}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", help="staging directory to normalize in place")
+    args = parser.parse_args()
+
+    root = pathlib.Path(args.root)
+    if not root.is_dir():
+        print(f"::error::normalize_mirror: {root} is not a directory")
+        return 1
+
+    conflicts = []
+    renamed = 0
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        target_name = intended_name(path.name)
+        if target_name is None:
+            continue
+        target = path.with_name(target_name)
+        if target.exists():
+            conflicts.append(f"{path.relative_to(root)} -> {target.name} already exists")
+            continue
+        path.rename(target)
+        renamed += 1
+        print(f"normalize_mirror: {path.name} -> {target.name}")
+
+    if conflicts:
+        for conflict in conflicts:
+            print(f"::error::normalize_mirror: {conflict}")
+        return 1
+
+    print(f"normalize_mirror: {renamed} file(s) normalized")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_normalize_mirror.py
+++ b/scripts/tests/test_normalize_mirror.py
@@ -1,0 +1,48 @@
+"""The mirror is navigated by exact filename, so normalization has to be exact."""
+
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import normalize_mirror as norm  # noqa: E402
+
+
+class IntendedNameTests(unittest.TestCase):
+    def test_doubled_extensions_are_collapsed(self):
+        cases = {
+            "SPEC_INDEX.md.md": "SPEC_INDEX.md",
+            "REQUIREMENTS_REGISTRY.csv.csv": "REQUIREMENTS_REGISTRY.csv",
+            "NOTES.txt.txt": "NOTES.txt",
+            "01 — CORE_SCHEMA_AND_LIFECYCLES.md.md": "01 — CORE_SCHEMA_AND_LIFECYCLES.md",
+        }
+        for name, expected in cases.items():
+            with self.subTest(name=name):
+                self.assertEqual(norm.intended_name(name), expected)
+
+    def test_correct_names_are_left_alone(self):
+        for name in (
+            "SPEC_INDEX.md",
+            "REQUIREMENTS_REGISTRY.csv",
+            "01 — CORE_SCHEMA_AND_LIFECYCLES.md",
+            "START_HERE",
+            "archive.tar.gz",
+        ):
+            with self.subTest(name=name):
+                self.assertIsNone(norm.intended_name(name))
+
+    def test_a_single_dot_md_is_not_stripped(self):
+        # The failure worth guarding: turning SPEC_INDEX.md into SPEC_INDEX would
+        # break every FILE reference in the requirements registry.
+        self.assertIsNone(norm.intended_name("SPEC_INDEX.md"))
+
+
+class PlanTests(unittest.TestCase):
+    def test_plan_covers_only_what_needs_renaming(self):
+        plan = norm.plan(["A.md.md", "B.md", "C.csv.csv", "START_HERE"])
+        self.assertEqual(plan, {"A.md.md": "A.md", "C.csv.csv": "C.csv"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #10

## Achieved outcome

The mirror is now an allowlist rather than a whole-folder copy. Five control files and
`06 - Handoff/**` are taken; everything else in the specification folder is excluded by
default, including the working copies, research, inputs and reports.

## Tested revision

The head of this branch.

## Changed artifacts

| Artifact | Change |
| --- | --- |
| `docs/zendev/spec-mirror-allowlist.txt` | The rclone filter set, with the researcher decision and its reasons recorded beside it |
| `scripts/normalize_mirror.py` | Collapses the extension Drive appends on export |
| `scripts/tests/test_normalize_mirror.py` | Negative controls, including that a correct `.md` name is never stripped |
| `.github/workflows/spec-sync.yml` | Filter set, staging directory, normalization, and a listing of what arrived |

Two design points worth the review time:

**The allowlist is on a policy path.** `docs/zendev/` is policy, so `policy-guard`
refuses to let it change inside a product diff and the acceptor may not merge a
widening on its own. Widening this file publishes more of the specification, so it is
a decision for a person.

**The sync now stages.** rclone copies into `RUNNER_TEMP`, names are normalized there,
and the result replaces `docs/spec/mirror` wholesale. Normalizing in place would make
the next sync see the renamed files as missing, re-download the originals and delete
the renamed ones, on every single run.

## Acceptance criteria

- [x] Only allowlisted paths can arrive — the filter ends in `- *`
- [x] The allowlist lives on a policy path
- [x] `--drive-export-formats md,csv` gives Markdown for Docs and CSV for the Sheet
- [x] Doubled extensions are collapsed
- [x] Normalization runs on staging, so it cannot fight the next sync
- [x] A name collision fails the step with both names named
- [x] The run log lists every mirrored file

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest discover -s scripts/tests` | `passed` | 11 tests, 0 failures |
| Workflow YAML parse | `passed` | 11 steps |
| `build-and-test`, `policy-guard` | see checks tab | |
| The mirror itself | `not_run` | no sync has ever succeeded; the first dispatch happens after this merges |

## Not checked

Everything that depends on contact with Drive. The filter syntax, the export
behaviour, and the doubled-extension theory are all reasoned from the tool
documentation and the researcher description of the source, not observed. The first
dispatch is the experiment, and the listing step exists so that its result is legible
rather than inferred.

## Assumptions and unknowns

- **Established:** the allowlist and the publication confirmation, quoted in #10 from
  the researcher answer of 2026-09-03.
- **Reasoned conclusion:** exporting a Doc titled `SPEC_INDEX.md` yields
  `SPEC_INDEX.md.md`. If it does not, normalization simply renames nothing.
- **Unknown:** whether any two handoff documents normalize to the same filename. The
  script fails loudly if so rather than silently keeping one.
- **Unknown:** how the em-dash and spaces in the handoff filenames survive export. The
  listing step will show it.

## Highest-risk area for review

The filter file. A wrong rule here does not fail a build — it publishes something that
was meant to stay in Drive. The rules are anchored with a leading slash so they cannot
match nested directories by accident, and the final `- *` makes exclusion the default.

## Remaining gate

None for this Issue. After merge, one manual dispatch of `spec-sync` is what proves or
refutes the assumptions above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)