### PR TITLE
Add hash-verified seeded legacy baseline (REQ-MIGRATION-002)

### DIFF
--- a/TradeCraftSimulation.Tests/LegacyBaselineSnapshot.cs
+++ b/TradeCraftSimulation.Tests/LegacyBaselineSnapshot.cs
@@ -1,0 +1,60 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using Simulator;
+
+namespace TradeCraftSimulation.Tests;
+
+/// <summary>
+/// Normalizes a legacy <see cref="Simulation"/>'s state (city stocks, prices and pop
+/// balances) into a stable hash, independent of console/CSV text formatting. This is the
+/// golden reference REQ-MIGRATION-002 asks for: something the canonical migration can diff
+/// against without caring how a human-readable report happens to round or lay out numbers.
+/// </summary>
+public static class LegacyBaselineSnapshot
+{
+    /// <summary>
+    /// Builds the canonical string a hash is taken over. Iterates <see cref="Simulation.Cities"/>,
+    /// <see cref="City.Population"/> and <see cref="Storage.All"/> in their fixed declaration
+    /// order, so the result never depends on dictionary/hash-set iteration order, and formats
+    /// doubles round-trippable ("R") rather than at the fixed decimal precision the console/CSV
+    /// views use, so this snapshot cannot be mistaken for either of them.
+    /// </summary>
+    public static string Normalize(Simulation simulation)
+    {
+        var builder = new StringBuilder();
+        builder.Append("turn=").Append(simulation.Turn.ToString(CultureInfo.InvariantCulture));
+        builder.Append(";totalMoney=").Append(Num(simulation.TotalMoney));
+        builder.Append(";cargoLost=").Append(Num(simulation.TotalCargoLost));
+
+        foreach (City city in simulation.Cities)
+        {
+            builder.Append("|city=").Append(city.Type).Append(':').Append(city.Name);
+
+            foreach (ResourceType resource in Storage.All)
+            {
+                builder.Append(";res=").Append(resource)
+                    .Append(",price=").Append(Num(city.Market.PriceOf(resource)))
+                    .Append(",stock=").Append(Num(city.StockOf(resource)))
+                    .Append(",traded=").Append(Num(city.Market.Traded[resource]))
+                    .Append(",imported=").Append(Num(city.Market.Imported[resource]))
+                    .Append(",exported=").Append(Num(city.Market.Exported[resource]));
+            }
+
+            foreach (Pop pop in city.Population)
+            {
+                builder.Append(";pop=").Append(pop.Type)
+                    .Append(",count=").Append(pop.Count.ToString(CultureInfo.InvariantCulture))
+                    .Append(",money=").Append(Num(pop.Money));
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>SHA-256 of <see cref="Normalize"/>, hex-encoded, so a test compares one short string.</summary>
+    public static string Hash(Simulation simulation) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(Normalize(simulation))));
+
+    private static string Num(double value) => value.ToString("R", CultureInfo.InvariantCulture);
+}

--- a/TradeCraftSimulation.Tests/LegacyBaselineSnapshotTests.cs
+++ b/TradeCraftSimulation.Tests/LegacyBaselineSnapshotTests.cs
@@ -1,0 +1,39 @@
+using Simulator;
+using Xunit;
+
+namespace TradeCraftSimulation.Tests;
+
+/// <summary>
+/// Locks REQ-MIGRATION-002: repeated same-seed legacy runs on the same runtime must produce
+/// the same normalized snapshot/hash, and the hash must actually depend on the run.
+/// </summary>
+public class LegacyBaselineSnapshotTests
+{
+    // The spec's representative baseline horizon (Milestone 0 implementation steps).
+    private const int RepresentativeTurns = 30;
+
+    [Fact]
+    public void The_same_seed_produces_the_same_normalized_snapshot_hash()
+    {
+        string first = RunAndHash(seed: 7, turns: RepresentativeTurns);
+        string second = RunAndHash(seed: 7, turns: RepresentativeTurns);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void A_different_seed_produces_a_different_normalized_snapshot_hash()
+    {
+        string first = RunAndHash(seed: 7, turns: RepresentativeTurns);
+        string second = RunAndHash(seed: 8, turns: RepresentativeTurns);
+
+        Assert.NotEqual(first, second);
+    }
+
+    private static string RunAndHash(int seed, int turns)
+    {
+        var simulation = new Simulation(new SimulationConfig { Seed = seed });
+        for (int i = 0; i < turns; ++i) simulation.RunTurn();
+        return LegacyBaselineSnapshot.Hash(simulation);
+    }
+}

--- a/TradeCraftSimulation/MIGRATION.md
+++ b/TradeCraftSimulation/MIGRATION.md
@@ -1,0 +1,24 @@
+# Migration marker
+
+Every class in this project (`TradeCraftSimulation`) is **legacy**: the four-city,
+System.Random-seeded C# simulation kept as a reference oracle while the canonical
+implementation moves to TypeScript in `src/` (see [AGENTS.md](../AGENTS.md) and
+`docs/spec/mirror/06 - Handoff/11 — REPOSITORY_MIGRATION_AND_MILESTONE_GATES.md`,
+Milestone 0 onward).
+
+| Class | Legacy responsibility |
+| --- | --- |
+| `Simulation.cs` | Top-level orchestrator: four hard-coded cities, one shared seeded `Random`, six-stage turn loop. |
+| `SimulationConfig.cs` | Centralized tunables for the legacy economy. |
+| `City.cs` | Owns population and market per city; orchestrates production, pricing, trade and consumption. |
+| `Pop.cs` | Social class: production, need, want, consumption and spoilage. |
+| `Market.cs` | Per-city price engine and per-turn demand/supply/trade counters. |
+| `Deal.cs` | Inter-city trade evaluation and execution. |
+| `Storage.cs` | Typed goods inventory. |
+| `CsvLogger.cs` | Transitional per-turn CSV diagnostics. |
+| `Program.cs` | CLI entry point (`--turns`, `--seed`, `--csv`, `--quiet`, `--config`). Its behavior is not changed by the migration; it stays the runnable harness until Milestone 12. |
+
+Do not implement a canonical subsystem here and port it to TypeScript afterward, and
+do not let canonical code mutate the same stock as this legacy runtime. Legacy classes
+are deleted only after Milestone 6+ once their responsibility is proven in canonical
+code and tests (`docs/spec/mirror/06 - Handoff/11 — REPOSITORY_MIGRATION_AND_MILESTONE_GATES.md`).

--- a/docs/spec/IMPLEMENTATION_STATUS.md
+++ b/docs/spec/IMPLEMENTATION_STATUS.md
@@ -22,16 +22,17 @@ proves it. "The code looks right" is not evidence.
 
 | REQ ID | Status | Issue | Merged in | Proving test |
 | --- | --- | --- | --- | --- |
-| — | — | — | — | — |
+| REQ-MIGRATION-002 | `IN_PROGRESS` | #17 | pending (open pull request, not yet merged) | `TradeCraftSimulation.Tests.LegacyBaselineSnapshotTests.The_same_seed_produces_the_same_normalized_snapshot_hash` (and `A_different_seed_produces_a_different_normalized_snapshot_hash` for the non-constant sanity check) |
 
-**Summary: 0 of 0 requirements implemented.** The specification mirror is not yet
-synchronized, so no requirement identifiers exist to track.
+**Summary: 0 of 19 requirements implemented; 1 in progress.** REQ-MIGRATION-002 moves to
+`IMPLEMENTED` once its pull request merges. The other 18 requirement identifiers in
+`docs/spec/mirror/REQUIREMENTS_REGISTRY.csv` are not yet mapped to this table; that
+mapping is separate follow-up work, not evidence that they are unimplemented.
 
 ## Pre-existing behavior
 
 The repository already contains a working simulation — four cities, three goods,
-supply-and-demand pricing, merchant arbitrage, and 42 passing tests including money
-and stock conservation invariants. None of it is yet mapped to requirement
-identifiers. Mapping the existing code onto the registry is the first substantive
-unit of work once the registry exists; until then the table above is empty by fact,
-not by omission.
+supply-and-demand pricing, merchant arbitrage, and (as of this update) 44 passing
+tests including money and stock conservation invariants. Apart from
+REQ-MIGRATION-002 above, none of it is yet mapped to requirement identifiers.
+Mapping the rest of the existing code onto the registry remains follow-up work.


### PR DESCRIPTION
Closes #17

## Achieved outcome

The legacy TradeCraftSimulation now has a deterministic, hash-verified seeded
baseline that is independent of console/CSV text formatting: a same-seed run
produces the same normalized snapshot hash, and a different seed produces a
different one. A migration marker documents which classes in the C# project
are legacy. This is the golden reference `REQ-MIGRATION-002` requires for
later canonical-migration changes to diff against.

## Tested revision

d1530395556c3da5f55f959af2050dfdfc271d0c

## Changed artifacts

- `TradeCraftSimulation.Tests/LegacyBaselineSnapshot.cs` — new test-only helper.
  `Normalize(Simulation)` builds a canonical string over turn, total money,
  cargo lost, and per-city/per-resource/per-pop stocks, prices and balances,
  iterating `Cities`/`Population`/`Storage.All` in their fixed declaration
  order (never dictionary/hash-set order) and formatting doubles round-trip
  (`"R"`) rather than at the fixed decimal precision the console/CSV views
  use. `Hash(Simulation)` is the SHA-256 hex digest of that string.
- `TradeCraftSimulation.Tests/LegacyBaselineSnapshotTests.cs` — new tests:
  `The_same_seed_produces_the_same_normalized_snapshot_hash` and
  `A_different_seed_produces_a_different_normalized_snapshot_hash`, both over
  the spec's representative 30-turn horizon.
- `TradeCraftSimulation/MIGRATION.md` — new migration marker: a table listing
  every class in `TradeCraftSimulation` as legacy, with its responsibility,
  per the Milestone 0 implementation step and the repository's
  strangler-migration plan.
- `docs/spec/IMPLEMENTATION_STATUS.md` — added a coverage row for
  `REQ-MIGRATION-002` set to `IN_PROGRESS` (per the file's own legend,
  `IMPLEMENTED` requires a merge, which an AUTHOR run never performs) naming
  the proving tests, and corrected two now-stale claims in the surrounding
  prose ("mirror not yet synchronized", "42 passing tests", "table above is
  empty by fact") that this same edit made inaccurate.

## Acceptance criteria

- [x] A deterministic snapshot/hash utility exists for the legacy simulation,
      computed from normalized simulation state rather than console/CSV text.
      — `LegacyBaselineSnapshot.Normalize`/`Hash`.
- [x] A test proves two same-seed runs on the same runtime produce an
      identical normalized hash. —
      `The_same_seed_produces_the_same_normalized_snapshot_hash`.
- [x] A test proves a different seed produces a different hash (the utility
      is not a constant). —
      `A_different_seed_produces_a_different_normalized_snapshot_hash`.
- [x] A migration marker documents which classes are legacy. —
      `TradeCraftSimulation/MIGRATION.md`.
- [x] All existing legacy tests remain green and unmodified in behavior. —
      42 pre-existing tests unchanged, still pass; 44 total now.
- [x] `Program.cs` CLI behavior (`--turns`, `--seed`, `--csv`, `--quiet`) is
      unchanged. — `Program.cs` was not touched.
- [x] `docs/spec/IMPLEMENTATION_STATUS.md` updated for `REQ-MIGRATION-002`
      with the proving test name. — see above; status is `IN_PROGRESS`
      pending merge, per the legend's own definition of `IMPLEMENTED`.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `dotnet restore` | passed | clean restore of both projects at d153039 |
| `dotnet build --configuration Release --no-restore` | passed | Build succeeded, 0 warnings, 0 errors |
| `dotnet test --configuration Release --no-build` | passed | 44/44 passed, 0 failed, 0 skipped |
| `npm ci` / `npm run typecheck` / `npm test` / `npm run build` | not_run | this change touches only `TradeCraftSimulation.Tests/**`, `TradeCraftSimulation/MIGRATION.md` (doc) and `docs/spec/**`; no `src/**` or root project files changed, so the canonical TypeScript suite is not implicated (AGENTS.md: "Run the checks for the runtime you touched") |

## Not checked

- Legacy `Deal.cs`/trade-path behavior beyond what the pre-existing 42 tests
  already cover — out of scope for this Issue, which only adds new,
  independent test infrastructure.
- Cross-platform/cross-runtime hash stability (e.g. a different CPU
  architecture or .NET minor version producing different floating-point
  bits). The Issue's acceptance criterion and the spec's Gate M0 wording are
  both scoped to "the same runtime"; this is not verified across runtimes
  and is called out here as a residual assumption rather than silently
  generalized.

## Assumptions and unknowns

- Assumption: "representative 30-turn seeded output" (Milestone 0
  implementation step) means the snapshot is taken after running exactly 30
  turns from a fresh `Simulation`, which is what both new tests do.
- Assumption: "normalized simulation state" for this Issue's scope means city
  stocks, prices, traded/imported/exported flow counters and pop
  counts/money — the same fields already exposed by `City`/`Market`/`Pop` for
  reporting — rather than a new expanded state surface. This matches the
  Issue's own Scope bullet ("city stocks, prices, balances — not printed/CSV
  text").
- Unknown/deferred: whether `REQ-MIGRATION-001` (baseline lock) gets formally
  closed in `IMPLEMENTATION_STATUS.md` is explicitly out of scope per the
  Issue's Non-goals and is left for a separate run.

## Highest-risk area for review

`LegacyBaselineSnapshot.Normalize`'s choice of which fields to include and in
what order. If a reviewer believes the canonical migration will need
additional normalized fields (e.g. per-pop `Satisfaction`, `Need`/`Want`, or
`Market.Demand`/`Supply`) to be a useful golden reference later, that is an
easy, low-risk addition now versus a breaking hash change later.

## Remaining gate

None from this PR's own scope. `docs/spec/IMPLEMENTATION_STATUS.md` will need
a follow-up edit (by whichever run merges this, or a subsequent AUTHOR run)
to flip `REQ-MIGRATION-002` from `IN_PROGRESS` to `IMPLEMENTED` once merged,
naming the merge commit.