### PR TITLE
Reconcile IMPLEMENTATION_STATUS.md and add the runbook step that keeps it honest

### DIFF
--- a/docs/spec/IMPLEMENTATION_STATUS.md
+++ b/docs/spec/IMPLEMENTATION_STATUS.md
@@ -18,16 +18,20 @@ proves it. "The code looks right" is not evidence.
 | `DEFERRED` | Deliberately out of scope for now, with a recorded reason |
 | `CONTESTED` | Implementable only after the researcher resolves a contradiction |
 
+Only `IMPLEMENTED` rows are evidence: a merge commit plus a named test that fails
+without it. Every other status, including a row not yet present in this table, is a
+claim without a proving merge.
+
 ## Coverage
 
 | REQ ID | Status | Issue | Merged in | Proving test |
 | --- | --- | --- | --- | --- |
-| REQ-MIGRATION-002 | `IN_PROGRESS` | #17 | pending (open pull request, not yet merged) | `TradeCraftSimulation.Tests.LegacyBaselineSnapshotTests.The_same_seed_produces_the_same_normalized_snapshot_hash` (and `A_different_seed_produces_a_different_normalized_snapshot_hash` for the non-constant sanity check) |
+| REQ-MIGRATION-002 | `IMPLEMENTED` | #17 | #18, `2ee9a06633ad051887ec527acda1240f26557d0c` | `TradeCraftSimulation.Tests.LegacyBaselineSnapshotTests.The_same_seed_produces_the_same_normalized_snapshot_hash` (and `A_different_seed_produces_a_different_normalized_snapshot_hash` for the non-constant sanity check) |
 
-**Summary: 0 of 19 requirements implemented; 1 in progress.** REQ-MIGRATION-002 moves to
-`IMPLEMENTED` once its pull request merges. The other 18 requirement identifiers in
-`docs/spec/mirror/REQUIREMENTS_REGISTRY.csv` are not yet mapped to this table; that
-mapping is separate follow-up work, not evidence that they are unimplemented.
+**Summary: 1 of 19 requirements implemented; 0 in progress.** The other 18 requirement
+identifiers in `docs/spec/mirror/REQUIREMENTS_REGISTRY.csv` are not yet mapped to this
+table; that mapping is separate follow-up work, not evidence that they are
+unimplemented.
 
 ## Pre-existing behavior
 

--- a/docs/zendev/AUTHOR_RUNBOOK.md
+++ b/docs/zendev/AUTHOR_RUNBOOK.md
@@ -15,6 +15,27 @@ gh pr list --state open --json number,title,headRefName,isDraft,statusCheckRollu
 git log --oneline -10
 ```
 
+### Reconcile implementation status
+
+Before selecting work, bring `docs/spec/IMPLEMENTATION_STATUS.md` into agreement with
+the merge state of the pull requests it already references:
+
+```sh
+gh pr list --state merged --json number,mergeCommit,mergedAt --limit 50
+```
+
+For every row already in the table whose `Issue`/`Merged in` column names a pull
+request that has since merged, flip its status to `IMPLEMENTED`, and record the merge
+commit and the proving test named in that pull request's body. Update the summary
+line so it agrees with the corrected rows. Carry the correction in the same pull
+request as this run's own work — or, if reconciliation is the only change this run
+makes, hand it off on its own.
+
+This step only reconciles rows that already exist in the table against pull requests
+that have already merged. It is not licence to add new rows, map more requirement
+IDs, or read anything beyond `gh pr list` and the pull request bodies it names — a
+run choosing or reading a new requirement is still bounded by section 4.
+
 ## 2. Select one unit of work
 
 Take the first applicable item and stop searching:


### PR DESCRIPTION
Closes #19

## Achieved outcome

`docs/spec/IMPLEMENTATION_STATUS.md` no longer strands one merge behind reality, and
the specific stale row it accumulated is corrected. `docs/zendev/AUTHOR_RUNBOOK.md`
now names a bounded reconciliation step, run before work selection, that closes the
gap the Issue diagnosed: the author writes the file inside its own pull request
(where "not yet merged" is honest), and the acceptor is rightly forbidden from
pushing commits, so nothing previously owned the transition to `IMPLEMENTED`.

## Tested revision

c31bac3a65c831454de6cc2deb65968f711f7b04

## Changed artifacts

- `docs/zendev/AUTHOR_RUNBOOK.md` — added a "Reconcile implementation status"
  sub-step under section 1 (`Understand`), before section 2 (`Select one unit of
  work`). It runs `gh pr list --state merged`, flips any table row whose referenced
  pull request has since merged to `IMPLEMENTED` with the merge commit and proving
  test, and updates the summary line. It is explicitly bounded to rows already in the
  table and pull requests already merged — not licence to add rows, map more
  requirement IDs, or read further into the mirror. Inserted as a subsection rather
  than a new top-level numbered section so the existing section numbers, including
  section 4 (hardcoded in `.github/workflows/zendev-author.yml`'s prompt as "the
  reading order in section 4 of the runbook"), do not shift.
- `docs/spec/IMPLEMENTATION_STATUS.md` — `REQ-MIGRATION-002` now reads `IMPLEMENTED`,
  citing PR #18's merge commit `2ee9a06633ad051887ec527acda1240f26557d0c` and the
  same two proving tests already named. Summary line changed from "0 of 19 ... 1 in
  progress" to "1 of 19 ... 0 in progress". Added one sentence to the Legend making
  explicit that only `IMPLEMENTED` rows are evidence and every other status,
  including an absent row, is a claim without a proving merge.

## Acceptance criteria

- [x] The author runbook names reconciliation as a step, before work selection, and
      bounds it so it cannot become an excuse to read the whole mirror. —
      `docs/zendev/AUTHOR_RUNBOOK.md` "Reconcile implementation status", scoped to
      existing rows and merged PRs only.
- [x] `REQ-MIGRATION-002` reads `IMPLEMENTED`, with the merge commit and the proving
      test named. — see Coverage table row above.
- [x] The summary line counts implemented requirements against the registry total. —
      "1 of 19 requirements implemented; 0 in progress."
- [x] A reader can tell, from the file alone, which rows are evidence and which are
      still claims. — new Legend sentence states the rule directly.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest discover -s scripts/tests -v` | passed | 20/20 tests passed at c31bac3 |
| `python scripts/policy_guard.py --base master` | passed | "policy-guard: passed over 2 changed file(s)" — both changed files are policy (`docs/zendev/`) or neither policy nor product (`docs/spec/`), never mixed with product |
| Manual: file vs. `gh pr list --state merged` | passed | PR #18 merged at 2026-09-03T20:12:42Z with commit `2ee9a06633ad051887ec527acda1240f26557d0c`; table now agrees |
| `npm ci` / `npm run typecheck` / `npm test` / `npm run build` | not_run | no `src/**` or root project files changed |
| `dotnet build --configuration Release` / `dotnet test --configuration Release` | not_run | no `TradeCraftSimulation/**` or `TradeCraftSimulation.Tests/**` files changed |

## Not checked

- Whether a future run's reconciliation step, when it finds multiple stale rows at
  once, produces an unwieldy diff — this run only had one row to reconcile, so the
  step's wording is not exercised against that case yet.

## Assumptions and unknowns

- Assumption: "before work selection" (Issue Scope) is satisfied by a sub-step inside
  section 1 (`Understand`), which already runs before section 2 (`Select one unit of
  work`), rather than requiring a new top-level numbered section. Chose this to avoid
  shifting section 4's number, which `.github/workflows/zendev-author.yml` hardcodes
  in its prompt text.
- Assumption: "the merge commit and the proving test named" (acceptance criterion) is
  satisfied by naming the PR number alongside the commit hash in the `Merged in`
  column, not by replacing the PR number.

## Highest-risk area for review

The reconciliation step's wording in `AUTHOR_RUNBOOK.md`. It is instructions for a
future unattended run rather than code, so the only test of it is that a future AUTHOR
run's behavior matches: it should reconcile without expanding into a general mirror
read. If a reviewer sees a path where the wording could be read as licence to touch
rows beyond the ones already merged, that is worth tightening now rather than after a
run over-reaches.

## Remaining gate

None from this pull request's own scope.