### PR TITLE
Fix status:* label hygiene in the ZenDev runbooks

### DIFF
--- a/docs/zendev/ACCEPTOR_RUNBOOK.md
+++ b/docs/zendev/ACCEPTOR_RUNBOOK.md
@@ -87,6 +87,13 @@ Post the accepted revision and the evidence on the Issue, and confirm the Issue 
 If merged code satisfies the Issue only partially, keep the Issue open and narrow it
 with a recorded correction rather than closing it optimistically.
 
+Once the Issue is confirmed closed, remove every `status:*` label it still carries —
+a closed Issue carries no active `status:*` label, since the forge closed state and
+its reason are the durable resolution. If the merge did not close the Issue
+automatically (no `Closes #<issue>` took effect, or the Issue was already closed by
+other means), close it yourself and then remove its `status:*` label(s); do not skip
+the removal because the automatic close did not fire.
+
 ## 5. When you cannot decide
 
 If the required information is missing — checks never ran, the environment was

--- a/docs/zendev/AUTHOR_RUNBOOK.md
+++ b/docs/zendev/AUTHOR_RUNBOOK.md
@@ -58,7 +58,9 @@ pull request, a `status:in-progress` label, or a branch for that Issue — do no
 ## 3. Claim before mutating
 
 Comment on the Issue with: role, intended scope, the branch name you will use, and
-any known blocker. Set `status:in-progress`. Only then create the branch:
+any known blocker. Set `status:in-progress`, replacing any `status:*` label already
+on the Issue — the label catalog allows at most one `status:*` at a time, so an
+Issue never carries two. Only then create the branch:
 
 ```sh
 git switch -c claude/issue-<number>-<slug>
@@ -130,8 +132,9 @@ hopeful pull request. Record the failure on the Issue and stop.
 
 Push the branch and open a pull request whose body follows
 [the pull request template](../../.github/PULL_REQUEST_TEMPLATE.md) completely, with
-`Closes #<issue>`. Set `status:needs-review` on the Issue. Post a handoff comment
-naming the branch, the tested revision, checks, decisions, and what remains.
+`Closes #<issue>`. Set `status:needs-review` on the Issue, replacing
+`status:in-progress`. Post a handoff comment naming the branch, the tested revision,
+checks, decisions, and what remains.
 
 You do not approve and you do not merge. The run ends here.
 
@@ -149,5 +152,6 @@ append-only.
 
 Stop and record on the Issue: the exact gate, a stable reason code, what you already
 tried, and the specific event or grant that would make the work eligible again. Set
-`status:blocked`. Do not mark the unit of work complete. Do not invent a workaround
+`status:blocked`, replacing any `status:*` label already on the Issue. Do not mark
+the unit of work complete. Do not invent a workaround
 that changes what the task means.


### PR DESCRIPTION
Closes #20

## Achieved outcome

Status-label hygiene now holds across the AUTHOR/ACCEPTOR loop: setting a
`status:*` label always replaces whichever one was already there, and closing an
Issue removes its `status:*` label. The seven closed Issues that had already
accumulated a stale label (#19, #17, #14, #10, #8, #6, #4) are cleaned up directly.

## Tested revision

`d86b979bfd27cffd7b1648aae69f78f35918cc8e`

## Changed artifacts

- `docs/zendev/AUTHOR_RUNBOOK.md` — section 3 (claim) now says setting
  `status:in-progress` replaces any existing `status:*` label; section 7 (hand off)
  says `status:needs-review` replaces `status:in-progress`; section 8 (blocked) says
  `status:blocked` replaces any existing `status:*` label.
- `docs/zendev/ACCEPTOR_RUNBOOK.md` — section 4 (verdict) now says that once an
  Issue is confirmed closed, every `status:*` label it still carries is removed, and
  names the fallback when the merge does not close the Issue automatically: close it
  yourself, then remove the label(s).
- Forge-side only (not part of the diff): removed all `status:*` labels from closed
  Issues #19, #17, #14, #10, #8, #6, #4, per the Issue's correction comment.

## Acceptance criteria

- [x] The acceptor runbook states that closing an Issue includes removing its
      `status:*` label — `docs/zendev/ACCEPTOR_RUNBOOK.md` section 4.
- [x] Issue #17 carries no `status:*` label — verified with
      `gh issue list --state all --json number,labels`.
- [x] The rule names what to do when the Issue does not close automatically —
      ACCEPTOR_RUNBOOK.md section 4, added paragraph.
- [x] (from the correction comment) No open Issue carries more than one `status:*`
      label, and no closed Issue carries any — verified with
      `gh issue list --state all --json number,labels`: #20 (open) carries only
      `status:in-progress`; #19, #17, #14, #10, #8, #6, #4 (closed) carry none.
- [x] (from the correction comment) The author runbook states that setting a
      `status:*` label replaces any existing one — AUTHOR_RUNBOOK.md sections 3, 7, 8.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `npm ci` | passed | 39 packages installed, 0 vulnerabilities |
| `npm run typecheck` | passed | `tsc --noEmit` clean |
| `npm test` | passed | vitest: 1 file, 2 tests passed |
| `npm run build` | passed | vite build succeeded |
| `dotnet restore` | passed | both projects restored |
| `dotnet build --configuration Release` | passed | 0 warnings, 0 errors |
| `dotnet test --configuration Release` | passed | 44/44 passed |
| `python -m unittest discover -s scripts/tests` | passed | 20/20 passed |
| `python scripts/policy_guard.py --base origin/master` | passed | "passed over 2 changed file(s)" — docs/zendev/** only, no product paths |

All checks run locally against the tested revision above; no check is `not_run` or
`unavailable`.

## Not checked

Nothing deliberately skipped. This is a docs-only change to two runbook files; there
is no product behavior to regress, so no new automated test was added — the change
is process guidance, verified by re-reading the edited sections and by the label
state shown above.

## Assumptions and unknowns

- Assumption: the Issue's acceptance criteria (as narrowed by the correction
  comment) are the full scope of this unit of work; the correction comment states
  "Nothing else about the Issue changes," which I took as authoritative over the
  original body wherever the two differ.
- Assumption: "the label catalog allows at most one `status:*`" (stated in the
  correction comment) is an existing catalog rule this PR documents in the runbooks,
  not a new rule being introduced — `gh label list` shows the six `status:*` labels
  as a single-select-by-convention axis, consistent with `AGENTS.md`'s Issue
  standard.
- The forge-side label removals on #19, #17, #14, #10, #8, #6, #4 are not visible in
  this diff (labels are not repository files); they're recorded here and on the
  Issue as the durable evidence.

## Highest-risk area for review

The three edited points in `AUTHOR_RUNBOOK.md` (claim, hand-off, blocked) are the
only enforcement mechanism for "at most one `status:*` label" going forward — it's a
runbook instruction, not a workflow-enforced guard, matching the Issue's explicit
non-goal ("No automation of label hygiene in a workflow"). If a future AUTHOR run
skips the replace step, the label can drift again; that's an accepted, named
trade-off, not an oversight.

## Remaining gate

None. No decision, authority, or follow-up is required to accept this change.