### PR TITLE
Implement REQ-MIGRATION-003: canonical TypeScript scaffolding

### DIFF
--- a/docs/migration/LEGACY_MARKER.md
+++ b/docs/migration/LEGACY_MARKER.md
@@ -1,0 +1,31 @@
+# Legacy migration marker
+
+Required by Milestone 0 of
+`docs/spec/mirror/06 - Handoff/11 — REPOSITORY_MIGRATION_AND_MILESTONE_GATES.md`:
+"Add a migration marker documenting which classes are legacy."
+
+Every class below is **legacy**: it lives in the C# reference oracle
+(`TradeCraftSimulation/`), it is not touched by `REQ-MIGRATION-003`, and it stays
+authoritative for its own stocks until a canonical TypeScript replacement under
+`src/` is implemented and proven with tests (see the non-negotiable migration
+rules — one authoritative owner per stock, no bidirectional mirroring). This file
+is a snapshot of that boundary as of `REQ-MIGRATION-003`; update it as
+responsibilities move to `src/`, do not delete rows retroactively.
+
+| Legacy class | File | Responsibility |
+| --- | --- | --- |
+| `City` | `TradeCraftSimulation/City.cs` | City entity: stocks, prices, population |
+| `Pop` | `TradeCraftSimulation/Pop.cs` | Population unit: production/consumption needs |
+| `Market` | `TradeCraftSimulation/Market.cs` | Intercity trade and price discovery |
+| `Deal` | `TradeCraftSimulation/Deal.cs` | A single trade transaction between cities |
+| `Storage` | `TradeCraftSimulation/Storage.cs` | Per-city goods inventory |
+| `Simulation` | `TradeCraftSimulation/Simulation.cs` | Six-stage turn loop orchestrator |
+| `SimulationConfig` | `TradeCraftSimulation/SimulationConfig.cs` | Seed, turn count and tunable parameters |
+| `CsvLogger` | `TradeCraftSimulation/CsvLogger.cs` | Per-turn CSV run output |
+| `Program` | `TradeCraftSimulation/Program.cs` | CLI entry point (`--turns`, `--seed`, `--csv`, `--quiet`) |
+
+Canonical replacements land under `src/config/`, `src/domain/`, `src/simulation/`
+and `src/diagnostics/` starting at Milestone 1 (`REQ-CORE-001`,
+`REQ-CONFIG-001..005`), per ADR
+[0002-typescript-canonical-engine](../adr/0002-typescript-canonical-engine.md).
+No row above is deleted, moved or renamed by `REQ-MIGRATION-003`.

--- a/docs/spec/IMPLEMENTATION_STATUS.md
+++ b/docs/spec/IMPLEMENTATION_STATUS.md
@@ -28,8 +28,9 @@ claim without a proving merge.
 | --- | --- | --- | --- | --- |
 | REQ-MIGRATION-001 | `IMPLEMENTED` | #23 | #24, `7d732d1ffe3f73f202d63dc82baf8f3125a13ce9` | `dotnet build --configuration Release` (0 warnings, 0 errors) and the full `TradeCraftSimulation.Tests` suite (44/44 passed, 0 failed, 0 skipped) at revision `10af216915bd96f680ec6da4197f408175c96509`, matching Gate M0's "build succeeds and all existing tests pass unchanged" |
 | REQ-MIGRATION-002 | `IMPLEMENTED` | #17 | #18, `2ee9a06633ad051887ec527acda1240f26557d0c` | `TradeCraftSimulation.Tests.LegacyBaselineSnapshotTests.The_same_seed_produces_the_same_normalized_snapshot_hash` (and `A_different_seed_produces_a_different_normalized_snapshot_hash` for the non-constant sanity check) |
+| REQ-MIGRATION-003 | `IN_PROGRESS` | #27 | pending | `src/config/index.test.ts`, `src/domain/index.test.ts`, `src/simulation/index.test.ts`, `src/diagnostics/index.test.ts` (one per new module area) and `src/index.test.ts`'s `canonicalScaffolding` assertion, at the revision on branch `claude/issue-27-canonical-scaffolding`; `npm run typecheck`, `npm test`, `npm run build`, `dotnet build --configuration Release` and `dotnet test --configuration Release` all green in the same pull request |
 
-**Summary: 2 of 19 requirements implemented; 0 in progress.** The other 17
+**Summary: 2 of 19 requirements implemented; 1 in progress.** The other 16
 requirement identifiers in `docs/spec/mirror/REQUIREMENTS_REGISTRY.csv` are not yet
 mapped to this table; that mapping is separate follow-up work, not evidence that they
 are unimplemented.

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { CONFIG_MODULE_AREA } from "./index";
+
+describe("config module area", () => {
+  it("exists as a distinct scaffolding area and typechecks under vitest", () => {
+    expect(CONFIG_MODULE_AREA).toBe("config");
+  });
+});

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Config module area (REQ-MIGRATION-003 scaffolding).
+ *
+ * Owns RunOptions, SimulationConfig, ScenarioDefinition, DefinitionPack and
+ * their validators from Milestone 1 onward. Deliberately empty of behavior
+ * in M0 — see AGENTS.md and ADR 0002.
+ */
+export const CONFIG_MODULE_AREA = "config" as const;

--- a/src/diagnostics/index.test.ts
+++ b/src/diagnostics/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { DIAGNOSTICS_MODULE_AREA } from "./index";
+
+describe("diagnostics module area", () => {
+  it("exists as a distinct scaffolding area and typechecks under vitest", () => {
+    expect(DIAGNOSTICS_MODULE_AREA).toBe("diagnostics");
+  });
+});

--- a/src/diagnostics/index.ts
+++ b/src/diagnostics/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Diagnostics module area (REQ-MIGRATION-003 scaffolding).
+ *
+ * Owns accounting ledgers, invariant reports and benchmark snapshots from
+ * Milestone 1 onward. Deliberately empty of behavior in M0 — see AGENTS.md
+ * and ADR 0002.
+ */
+export const DIAGNOSTICS_MODULE_AREA = "diagnostics" as const;

--- a/src/domain/index.test.ts
+++ b/src/domain/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { DOMAIN_MODULE_AREA } from "./index";
+
+describe("domain module area", () => {
+  it("exists as a distinct scaffolding area and typechecks under vitest", () => {
+    expect(DOMAIN_MODULE_AREA).toBe("domain");
+  });
+});

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Domain module area (REQ-MIGRATION-003 scaffolding).
+ *
+ * Owns canonical entities and value types — identifiers, quantities, money,
+ * inventories, registries and the World/Market/Production/Population/Clans/
+ * Fiscal/Monetary/Expansion/Events domains — from Milestone 1 onward.
+ * Deliberately empty of behavior in M0 — see AGENTS.md and ADR 0002.
+ */
+export const DOMAIN_MODULE_AREA = "domain" as const;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -10,8 +10,7 @@ describe("canonical toolchain", () => {
     expect(toolchainStatus().runtime).toBe("typescript");
   });
 
-  it("does not yet claim canonical scaffolding exists", () => {
-    // Flips to true in REQ-MIGRATION-003, which is where the scaffolding belongs.
-    expect(toolchainStatus().canonicalScaffolding).toBe(false);
+  it("claims canonical scaffolding exists now that REQ-MIGRATION-003 is done", () => {
+    expect(toolchainStatus().canonicalScaffolding).toBe(true);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,18 +2,18 @@
  * Entry point of the canonical TypeScript engine.
  *
  * This file exists so that the toolchain has something to compile, test and build.
- * It deliberately contains **no canonical economics**: REQ-MIGRATION-003 places the
- * Config, Domain, Simulation and Diagnostics scaffolding here, and the canonical
- * subsystems arrive from M1 onward. Anything economic added here before then would
- * be implementing the specification in the wrong order.
+ * It deliberately contains **no canonical economics**: REQ-MIGRATION-003 placed the
+ * Config, Domain, Simulation and Diagnostics module areas under `src/`, and the
+ * canonical subsystems arrive from M1 onward. Anything economic added here before
+ * then would be implementing the specification in the wrong order.
  */
 
 export interface ToolchainStatus {
   readonly runtime: "typescript";
-  /** False until REQ-MIGRATION-003 introduces the canonical scaffolding. */
+  /** True once REQ-MIGRATION-003 has added the canonical scaffolding. */
   readonly canonicalScaffolding: boolean;
 }
 
 export function toolchainStatus(): ToolchainStatus {
-  return { runtime: "typescript", canonicalScaffolding: false };
+  return { runtime: "typescript", canonicalScaffolding: true };
 }

--- a/src/simulation/index.test.ts
+++ b/src/simulation/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { SIMULATION_MODULE_AREA } from "./index";
+
+describe("simulation module area", () => {
+  it("exists as a distinct scaffolding area and typechecks under vitest", () => {
+    expect(SIMULATION_MODULE_AREA).toBe("simulation");
+  });
+});

--- a/src/simulation/index.ts
+++ b/src/simulation/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Simulation module area (REQ-MIGRATION-003 scaffolding).
+ *
+ * Owns WorldState, TickContext, the phase orchestrator, reconciliation and
+ * the keyed deterministic RNG service from Milestone 1 onward. Deliberately
+ * empty of behavior in M0 — see AGENTS.md and ADR 0002.
+ */
+export const SIMULATION_MODULE_AREA = "simulation" as const;


### PR DESCRIPTION
Closes #27

## Achieved outcome

`src/` now has distinct `config/`, `domain/`, `simulation/` and `diagnostics/`
module areas as REQ-MIGRATION-003 requires, each a minimal placeholder proved
by a Vitest test. `toolchainStatus().canonicalScaffolding` is `true`. A legacy
migration marker (`docs/migration/LEGACY_MARKER.md`) documents the nine
`TradeCraftSimulation` classes that remain legacy and the one-authoritative-
owner-per-stock rule they operate under until canonical replacements land at
M1. No canonical economics were introduced and no `TradeCraftSimulation/**`
file was touched.

## Tested revision

`7944bc0c71032ef61af597dcf4298e0bd0c379e6`

## Changed artifacts

- `src/config/index.ts`, `src/config/index.test.ts` — Config module area placeholder + test
- `src/domain/index.ts`, `src/domain/index.test.ts` — Domain module area placeholder + test
- `src/simulation/index.ts`, `src/simulation/index.test.ts` — Simulation module area placeholder + test
- `src/diagnostics/index.ts`, `src/diagnostics/index.test.ts` — Diagnostics module area placeholder + test
- `src/index.ts`, `src/index.test.ts` — flip `canonicalScaffolding` from `false` to `true`
- `docs/migration/LEGACY_MARKER.md` — new migration marker listing legacy C# classes
- `docs/spec/IMPLEMENTATION_STATUS.md` — `REQ-MIGRATION-003` row added as `IN_PROGRESS` (`Merged in = pending`), per the Issue's QA-correction comment: only the post-merge reconciliation step may record the real merge commit and flip status to `IMPLEMENTED`

## Acceptance criteria

- [x] `src/` contains distinct `config/`, `domain/`, `simulation/`, `diagnostics/` module areas, each with a minimal placeholder and no economic behavior. — done, see Changed artifacts.
- [x] A migration marker documents which legacy C# classes remain legacy. — `docs/migration/LEGACY_MARKER.md`, all nine classes.
- [x] `toolchainStatus().canonicalScaffolding` is `true` and its test reflects that. — `src/index.ts` / `src/index.test.ts`.
- [x] `npm ci`, `npm run typecheck`, `npm test` and `npm run build` all succeed. — see Checks.
- [x] `dotnet build --configuration Release` and `dotnet test --configuration Release` remain green and unchanged in behavior. — see Checks, 44/44 passing, same as before this change.
- [x] No `TradeCraftSimulation/**` or `TradeCraftSimulation.Tests/**` files are modified. — confirmed via `git status`/`git add -A -n` before commit; diff touches only `src/**` and `docs/**`.
- [x] `docs/spec/IMPLEMENTATION_STATUS.md` gains/updates the `REQ-MIGRATION-003` row in this pull request. — added as `IN_PROGRESS` per the Issue's QA correction (the PR cannot know its own future merge commit).

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `npm ci` | passed | 39 packages installed, 0 vulnerabilities |
| `npm run typecheck` | passed | `tsc --noEmit` exit 0 |
| `npm test` | passed | Vitest: 5 test files, 6 tests passed |
| `npm run build` | passed | `vite build` → `dist/canonical.js` built in 18ms |
| `dotnet restore` | passed | both projects restored |
| `dotnet build --configuration Release` | passed | 0 warnings, 0 errors |
| `dotnet test --configuration Release` | passed | 44/44 passed, 0 failed, 0 skipped — unchanged from baseline |

## Not checked

Nothing was deliberately skipped; all checks named in the Issue's Verification section ran and passed.

## Assumptions and unknowns

- Carries forward the Issue's own recorded assumption: that ADR 0002 / `SPEC_CHANGELOG.md` row `RUNTIME-001` is authoritative over the mirrored document's own internal C#-vs-browser wording tension for where M0 scaffolding lives (TypeScript under `src/`, not C#). This PR does not re-litigate that; it was resolved before this Issue was written.
- Migration marker location (`docs/migration/LEGACY_MARKER.md`, not inside `TradeCraftSimulation/**`) is a Decision recorded on Issue #27, driven by the Issue's own non-goal that no `TradeCraftSimulation/**` file be modified.
- `REQ-MIGRATION-003`'s `IMPLEMENTED` status and real merge commit are left to the next reconciliation run, per the Issue's QA-correction comment — this PR only sets `IN_PROGRESS`.

## Highest-risk area for review

`docs/spec/IMPLEMENTATION_STATUS.md` — verify the `IN_PROGRESS` row (not `IMPLEMENTED`) matches the QA-correction comment's intent and doesn't get misread as premature closing evidence.

## Remaining gate

None for this unit of work. Follow-up (separate, not this PR): after merge, a reconciliation run flips the `REQ-MIGRATION-003` row to `IMPLEMENTED` with the real merge commit, per `AUTHOR_RUNBOOK.md` section 1.
