### PR TITLE
Recover hourly ZenDev cadence with one bounded GitHub dispatcher

### DIFF
--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -8,8 +8,7 @@ name: Spec sync
 # What is copied is decided by docs/zendev/spec-mirror-allowlist.txt, not here.
 
 on:
-  schedule:
-    - cron: "5 * * * *"
+  # Automatic hourly cadence is owned by zendev-watchdog.yml.
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/zendev-acceptor.yml
+++ b/.github/workflows/zendev-acceptor.yml
@@ -4,8 +4,7 @@ name: ZenDev acceptor
 # changes. This role never implements. Authoring lives in zendev-author.yml.
 
 on:
-  schedule:
-    - cron: "43 * * * *"
+  # Automatic hourly cadence is owned by zendev-watchdog.yml.
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/zendev-author.yml
+++ b/.github/workflows/zendev-author.yml
@@ -4,8 +4,7 @@ name: ZenDev author
 # This role never merges. Acceptance lives in zendev-acceptor.yml.
 
 on:
-  schedule:
-    - cron: "17 * * * *"
+  # Automatic hourly cadence is owned by zendev-watchdog.yml.
   workflow_dispatch:
 
 permissions:
@@ -19,8 +18,8 @@ concurrency:
 
 jobs:
   author:
-    # The schedule stays inert until the repository variable ZENDEV_ENABLED is 'true'.
-    # A manual dispatch always runs, so the loop can be validated before it is armed.
+    # The dispatcher respects ZENDEV_ENABLED. Direct operator dispatch remains
+    # available for maintenance even while automatic scheduling is paused.
     if: vars.ZENDEV_ENABLED == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/.github/workflows/zendev-watchdog.yml
+++ b/.github/workflows/zendev-watchdog.yml
@@ -1,0 +1,46 @@
+name: ZenDev scheduling watchdog
+
+# GitHub-only recovery is best effort, not an external availability guarantee.
+# The lightweight probe runs four times/hour; models are dispatched at most once
+# per hour by this probe. It is the only automatic cadence owner.
+on:
+  schedule:
+    - cron: "11,26,41,56 * * * *"
+  workflow_dispatch:
+    inputs:
+      dispatch:
+        description: "Recover due workflows (false performs read-only diagnostics)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: zendev-scheduling-watchdog
+  cancel-in-progress: false
+
+jobs:
+  watchdog:
+    if: github.repository == 'drevendev/trade_simulation' && github.ref == 'refs/heads/master' && vars.ZENDEV_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+      - name: Recover missed hourly dispatches
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ZENDEV_ENABLED: ${{ vars.ZENDEV_ENABLED }}
+          RECOVER: ${{ github.event_name == 'schedule' || inputs.dispatch }}
+        run: |
+          if [ "$RECOVER" = "true" ]; then
+            python scripts/schedule_watchdog.py --dispatch
+          else
+            python scripts/schedule_watchdog.py
+          fi

--- a/docs/zendev/SCHEDULING.md
+++ b/docs/zendev/SCHEDULING.md
@@ -1,0 +1,118 @@
+# Hourly scheduling and recovery
+
+## What changed
+
+`zendev-watchdog.yml` is the only automatic cadence owner. It wakes at UTC minutes
+11, 26, 41 and 56 and runs a small Python dispatcher, not a model. The three worker
+workflows retain `workflow_dispatch`, their existing concurrency groups, roles,
+timeouts and acceptance limits. Their former independent cron entries are removed
+so a delayed native event cannot duplicate a recovery dispatch.
+
+The fixed targets are `spec-sync.yml`, `zendev-author.yml` and
+`zendev-acceptor.yml`, on `drevendev/trade_simulation`, branch `master` only.
+For each target the dispatcher:
+
+1. Respects `ZENDEV_ENABLED` and refuses to re-enable a disabled workflow.
+2. Checks all queued, running, pending, requested and waiting runs, including old
+   approvals. If any exist, it leaves the workflow alone.
+3. Checks runs created in the previous hour. Every attempt counts, including failed,
+   cancelled and skipped runs; a permanent failure must not cause a paid retry storm.
+4. Rechecks eligibility and submits one dispatch only if no run was created within
+   the hour. Missed historical hours are not replayed.
+
+All normal hourly workers have one producer, and watchdog concurrency serializes its
+passes. An operator can still explicitly dispatch/re-run a worker at any time. The
+API's read and dispatch operations are not atomic, so a simultaneous operator action
+can race the last check; per-role concurrency prevents parallel execution, not an
+extra queued unit. A re-run of an old run preserves its original creation timestamp:
+it blocks dispatch while active but does not reset the creation-based hourly cooldown.
+
+The three roles remain independent; dispatch submission order is not a promise that
+sync finishes before author or author finishes before acceptor. Review always checks
+the actual PR and its exact-head CI. A PR produced after an acceptor selection is
+eligible at a later acceptor run, just as with the former independent schedules.
+
+## Limits and diagnosis
+
+This is **GitHub-only best-effort recovery**, not a guarantee of hourly delivery.
+GitHub explicitly permits delayed/dropped scheduled events:
+[GitHub troubleshooting](https://docs.github.com/en/actions/how-tos/troubleshoot-workflows#scheduled-workflows-running-at-unexpected-times).
+Multiple wakeups provide additional opportunities after a missed event. If delivered
+normally, a due workflow is found on the next probe (up to about 15 minutes after its
+one-hour cooldown). If all cron events stop arriving, this dispatcher also stops.
+It cannot report its own absence or repair GitHub's internal scheduler.
+
+On 2026-09-04, before the repair:
+
+- author: 04:36 -> 09:41 UTC despite hourly cron;
+- acceptor: 01:19 -> 06:30 UTC despite hourly cron;
+- sync: 04:20 -> 09:31 UTC despite hourly cron;
+- all workflows were active, `ZENDEV_ENABLED=true`, no intervening queued/active runs;
+- manual sync [33863818038](https://github.com/drevendev/trade_simulation/actions/runs/33863818038)
+  started within seconds and passed;
+- manual author [33863856193](https://github.com/drevendev/trade_simulation/actions/runs/33863856193)
+  produced PR #35, demonstrating that dispatch could resume useful work.
+
+The observed fault is missing/delayed schedule delivery, not a five-hour job. Its
+precise internal GitHub cause is unknown; no matching public incident was reported.
+Changing a cron minute alone would not establish that the problem was repaired.
+
+Distinguish three signals:
+
+- **Cadence:** are worker run creation timestamps no more than roughly 60-75 minutes
+  apart when no run is active? A longer gap needs investigation.
+- **Execution:** did the workflow/job finish without a technical failure?
+- **Progress:** did an issue advance or a PR get created/accepted? A green model
+  invocation may honestly report a blocker and produce no product change.
+
+The watchdog's summary lists `due`, `recent`, `active`, `disabled` or `dispatched`.
+`dispatched` means the API accepted the request, not that the target completed.
+An API error or incomplete history fails the watchdog visibly; it is never treated
+as an empty queue. A dispatch timeout is not immediately retried because the server
+may already have accepted it. A later pass reads current history again.
+
+## Permissions and opt-out
+
+The watchdog uses the ephemeral repository `GITHUB_TOKEN` with `actions: write` and
+`contents: read`. It receives no model token, Drive credential or `ZENDEV_PAT`.
+GitHub permits `workflow_dispatch` from `GITHUB_TOKEN` to create a new run:
+[Triggering workflows](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow).
+The existing model-job credentials and permissions are unchanged. In particular this
+does **not** resolve the workflow-file push permission problem tracked by Issue #33.
+
+The Actions `vars` context supplies `ZENDEV_ENABLED` to the script; the default
+`GITHUB_TOKEN` is not given extra access to the repository Variables API. Local
+diagnostics instead query that API using the operator's existing `gh` login.
+
+Set `ZENDEV_ENABLED=false` or disable the watchdog workflow to stop future automatic
+dispatch. Already queued/running work is not cancelled. Explicit operator dispatches
+retain their existing opt-out override for maintenance. Do not disable any worker
+workflow expecting the watchdog to re-enable it: disabled targets stay disabled.
+
+## Verification and recovery
+
+Read-only local diagnostics (requires Python and authenticated GitHub CLI):
+
+```sh
+python scripts/schedule_watchdog.py
+```
+
+After the policy PR has been independently accepted into `master`:
+
+```sh
+# Read-only workflow smoke: no paid agent dispatches.
+gh workflow run zendev-watchdog.yml -R drevendev/trade_simulation -r master -f dispatch=false
+# Explicitly recover only due workers, using the same admission checks.
+gh workflow run zendev-watchdog.yml -R drevendev/trade_simulation -r master -f dispatch=true
+```
+
+Inspect the returned run and its summary, then observe at least two **scheduled**
+watchdog executions and subsequent worker timestamps. A manual smoke is not evidence
+that cron is delivering events. The workflow deliberately refuses execution on a
+PR branch; local unit tests/mock dispatches and dry-run diagnostics verify pre-merge
+behavior without letting unaccepted scheduling policy launch agents.
+
+Rollback is a reviewed revert restoring the three former cron entries and removing
+the watchdog together. Do not run both automatic scheduling schemes concurrently.
+An independent external timer is the next option if GitHub-only gaps persist; no
+external service is installed or configured by this change.

--- a/scripts/schedule_watchdog.py
+++ b/scripts/schedule_watchdog.py
@@ -1,0 +1,152 @@
+"""Recover missed ZenDev dispatches; dry-run unless --dispatch is explicit.
+
+Only the fixed repository, master branch and three existing workflows are allowed.
+No model runs here. A successful dispatch is not a successful unit of product work.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timedelta, timezone
+import json
+import os
+from pathlib import Path
+import subprocess
+from urllib.parse import urlencode
+
+REPOSITORY = "drevendev/trade_simulation"
+BRANCH = "master"
+TARGETS = ("spec-sync.yml", "zendev-author.yml", "zendev-acceptor.yml")
+ACTIVE_STATUSES = ("queued", "in_progress", "waiting", "pending", "requested")
+INTERVAL = timedelta(hours=1)
+
+
+def api(path: str, *, payload: dict | None = None):
+    command = ["gh", "api", "--hostname", "github.com", path]
+    data = None
+    if payload is not None:
+        command += ["--method", "POST", "--input", "-"]
+        data = json.dumps(payload)
+    result = subprocess.run(
+        command, input=data, capture_output=True, text=True, timeout=30
+    )
+    if result.returncode:
+        # Never echo token-bearing command environments or arbitrary server output.
+        raise RuntimeError(f"GitHub API request failed (gh exit {result.returncode})")
+    if payload is not None:
+        return None  # Successful dispatch responses may have no body.
+    return json.loads(result.stdout)
+
+
+def timestamp(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("GitHub timestamp must include a timezone")
+    return parsed
+
+
+def read_runs(endpoint: str, **filters) -> list[dict]:
+    """Return a complete filtered list, or fail closed on truncation/schema drift."""
+    runs = []
+    for page in range(1, 11):
+        query = urlencode({"branch": BRANCH, "per_page": 100, "page": page, **filters})
+        response = api(f"{endpoint}/runs?{query}")
+        total = response["total_count"]
+        batch = response["workflow_runs"]
+        if not isinstance(total, int) or total < 0 or not isinstance(batch, list):
+            raise ValueError("Invalid workflow history response")
+        runs.extend(batch)
+        if len(runs) >= total:
+            return runs
+        if not batch:
+            break
+    raise RuntimeError("Incomplete workflow history; refusing to dispatch")
+
+
+def inspect_target(target: str, now: datetime) -> dict:
+    if target not in TARGETS:
+        raise ValueError("Workflow is not allowlisted")
+    endpoint = f"repos/{REPOSITORY}/actions/workflows/{target}"
+    workflow = api(endpoint)
+    if workflow["state"] != "active":
+        return {"workflow": target, "decision": "disabled"}
+
+    # Query every nonterminal state, including approvals and old queued runs.
+    # Filtering by a recent date alone could overlook an old waiting job.
+    active = []
+    for status in ACTIVE_STATUSES:
+        active.extend(read_runs(endpoint, status=status))
+    for run in active:
+        if run["head_branch"] != BRANCH or run["workflow_id"] != workflow["id"]:
+            raise ValueError("Workflow history is outside the requested target")
+    if active:
+        return {"workflow": target, "decision": "active", "run_ids": [r["id"] for r in active]}
+
+    # Failed/cancelled attempts count too: do not turn a permanent failure into
+    # a paid retry storm. No historic catch-up; at most one dispatch per target.
+    recent = read_runs(endpoint, created=">=" + (now - INTERVAL).isoformat())
+    for run in recent:
+        if run["head_branch"] != BRANCH or run["workflow_id"] != workflow["id"]:
+            raise ValueError("Workflow history is outside the requested target")
+        if run["status"] != "completed":
+            return {"workflow": target, "decision": "active", "run_ids": [run["id"]]}
+    latest = max(recent, key=lambda r: timestamp(r["created_at"]), default=None)
+    if latest is not None and now - timestamp(latest["created_at"]) < INTERVAL:
+        return {"workflow": target, "decision": "recent", "run_id": latest["id"],
+                "created_at": latest["created_at"], "conclusion": latest["conclusion"]}
+    return {"workflow": target, "decision": "due"}
+
+
+def is_enabled() -> bool:
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        # GITHUB_TOKEN does not grant repository Variables API access. The
+        # workflow passes the trusted vars context instead; do not add a PAT.
+        if (os.environ.get("GITHUB_REPOSITORY") != REPOSITORY
+                or os.environ.get("GITHUB_REF") != f"refs/heads/{BRANCH}"):
+            raise ValueError("Dispatcher can only execute on the canonical master")
+        return os.environ.get("ZENDEV_ENABLED") == "true"
+    return api(f"repos/{REPOSITORY}/actions/variables/ZENDEV_ENABLED")["value"] == "true"
+
+
+def run(*, dispatch: bool = False, now: datetime | None = None) -> list[dict]:
+    if not is_enabled():
+        return [{"decision": "disabled", "reason": "ZENDEV_ENABLED is not true"}]
+    results = []
+    for target in TARGETS:
+        result = inspect_target(target, now or datetime.now(timezone.utc))
+        if result["decision"] == "due" and dispatch:
+            # Re-read immediately before POST to reduce races with an operator's
+            # manual dispatch. Cross-workflow API operations are not atomic.
+            if not is_enabled():
+                results.append({"workflow": target, "decision": "disabled"})
+                break
+            result = inspect_target(target, now or datetime.now(timezone.utc))
+            if result["decision"] == "due":
+                api(f"repos/{REPOSITORY}/actions/workflows/{target}/dispatches",
+                    payload={"ref": BRANCH})
+                result["decision"] = "dispatched"
+                # Emit immediately: retain a receipt if a later target fails.
+                print(json.dumps(result), flush=True)
+        results.append(result)
+    return results
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dispatch", action="store_true")
+    args = parser.parse_args()
+    try:
+        results = run(dispatch=args.dispatch)
+        report = "## ZenDev scheduling watchdog\n\n```json\n" + json.dumps(results, indent=2) + "\n```\n"
+        print(report)
+        if os.environ.get("GITHUB_STEP_SUMMARY"):
+            with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a", encoding="utf-8") as summary:
+                summary.write(report)
+        return 0
+    except (RuntimeError, ValueError, KeyError, TypeError, OSError, subprocess.TimeoutExpired) as error:
+        print(f"::error::Watchdog failed closed: {type(error).__name__}", flush=True)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_schedule_watchdog.py
+++ b/scripts/tests/test_schedule_watchdog.py
@@ -1,0 +1,183 @@
+"""Scheduling safety controls without network calls or paid model dispatches."""
+
+from datetime import datetime, timedelta, timezone
+import os
+import pathlib
+import subprocess
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import schedule_watchdog as watchdog
+
+NOW = datetime(2026, 9, 4, 12, 0, tzinfo=timezone.utc)
+
+
+def attempt(age=30, status="completed", conclusion="success", **fields):
+    return {"id": 123, "workflow_id": 1, "head_branch": "master", "status": status,
+            "conclusion": conclusion, "created_at": (NOW - timedelta(minutes=age)).isoformat(),
+            **fields}
+
+
+class InspectTests(unittest.TestCase):
+    def inspect(self, recent=(), active=(), state="active"):
+        def history(endpoint, **filters):
+            return list(active) if filters.get("status") == "waiting" else (
+                [] if "status" in filters else list(recent))
+        with patch.object(watchdog, "api", return_value={"state": state, "id": 1}), \
+                patch.object(watchdog, "read_runs", side_effect=history):
+            return watchdog.inspect_target(watchdog.TARGETS[0], NOW)
+
+    def test_recent_success_failed_and_cancelled_attempts_suppress_retry(self):
+        for conclusion in ("success", "failure", "cancelled", "skipped", "timed_out"):
+            with self.subTest(conclusion=conclusion):
+                self.assertEqual(self.inspect([attempt(conclusion=conclusion)])["decision"], "recent")
+
+    def test_one_hour_boundary_is_due(self):
+        self.assertEqual(self.inspect([attempt(age=59.99)])["decision"], "recent")
+        self.assertEqual(self.inspect([attempt(age=60)])["decision"], "due")
+        self.assertEqual(self.inspect()["decision"], "due")
+
+    def test_old_waiting_approval_blocks(self):
+        self.assertEqual(self.inspect(active=[attempt(age=180, status="waiting")])["decision"], "active")
+
+    def test_new_run_created_during_inspection_blocks(self):
+        for status in ("queued", "in_progress", "waiting", "pending", "requested"):
+            self.assertEqual(self.inspect([attempt(status=status)])["decision"], "active")
+
+    def test_disabled_workflow_is_not_reenabled(self):
+        self.assertEqual(self.inspect(state="disabled_manually")["decision"], "disabled")
+
+    def test_latest_unsorted_attempt_and_future_time_are_safe(self):
+        self.assertEqual(self.inspect([attempt(age=59), attempt(age=-1)])["run_id"], 123)
+        self.assertEqual(self.inspect([attempt(age=-1)])["decision"], "recent")
+
+    def test_wrong_branch_and_workflow_fail_closed(self):
+        for fields in ({"head_branch": "untrusted"}, {"workflow_id": 99}):
+            for keyword in ("recent", "active"):
+                with self.assertRaises(ValueError):
+                    self.inspect(**{keyword: [attempt(**fields)]})
+
+    def test_unknown_target_fails_without_network(self):
+        with patch.object(watchdog, "api") as api, self.assertRaises(ValueError):
+            watchdog.inspect_target("other.yml", NOW)
+        api.assert_not_called()
+
+
+class HistoryTests(unittest.TestCase):
+    def test_paginates_until_total_is_satisfied(self):
+        with patch.object(watchdog, "api", side_effect=[
+            {"total_count": 2, "workflow_runs": [attempt()]},
+            {"total_count": 2, "workflow_runs": [attempt(id=124)]},
+        ]) as api:
+            self.assertEqual(len(watchdog.read_runs("endpoint", status="waiting")), 2)
+            self.assertIn("page=2", api.call_args.args[0])
+            self.assertIn("branch=master", api.call_args.args[0])
+
+    def test_truncated_and_malformed_history_fail_closed(self):
+        for response in ({"total_count": 1, "workflow_runs": []},
+                         {"total_count": "0", "workflow_runs": []},
+                         {"total_count": -1, "workflow_runs": []}):
+            with patch.object(watchdog, "api", return_value=response), \
+                    self.assertRaises((RuntimeError, ValueError)):
+                watchdog.read_runs("endpoint")
+
+
+class DispatchTests(unittest.TestCase):
+    def setUp(self):
+        self.enabled = patch.object(watchdog, "is_enabled", return_value=True)
+        self.enabled.start()
+        self.addCleanup(self.enabled.stop)
+
+    def test_dry_run_never_posts(self):
+        with patch.object(watchdog, "inspect_target", return_value={"decision": "due"}), \
+                patch.object(watchdog, "api") as api:
+            self.assertEqual(len(watchdog.run(now=NOW)), 3)
+            api.assert_not_called()
+
+    def test_dispatches_each_due_target_once_to_master(self):
+        with patch.object(watchdog, "inspect_target", side_effect=lambda target, now: {
+            "workflow": target, "decision": "due"}), patch.object(watchdog, "api") as api:
+            watchdog.run(dispatch=True, now=NOW)
+            self.assertEqual(api.call_count, 3)
+            for call, target in zip(api.call_args_list, watchdog.TARGETS):
+                self.assertEqual(call.args[0], f"repos/{watchdog.REPOSITORY}/actions/workflows/{target}/dispatches")
+                self.assertEqual(call.kwargs, {"payload": {"ref": "master"}})
+
+    def test_recheck_prevents_racing_with_manual_run(self):
+        with patch.object(watchdog, "inspect_target", side_effect=[
+            {"decision": "due"}, {"decision": "active"},
+            {"decision": "recent"}, {"decision": "disabled"},
+        ]), patch.object(watchdog, "api") as api:
+            watchdog.run(dispatch=True, now=NOW)
+            api.assert_not_called()
+
+    def test_disabled_repository_and_inspection_error_never_post(self):
+        with patch.object(watchdog, "is_enabled", return_value=False), \
+                patch.object(watchdog, "api") as api:
+            self.assertEqual(watchdog.run(dispatch=True)[0]["decision"], "disabled")
+            api.assert_not_called()
+        with patch.object(watchdog, "inspect_target", side_effect=RuntimeError("API failure")), \
+                patch.object(watchdog, "api") as api, self.assertRaises(RuntimeError):
+            watchdog.run(dispatch=True)
+        api.assert_not_called()
+
+    def test_uncertain_dispatch_is_not_retried(self):
+        with patch.object(watchdog, "inspect_target", return_value={"decision": "due"}), \
+                patch.object(watchdog, "api", side_effect=RuntimeError("network")) as api, \
+                self.assertRaises(RuntimeError):
+            watchdog.run(dispatch=True, now=NOW)
+        self.assertEqual(api.call_count, 1)
+
+
+class EnvironmentTests(unittest.TestCase):
+    def test_actions_uses_trusted_vars_not_variables_api(self):
+        env = {"GITHUB_ACTIONS": "true", "GITHUB_REPOSITORY": watchdog.REPOSITORY,
+               "GITHUB_REF": "refs/heads/master", "ZENDEV_ENABLED": "true"}
+        with patch.dict(os.environ, env, clear=True), patch.object(watchdog, "api") as api:
+            self.assertTrue(watchdog.is_enabled())
+            os.environ["ZENDEV_ENABLED"] = "false"
+            self.assertFalse(watchdog.is_enabled())
+            os.environ["GITHUB_REF"] = "refs/heads/untrusted"
+            with self.assertRaises(ValueError):
+                watchdog.is_enabled()
+            api.assert_not_called()
+
+    def test_local_diagnostics_read_current_variable(self):
+        with patch.dict(os.environ, {}, clear=True), \
+                patch.object(watchdog, "api", return_value={"value": "true"}) as api:
+            self.assertTrue(watchdog.is_enabled())
+            self.assertIn("variables/ZENDEV_ENABLED", api.call_args.args[0])
+
+    def test_api_failure_does_not_disclose_server_body(self):
+        with patch.object(subprocess, "run", return_value=subprocess.CompletedProcess(
+            [], 1, stdout="", stderr="sensitive fixture")), self.assertRaises(RuntimeError) as error:
+            watchdog.api("endpoint")
+        self.assertNotIn("sensitive", str(error.exception))
+
+    def test_only_dispatch_has_post_and_json_body(self):
+        with patch.object(subprocess, "run", return_value=subprocess.CompletedProcess(
+            [], 0, stdout="", stderr="")) as process:
+            watchdog.api("endpoint", payload={"ref": "master"})
+            self.assertIn("POST", process.call_args.args[0])
+            self.assertEqual(process.call_args.kwargs["input"], '{"ref": "master"}')
+
+
+class WiringTests(unittest.TestCase):
+    def test_one_scheduler_and_no_agent_authority_changes(self):
+        root = pathlib.Path(__file__).resolve().parents[2]
+        for target in watchdog.TARGETS:
+            text = (root / ".github/workflows" / target).read_text()
+            self.assertNotIn("  schedule:", text)
+            self.assertIn("  workflow_dispatch:", text)
+        scheduler = (root / ".github/workflows/zendev-watchdog.yml").read_text()
+        self.assertIn('cron: "11,26,41,56 * * * *"', scheduler)
+        self.assertIn("GH_TOKEN: ${{ github.token }}", scheduler)
+        self.assertNotIn("secrets.ZENDEV_PAT", scheduler)
+        self.assertNotIn("claude-code-action", scheduler)
+        self.assertIn("default: false", scheduler)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #34

## Achieved outcome
Replace three unreliable independent hourly cron entries with a single lightweight, non-model GitHub scheduling watchdog waking at minutes 11, 26, 41 and 56. It dispatches each existing master workflow only if enabled, no run is active/waiting, and no run was created in the previous hour. Failed attempts count toward the cooldown. Dry-run is the default. This is GitHub-only best effort, not an availability guarantee.

## Issue and tested revision
Issue #34. Tested revision: 53d1c3273bd01f9352cbbd60aa54c5b42e5f2d5b.

## Changed artifacts
- .github/workflows/zendev-watchdog.yml: non-model dispatcher, master/repository guard, opt-out, read-only manual default and serialized passes.
- Existing sync/author/acceptor workflows: remove independent cron entries only; retain manual dispatch and existing role authority.
- scripts/schedule_watchdog.py and scripts/tests/test_schedule_watchdog.py: fixed targets, complete active/recent history, bounded API calls, race recheck, fail-closed handling and regression tests.
- docs/zendev/SCHEDULING.md: measured incident, architecture, limitations, permissions, smoke procedure and rollback.

## Acceptance criteria
- passed: four cron wakeups/hour configured, no model in dispatcher.
- passed: disabled/recent/active targets suppressed; one-hour boundary, failed/cancelled cooldown, pagination, wrong target, API errors and uncertain dispatch covered by tests.
- passed: live read-only diagnostics correctly found manual sync/author recent and acceptor active, without dispatching.
- passed: existing role prompts and merge limits unchanged; only dispatcher gets actions:write via ephemeral GITHUB_TOKEN, no PAT or model credential.
- not_run: post-merge workflow smoke and observation of scheduled delivery. These require independent acceptance first; the new workflow refuses PR-branch execution.

## Checks
- passed: python -m unittest discover -s scripts/tests -v (40 tests).
- passed: python scripts/policy_guard.py --base origin/master (7 changed files).
- passed: YAML parse of all four changed workflows and git diff --check.
- passed: read-only live diagnostic against GitHub.
- passed: local TypeScript typecheck, 2/2 tests and Vite build. Initial npm ci stalled and was stopped; npm ci --no-audit --no-fund --fetch-retries=0 --fetch-timeout=30000 installed the unchanged lockfile successfully. No audit result is claimed. Exact-head CI remains mandatory.
- unavailable: local .NET SDK is absent. passed: required build-and-test check in CI run 33864670976 (legacy restore/build/test).

## Assumptions and unknowns
GitHub documents delayed/dropped schedules but does not expose the internal cause of this specific gap. Multiple wakeups increase recovery opportunities, but cannot repair a GitHub-wide cron outage. Hourly means a minimum one-hour cooldown between automatic dispatches, not an exact-minute guarantee. See the runbook for operator races, re-runs and independent role ordering. No external timer was installed, per the owner decision.

## Highest-risk review area
Scheduling/permissions wiring: prove only master and the three fixed workers can be dispatched; no duplicate automatic cron producer remains; verify GITHUB_TOKEN actions:write is sufficient while ZENDEV_ENABLED comes from trusted vars context (not the Variables API).

## Remaining gate
Independent ACCEPTOR review, all required exact-head CI green, then post-merge dispatcher smoke and real schedule observation. The author will not merge this policy change. Issue #33 token permissions and product/status fixes are explicitly outside this PR.