### PR TITLE
Fix same-head metadata re-review deadlock

### DIFF
--- a/docs/zendev/ACCEPTOR_RUNBOOK.md
+++ b/docs/zendev/ACCEPTOR_RUNBOOK.md
@@ -13,8 +13,37 @@ that makes this review real.
 gh pr list --state open --json number,title,headRefName,labels,statusCheckRollup,mergeable
 ```
 
-Take the oldest open, non-draft pull request on which you have not already given a
-verdict at its current head revision. One pull request per run.
+Take the oldest eligible open, non-draft pull request. One pull request per run.
+A head revision without a prior verdict is eligible as before. Inspect both formal
+reviews and verdict comments: a verdict posted as a comment because GitHub refuses
+a same-account review counts equally.
+
+### Same-head, metadata-only correction
+
+A previously reviewed head is eligible again **only when all** of these hold:
+
+1. The latest verdict for that exact head is `REQUEST_CHANGES`, and its outstanding
+   defects concern only the PR description/handoff or linked Issue metadata, not
+   repository files, failing checks, or missing implementation evidence.
+2. After that verdict, AUTHOR posted a correction handoff comment on the PR or its
+   linked Issue. It names the exact unchanged head, links the rejection, identifies
+   each requested metadata correction, and requests another review (including by
+   handing off with `status:needs-review`).
+3. The corrected metadata is actually present. A new timestamp, status label, or
+   repeated claim alone is not a correction. Do not require an empty commit.
+4. No subsequent verdict has already reviewed that correction handoff. Compare
+   comment URLs/IDs and event order, not just the head SHA or PR `updatedAt` (the
+   reviewer's own comments also update the PR).
+
+Record the head SHA, prior rejection URL and AUTHOR correction handoff URL/ID in
+the repeat verdict. An unchanged handoff must not generate repeated reviews. If a
+repeat review requests another metadata correction, a new, substantive AUTHOR
+handoff after that verdict is required to qualify again.
+
+This exception only selects work; it grants no acceptance. Apply every refusal,
+independent verification, human policy-approval and merge gate below afresh. A
+metadata edit cannot resolve a file-level defect or waive a required check. If no
+PR qualifies, stop without re-reviewing an unchanged rejection.
 
 ## 2. Refuse fast
 


### PR DESCRIPTION
Closes #37

## Achieved outcome
Removes the same-head metadata deadlock without empty commits or relaxed merge gates. A fresh, substantive AUTHOR correction handoff can make a metadata-only rejection eligible once more; the repeat verdict records its identity and cannot consume it twice.

## Tested revision
bc18976e964fbe2709c267cfe22e222502dbbc29

## Changed artifacts
Only docs/zendev/ACCEPTOR_RUNBOOK.md, section 1. No workflows, credentials, product code, or specification edits.

## Acceptance criteria and verification
Manual rule trace (passed as document review, not an automated runtime test):
- New head without verdict: eligible under the original path.
- PR #35 case: same head, latest metadata-only rejection, later AUTHOR handoff linking that rejection and naming the exact head, actual corrected description: eligible for fresh review.
- Identical handoff after a repeat verdict: ineligible because the verdict records its URL/ID.
- Timestamp/label-only change, repeated claim, or an unresolved file defect: ineligible.
- Later metadata rejection: needs another substantive AUTHOR handoff after that verdict.
- Formal reviews and same-account fallback verdict comments are both considered.
- Every existing refusal, runtime verification, human policy-approval, and current-head required-check gate still applies.

## Checks
- passed: Python unittest suite, 40/40; policy_guard against origin/master, one policy file; git diff --check.
- passed locally at this revision: npm run typecheck, npm test (6/6), npm run build, using the existing installed dependency tree.
- not_run locally: clean npm ci; CI performs it independently.
- unavailable locally: .NET SDK; CI must verify build-and-test before acceptance.
- pending gate: CI build-and-test, typescript, policy-guard at this exact head. No merge until all three are measured passed.

## Assumptions and unknowns
This is a runbook change, not a coded selector. Its end-to-end effect must be observed in a fresh ACCEPTOR run after merge. A claim alone never proves the correction or implementation.

## Highest-risk area
Repeat eligibility must not become automatic acceptance or a generic retry of rejected code. The exception is restricted to metadata defects, requires a durable new handoff, and preserves every verification gate.

## Human decision / remaining gate
The operator explicitly authorized this narrow policy repair after its purpose and retained checks were explained. The change is prospective; it does not self-authorize acceptance. Record the user-approved operator policy acceptance only after current-head CI is green, then validate in a new ACCEPTOR job. Product PR #35 remains separate and requires that independent acceptance.