### PR TITLE
Make the dispatch cadence an operator variable

### DIFF
--- a/.github/workflows/zendev-watchdog.yml
+++ b/.github/workflows/zendev-watchdog.yml
@@ -37,6 +37,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ZENDEV_ENABLED: ${{ vars.ZENDEV_ENABLED }}
+          ZENDEV_INTERVAL_MINUTES: ${{ vars.ZENDEV_INTERVAL_MINUTES }}
           RECOVER: ${{ github.event_name == 'schedule' || inputs.dispatch }}
         run: |
           if [ "$RECOVER" = "true" ]; then

--- a/docs/zendev/SCHEDULING.md
+++ b/docs/zendev/SCHEDULING.md
@@ -71,6 +71,43 @@ An API error or incomplete history fails the watchdog visibly; it is never treat
 as an empty queue. A dispatch timeout is not immediately retried because the server
 may already have accepted it. A later pass reads current history again.
 
+## Cadence
+
+`ZENDEV_INTERVAL_MINUTES` is a repository variable holding the minimum gap between two
+dispatches of the same workflow. Unset means 60. The accepted range is 15 to 360; a
+missing, malformed or out-of-range value falls back to 60 and says so in the run
+summary, because a typo must never widen the cadence silently.
+
+This is the **only ceiling on how often paid model runs start**. Whatever wakes this
+dispatcher — GitHub cron, a manual dispatch, an external timer — cannot make a target
+run sooner than the interval allows. Set the cadence here; set the poke frequency
+wherever the timer lives.
+
+```sh
+gh variable set ZENDEV_INTERVAL_MINUTES -R drevendev/trade_simulation --body "30"
+```
+
+Cost scales roughly linearly with it. Measured on 2026-09-04: an author run averaged
+$0.96 and an acceptor run $0.42, so halving the interval roughly doubles the ceiling.
+An idle acceptor is cheap (about $0.07); an idle author is not, because an empty queue
+sends it to create one ready Issue rather than to stop.
+
+## External timer
+
+GitHub cron delivery has been unreliable for this repository, and the watchdog runs on
+the same scheduler it is meant to repair. An external timer that pokes
+`zendev-watchdog.yml` via `workflow_dispatch` removes that shared dependency.
+
+The timer is deliberately dumb: it decides nothing and holds no cadence. Every
+admission check — the `ZENDEV_ENABLED` switch, the interval cooldown, the active-run
+check, fail-closed on API trouble — stays here, tested, in the repository. Poking more
+often than `ZENDEV_INTERVAL_MINUTES` allows is harmless and changes nothing.
+
+Before enabling one, record its owner, its least-authority credential, how overlap is
+prevented, its retry bound, how to disable and revoke it, and the observation window
+that will decide whether it worked. A timer that nobody can turn off is worse than a
+missed schedule.
+
 ## Permissions and opt-out
 
 The watchdog uses the ephemeral repository `GITHUB_TOKEN` with `actions: write` and

--- a/scripts/schedule_watchdog.py
+++ b/scripts/schedule_watchdog.py
@@ -18,7 +18,15 @@ REPOSITORY = "drevendev/trade_simulation"
 BRANCH = "master"
 TARGETS = ("spec-sync.yml", "zendev-author.yml", "zendev-acceptor.yml")
 ACTIVE_STATUSES = ("queued", "in_progress", "waiting", "pending", "requested")
+
+# Minimum gap between two dispatches of the same workflow. This is the only ceiling
+# on how often paid model runs start: an external timer may poke this dispatcher as
+# often as it likes and cannot make a target run sooner than this.
 INTERVAL = timedelta(hours=1)
+# Operator range. Below the floor a slow run would be overtaken by its own successor;
+# above the ceiling the loop is not usefully scheduled at all.
+MIN_INTERVAL = timedelta(minutes=15)
+MAX_INTERVAL = timedelta(hours=6)
 
 
 def api(path: str, *, payload: dict | None = None):
@@ -63,7 +71,7 @@ def read_runs(endpoint: str, **filters) -> list[dict]:
     raise RuntimeError("Incomplete workflow history; refusing to dispatch")
 
 
-def inspect_target(target: str, now: datetime) -> dict:
+def inspect_target(target: str, now: datetime, interval: timedelta = INTERVAL) -> dict:
     if target not in TARGETS:
         raise ValueError("Workflow is not allowlisted")
     endpoint = f"repos/{REPOSITORY}/actions/workflows/{target}"
@@ -84,17 +92,44 @@ def inspect_target(target: str, now: datetime) -> dict:
 
     # Failed/cancelled attempts count too: do not turn a permanent failure into
     # a paid retry storm. No historic catch-up; at most one dispatch per target.
-    recent = read_runs(endpoint, created=">=" + (now - INTERVAL).isoformat())
+    recent = read_runs(endpoint, created=">=" + (now - interval).isoformat())
     for run in recent:
         if run["head_branch"] != BRANCH or run["workflow_id"] != workflow["id"]:
             raise ValueError("Workflow history is outside the requested target")
         if run["status"] != "completed":
             return {"workflow": target, "decision": "active", "run_ids": [run["id"]]}
     latest = max(recent, key=lambda r: timestamp(r["created_at"]), default=None)
-    if latest is not None and now - timestamp(latest["created_at"]) < INTERVAL:
+    if latest is not None and now - timestamp(latest["created_at"]) < interval:
         return {"workflow": target, "decision": "recent", "run_id": latest["id"],
                 "created_at": latest["created_at"], "conclusion": latest["conclusion"]}
     return {"workflow": target, "decision": "due"}
+
+
+def resolve_interval() -> timedelta:
+    """Read the operator cadence, falling back to the default on anything unusable.
+
+    A malformed or out-of-range value must never widen the cadence silently, so it
+    falls back to the conservative default rather than to the caller's intent.
+    """
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        raw = os.environ.get("ZENDEV_INTERVAL_MINUTES", "")
+    else:
+        try:
+            raw = api(f"repos/{REPOSITORY}/actions/variables/ZENDEV_INTERVAL_MINUTES")["value"]
+        except (RuntimeError, ValueError, KeyError, TypeError):
+            return INTERVAL
+    if not raw.strip():
+        return INTERVAL
+    try:
+        minutes = int(raw.strip())
+    except ValueError:
+        print(f"::warning::ZENDEV_INTERVAL_MINUTES is not an integer; using {INTERVAL}")
+        return INTERVAL
+    candidate = timedelta(minutes=minutes)
+    if not MIN_INTERVAL <= candidate <= MAX_INTERVAL:
+        print(f"::warning::ZENDEV_INTERVAL_MINUTES out of range; using {INTERVAL}")
+        return INTERVAL
+    return candidate
 
 
 def is_enabled() -> bool:
@@ -108,19 +143,21 @@ def is_enabled() -> bool:
     return api(f"repos/{REPOSITORY}/actions/variables/ZENDEV_ENABLED")["value"] == "true"
 
 
-def run(*, dispatch: bool = False, now: datetime | None = None) -> list[dict]:
+def run(*, dispatch: bool = False, now: datetime | None = None,
+        interval: timedelta = INTERVAL) -> list[dict]:
+    """The caller resolves the cadence, so this adds no API call of its own."""
     if not is_enabled():
         return [{"decision": "disabled", "reason": "ZENDEV_ENABLED is not true"}]
     results = []
     for target in TARGETS:
-        result = inspect_target(target, now or datetime.now(timezone.utc))
+        result = inspect_target(target, now or datetime.now(timezone.utc), interval)
         if result["decision"] == "due" and dispatch:
             # Re-read immediately before POST to reduce races with an operator's
             # manual dispatch. Cross-workflow API operations are not atomic.
             if not is_enabled():
                 results.append({"workflow": target, "decision": "disabled"})
                 break
-            result = inspect_target(target, now or datetime.now(timezone.utc))
+            result = inspect_target(target, now or datetime.now(timezone.utc), interval)
             if result["decision"] == "due":
                 api(f"repos/{REPOSITORY}/actions/workflows/{target}/dispatches",
                     payload={"ref": BRANCH})
@@ -136,8 +173,14 @@ def main() -> int:
     parser.add_argument("--dispatch", action="store_true")
     args = parser.parse_args()
     try:
-        results = run(dispatch=args.dispatch)
-        report = "## ZenDev scheduling watchdog\n\n```json\n" + json.dumps(results, indent=2) + "\n```\n"
+        interval = resolve_interval()
+        results = run(dispatch=args.dispatch, interval=interval)
+        minutes = int(interval.total_seconds() // 60)
+        report = (
+            "## ZenDev scheduling watchdog\n\n"
+            f"Dispatch interval: {minutes} minutes.\n\n"
+            "```json\n" + json.dumps(results, indent=2) + "\n```\n"
+        )
         print(report)
         if os.environ.get("GITHUB_STEP_SUMMARY"):
             with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a", encoding="utf-8") as summary:

--- a/scripts/tests/test_schedule_watchdog.py
+++ b/scripts/tests/test_schedule_watchdog.py
@@ -20,14 +20,49 @@ def attempt(age=30, status="completed", conclusion="success", **fields):
             **fields}
 
 
+class IntervalTests(unittest.TestCase):
+    """The cadence variable is the only ceiling on how often paid runs start."""
+
+    def resolve(self, value):
+        env = {"GITHUB_ACTIONS": "true"}
+        if value is not None:
+            env["ZENDEV_INTERVAL_MINUTES"] = value
+        with patch.dict(os.environ, env, clear=True):
+            return watchdog.resolve_interval()
+
+    def test_unset_and_blank_use_the_default(self):
+        self.assertEqual(self.resolve(None), watchdog.INTERVAL)
+        self.assertEqual(self.resolve("   "), watchdog.INTERVAL)
+
+    def test_operator_value_inside_the_range_is_honoured(self):
+        self.assertEqual(self.resolve("30"), timedelta(minutes=30))
+        self.assertEqual(self.resolve("15"), watchdog.MIN_INTERVAL)
+        self.assertEqual(self.resolve("360"), watchdog.MAX_INTERVAL)
+
+    def test_unusable_values_fall_back_and_never_widen_silently(self):
+        for value in ("14", "0", "-30", "361", "abc", "30.5", ""):
+            with self.subTest(value=value):
+                self.assertEqual(self.resolve(value), watchdog.INTERVAL)
+
+    def test_actions_reads_the_env_not_the_variables_api(self):
+        with patch.object(watchdog, "api", side_effect=AssertionError("no API call")):
+            self.assertEqual(self.resolve("30"), timedelta(minutes=30))
+
+    def test_run_does_not_resolve_the_cadence_itself(self):
+        """main() resolves once; run() must add no API call to the dispatch path."""
+        with patch.object(watchdog, "is_enabled", return_value=False),                 patch.object(watchdog, "api") as api:
+            watchdog.run(dispatch=True, now=NOW)
+        api.assert_not_called()
+
+
 class InspectTests(unittest.TestCase):
-    def inspect(self, recent=(), active=(), state="active"):
+    def inspect(self, recent=(), active=(), state="active", interval=watchdog.INTERVAL):
         def history(endpoint, **filters):
             return list(active) if filters.get("status") == "waiting" else (
                 [] if "status" in filters else list(recent))
         with patch.object(watchdog, "api", return_value={"state": state, "id": 1}), \
                 patch.object(watchdog, "read_runs", side_effect=history):
-            return watchdog.inspect_target(watchdog.TARGETS[0], NOW)
+            return watchdog.inspect_target(watchdog.TARGETS[0], NOW, interval)
 
     def test_recent_success_failed_and_cancelled_attempts_suppress_retry(self):
         for conclusion in ("success", "failure", "cancelled", "skipped", "timed_out"):
@@ -38,6 +73,13 @@ class InspectTests(unittest.TestCase):
         self.assertEqual(self.inspect([attempt(age=59.99)])["decision"], "recent")
         self.assertEqual(self.inspect([attempt(age=60)])["decision"], "due")
         self.assertEqual(self.inspect()["decision"], "due")
+
+    def test_boundary_follows_the_configured_interval(self):
+        half = timedelta(minutes=30)
+        self.assertEqual(self.inspect([attempt(age=29.99)], interval=half)["decision"], "recent")
+        self.assertEqual(self.inspect([attempt(age=30)], interval=half)["decision"], "due")
+        # The same run is still inside the default hour: cadence is the only difference.
+        self.assertEqual(self.inspect([attempt(age=30)])["decision"], "recent")
 
     def test_old_waiting_approval_blocks(self):
         self.assertEqual(self.inspect(active=[attempt(age=180, status="waiting")])["decision"], "active")
@@ -97,7 +139,7 @@ class DispatchTests(unittest.TestCase):
             api.assert_not_called()
 
     def test_dispatches_each_due_target_once_to_master(self):
-        with patch.object(watchdog, "inspect_target", side_effect=lambda target, now: {
+        with patch.object(watchdog, "inspect_target", side_effect=lambda target, now, interval=None: {
             "workflow": target, "decision": "due"}), patch.object(watchdog, "api") as api:
             watchdog.run(dispatch=True, now=NOW)
             self.assertEqual(api.call_count, 3)


### PR DESCRIPTION
Closes #50

## Why a human merges this

It changes the ceiling on how often paid model runs start. That is a spending decision,
not a code decision, so it is labelled `status:needs-decision` and waits for you rather
than for the acceptor.

## Achieved outcome

`ZENDEV_INTERVAL_MINUTES` now carries the minimum gap between two dispatches of the
same workflow. Unset means 60. The accepted range is 15 to 360; anything missing,
malformed or out of range falls back to 60 **and warns**, because a typo must never
widen the cadence silently.

This remains the only ceiling on how often paid runs start. An external timer can then
poke the dispatcher as often as it likes without changing what the loop costs — the
timer decides nothing, and every admission check stays here, tested.

## Changed artifacts

| Artifact | Change |
| --- | --- |
| `scripts/schedule_watchdog.py` | `resolve_interval()`, cadence threaded through `inspect_target` and `run`, resolved once in `main()` |
| `scripts/tests/test_schedule_watchdog.py` | 6 new tests: range, fallbacks, boundary at the configured interval, and that `run()` adds no API call |
| `.github/workflows/zendev-watchdog.yml` | passes the variable through the trusted `vars` context, no new permission |
| `docs/zendev/SCHEDULING.md` | cadence, cost consequence, and what an external timer must record before it is enabled |

## A regression the existing tests caught

Resolving the cadence inside `run()` added an API call to the dispatch path, and four
existing tests failed because they prove that path makes no unnecessary calls. They
were right. Resolution moved to `main()`, which is also where it belongs: one lookup
per invocation rather than one per target.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest discover -s scripts/tests` | `passed` | 46 tests |
| `resolve_interval` with `30` | `passed` | `0:30:00` |
| `resolve_interval` with `5` | `passed` | warns, returns `1:00:00` |
| Live dry-run against the real repository | `passed` | all three targets reported `due` — the loop is stalled, which is what prompted this |
| `build-and-test`, `typescript`, `policy-guard` | see checks tab | |
| Scheduled delivery actually recovering | `not_run` | needs the timer running and a day of observation |

## Not checked

Whether an external timer fixes delivery. Nothing here proves that, and
`SCHEDULING.md` says so: moving a cron minute, raising frequency or adding a poke must
not be reported as a cure without subsequent evidence.

## Remaining gate

Your merge, then `gh variable set ZENDEV_INTERVAL_MINUTES --body "30"`, then the Apps
Script timer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)