### PR TITLE
Let the watchdog actually start the author and the acceptor

### DIFF
--- a/.github/workflows/zendev-acceptor.yml
+++ b/.github/workflows/zendev-acceptor.yml
@@ -43,6 +43,14 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.ZENDEV_PAT }}
+          # The dispatcher runs this workflow with the repository's own GITHUB_TOKEN,
+          # so the triggering actor is github-actions[bot]. The action refuses a bot
+          # actor unless it is named here, which is why every watchdog-dispatched run
+          # failed before the model was even reached.
+          #
+          # Exactly this bot, never "*": on a public repository "*" would let any
+          # external app invoke this action with a prompt it controls.
+          allowed_bots: "github-actions"
           settings: |
             {
               "permissions": {

--- a/.github/workflows/zendev-author.yml
+++ b/.github/workflows/zendev-author.yml
@@ -45,6 +45,14 @@ jobs:
           # A PAT rather than the default token, so that pull requests this run opens
           # actually trigger the CI workflow. Events from GITHUB_TOKEN do not.
           github_token: ${{ secrets.ZENDEV_PAT }}
+          # The dispatcher runs this workflow with the repository's own GITHUB_TOKEN,
+          # so the triggering actor is github-actions[bot]. The action refuses a bot
+          # actor unless it is named here, which is why every watchdog-dispatched run
+          # failed before the model was even reached.
+          #
+          # Exactly this bot, never "*": on a public repository "*" would let any
+          # external app invoke this action with a prompt it controls.
+          allowed_bots: "github-actions"
           settings: |
             {
               "permissions": {


### PR DESCRIPTION
Closes #52

## Why a human merges this

It widens who may start a model run: a bot actor, where only humans could before. That
is an authority change, so it waits for you rather than for the acceptor.

## Achieved outcome

The scheduling watchdog can start the author and the acceptor. Until now it could not,
and had never done so successfully — the whole point of yesterday's recovery work was
inoperative at the last inch.

## Tested revision

The head of this branch.

## Changed artifacts

`allowed_bots: "github-actions"` on `zendev-author.yml` and `zendev-acceptor.yml`, with
the reason in a comment beside it. Nothing else.

## The evidence

| Triggering actor | Runs | Conclusions |
| --- | ---: | --- |
| `abogun-product` | 15 | success |
| `drevendev` | 11 | success |
| `github-actions[bot]` | 1 | failure |

The failure is not intermittent and not a quota: the action bails in 600 ms with
`Workflow initiated by non-human actor: github-actions (type: Bot)`, before the model
is reached.

## Why it stayed hidden all day

`spec-sync` runs no model, so a bot may dispatch it freely. The only scheduled watchdog
run that ever landed (14:55 UTC) found the author and acceptor `recent` — a human had
dispatched them minutes earlier — and dispatched `spec-sync` alone. It reported success,
and the defect never surfaced. Every green agent run today was started by a person.

## Why exactly `github-actions` and not `*`

This repository is public, and the action's own documentation warns that on a public
repository `*` may let external apps invoke it with prompts they control. Naming the
one bot limits the allowance to a `GITHUB_TOKEN` held by a workflow on the default
branch, and workflow changes are already reviewed alone by `policy-guard`.

## Acceptance criteria

- [x] The allowance names exactly `github-actions`
- [x] `spec-sync` untouched
- [ ] A watchdog-dispatched author run reaches the model — cannot be shown before merge,
      since dispatch runs the default-branch copy of a workflow

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest discover -s scripts/tests` | `passed` | 46 tests, unaffected |
| Workflow YAML parse | `passed` | `allowed_bots` present on both, value `github-actions` |
| `build-and-test`, `typescript`, `policy-guard` | see checks tab | |
| A bot-dispatched agent run succeeding | `not_run` | the point of the fix; provable only after merge |

## Not checked

Whether anything else in the loop breaks once bot-dispatched runs actually reach the
model. Nothing has ever got that far, so the path beyond the actor check is unexercised
under a bot actor. The next watchdog dispatch after merge is the experiment.

## Highest-risk area for review

The `allowed_bots` value. It is the entire security surface of this change, and the
difference between `github-actions` and `*` on a public repository is the difference
between the repository's own dispatcher and anyone's app.

## Remaining gate

Merge, then one manual `gh workflow run zendev-watchdog.yml -f dispatch=true` to prove
the path end to end before the external timer is installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)