### PR TITLE
Define AUTHOR's detection of comment-based ACCEPTOR change requests

### DIFF
--- a/docs/zendev/AUTHOR_RUNBOOK.md
+++ b/docs/zendev/AUTHOR_RUNBOOK.md
@@ -49,11 +49,55 @@ Take the first applicable item and stop searching:
 5. an Issue labelled `status:needs-triage` — turn exactly one into a ready Issue
    (fill Goal, Evidence, Scope, Non-goals, Acceptance criteria, Verification and the
    label axes), then stop for this run;
-6. if the queue is empty: read the specification navigation files and create **one**
-   new ready Issue for the next unimplemented requirement, then stop.
+6. otherwise — the backlog holds no eligible pull request, unblockable Issue, ready
+   Issue, or triage Issue after evaluating 1–5 — read the specification navigation
+   files and create **one** new ready Issue for the next unimplemented requirement,
+   then stop.
 
 Closing work outranks opening work. If another run already holds the item — an open
 pull request, a `status:in-progress` label, or a branch for that Issue — do not take it.
+
+Evaluating 1–6 and finding nothing to mutate is never a silent success. Item 6 exists
+precisely so this cannot happen: whenever 1–5 yield no eligible item, item 6 always
+produces a durable record (a new ready Issue) before the run stops. A run must not
+exit having done nothing without one of a commit, a claim comment, a triage
+promotion, a new Issue, or a `status:blocked` record to show for it — green CI on an
+older, unrelated revision is not evidence that this run made progress.
+
+### Detecting "changes requested" (item 1)
+
+GitHub refuses to let the same account formally review its own pull request, so the
+ACCEPTOR's verdict on a pull request you authored is sometimes a formal review
+(`reviewDecision: CHANGES_REQUESTED`) and sometimes a plain comment posted instead,
+headed exactly `## ACCEPTOR verdict: REQUEST_CHANGES` (or `## ACCEPTOR verdict:
+ACCEPT`) and naming the reviewed revision as `` Head `<sha>` `` in its first
+paragraph — see `ACCEPTOR_RUNBOOK.md` section 1. Both forms count equally as a
+verdict. A human operator QA comment carrying an equivalent explicit marker (for
+example `## Operator QA: REQUEST_CHANGES`) counts the same way as supporting
+evidence, but only an ACCEPTOR or formal-review verdict decides whether item 1
+applies.
+
+To decide whether item 1 applies to one of your open pull requests:
+
+1. Collect every formal review on the pull request, and every comment on the pull
+   request and its linked Issue.
+2. Keep only the entries that carry an explicit verdict: a formal review's `state`,
+   or a comment beginning with an `ACCEPTOR verdict:` marker.
+3. Order the kept entries by timestamp and take the latest one.
+4. Item 1 applies only when that latest verdict is a change request
+   (`CHANGES_REQUESTED` / `REQUEST_CHANGES`) **and** the revision it names — the
+   review's own commit, or the `` Head `<sha>` `` the comment states — is exactly the
+   pull request's current `headRefOid`. A verdict naming an older head was already
+   superseded by whatever was pushed since; do not re-address it, and do not let it
+   block or repeat against the new head.
+5. A later `ACCEPT`/`APPROVED` verdict at the current head means item 1 does not
+   apply; move on to item 2.
+
+This is the same-account fallback `ACCEPTOR_RUNBOOK.md` section 1 already
+requires the ACCEPTOR to honor when posting a verdict. AUTHOR must recognize the
+identical fallback when consuming one, not just the formal-review path — otherwise a
+real change request goes unaddressed while later runs report green with nothing
+actually fixed.
 
 ## 3. Claim before mutating
 


### PR DESCRIPTION
Closes #44

## Achieved outcome

`docs/zendev/AUTHOR_RUNBOOK.md` section 2 item 1 ("an open pull request of yours with changes requested") previously gave no procedure for recognizing a change-request verdict that ACCEPTOR posts as a plain PR comment — the fallback GitHub forces when the same account cannot formally review its own pull request (`## ACCEPTOR verdict: REQUEST_CHANGES`, documented in `ACCEPTOR_RUNBOOK.md` section 1). AUTHOR could therefore miss real feedback and only react once a differently-scoped formal review later restated the same defect, as happened on PR #43 / Issue #41.

The runbook now spells out, step by step, how to find the latest verdict (formal review or marker comment) across a pull request and its linked Issue, and requires the verdict's named head to exactly match the pull request's current `headRefOid` before item 1 applies — so a stale/superseded comment from before the latest push can never trigger repeat work or block forever. Item 6's trigger condition is also tightened from "the queue is empty" to "1–5 yielded nothing eligible," and a short paragraph makes explicit that a run finding zero eligible units is never a silent no-op — item 6 guarantees a durable record every time.

## Tested revision

`f2a2710098f388c34fb91cb38e09ffe18d1fb64e`

## Changed artifacts

- `docs/zendev/AUTHOR_RUNBOOK.md` — section 2 only: precise item-1 detection procedure for comment-based ACCEPTOR verdicts, head-matching supersession rule, and a tightened item-6 trigger plus an explicit no-silent-no-op statement. No other section touched. No product/runtime file, workflow, or `AGENTS.md` change.

## Acceptance criteria

- [x] Reproduce the comment-only versus formal-review selection case from the run/PR evidence — confirmed by reading PR #43 / Issue #41 directly: ACCEPTOR posted `## ACCEPTOR verdict: REQUEST_CHANGES` as a PR comment at head `bfe8969` (GitHub refused the same-account formal review "Review Can not request changes on your own pull request"), and AUTHOR's correction only followed a later, differently-scoped formal `CHANGES_REQUESTED` review from `abogun-product` — consistent with the runbook gap the Issue describes.
- [x] One fresh AUTHOR run handles a current-head ACCEPTOR REQUEST_CHANGES comment without requiring a separate human review — the new procedure in section 2 makes the marker-comment form an equal, independently sufficient trigger for item 1; it no longer depends on a formal review arriving.
- [x] Superseded comments do not cause repeat changes or endless retries — step 4 of the new procedure requires the verdict's stated head to equal the pull request's current `headRefOid`; once AUTHOR pushes a fix the head moves and the old verdict comment stops matching, mirroring the same head-based supersession `ACCEPTOR_RUNBOOK.md` section 1 already uses for its own same-head exception.
- [x] Unrelated in-progress work is not taken over — unchanged; the existing "Closing work outranks opening work... do not take it" sentence in section 2 is preserved verbatim.
- [x] A successful no-op records why no unit was eligible; do not conflate green execution with progress — item 6's trigger is now "1–5 yielded nothing eligible" rather than "the queue is empty," and an explicit paragraph states a run must not exit with no commit/claim/triage/new-Issue/blocked record to show for it.
- [x] Any policy change is separate, prospective and reviewed under the existing human-authority boundary — this PR touches only `docs/zendev/AUTHOR_RUNBOOK.md`; `policy_guard.py` confirms no product path is mixed in; the change is prospective per `AGENTS.md` ("govern later runs only after they are merged") and does not alter this run's own authority.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `npm ci && npm run typecheck && npm test && npm run build` | passed | typecheck clean; 9 test files / 40 tests passed; Vite build succeeded — ran locally at `f2a2710` even though the diff touches no TypeScript, because CI's `typescript` job has no path filter and runs on every PR |
| `dotnet restore && dotnet build --configuration Release --no-restore` | passed | build succeeded, 0 warnings, 0 errors |
| `dotnet test --configuration Release --no-build` | passed | 45/45 passed — ran locally even though the diff touches no C#, because CI's `build-and-test` job has no path filter |
| `python3 -m unittest discover -s scripts/tests -v` | passed | 46/46 passed |
| `python3 scripts/policy_guard.py --base master` | passed | `policy-guard: passed over 1 changed file(s)` — confirms the change is policy-only, no product path mixed in, no credential-shaped string added |

## Not checked

- No fresh, isolated AUTHOR/ACCEPTOR run was spun up to validate the new procedure end-to-end (the Issue's Verification section asks for this). A single bounded AUTHOR unit of work cannot itself launch a second autonomous run to test-drive its own runbook change without exceeding "exactly one bounded unit of work." The next real AUTHOR run that hits a same-account comment-verdict PR is the first live exercise of this text; residual risk is that the written procedure has an edge case only a live run surfaces.
- GitHub Actions CI (`build-and-test`, `typescript`, `policy-guard`) has not run yet on this exact head at the time of writing this body; the table above is from local execution at the tested revision. The Checks table should be treated as `not_run` for the CI check-run itself until `gh pr checks` shows green at `f2a2710098f388c34fb91cb38e09ffe18d1fb64e` — the reviewer (ACCEPTOR) is required by its own runbook to re-measure this independently regardless.

## Assumptions and unknowns

- Fact, verified directly: the exact marker text ACCEPTOR uses for a same-account fallback verdict (`## ACCEPTOR verdict: REQUEST_CHANGES` / `## ACCEPTOR verdict: ACCEPT`, with a `` Head `<sha>` `` line) — read from the live PR #43 comment thread, not inferred.
- Assumption: `ACCEPTOR_RUNBOOK.md` section 1's existing text is treated as authoritative for what a comment-based verdict looks like; this PR does not change that file, only makes AUTHOR consume the same shape it already documents.
- Unknown: whether a future ACCEPTOR run will always use this exact marker text verbatim, or whether it could drift in wording over time. This PR does not add a mechanical format test for the marker; it is prose guidance for an agent to follow, consistent with how the rest of both runbooks are written.

## Highest-risk area for review

The head-matching supersession rule (item 1, step 4): if a reviewer disagrees that comparing the verdict's stated head against current `headRefOid` is sufficient to prevent both false-negative (real feedback ignored) and false-positive (stale feedback re-triggered) outcomes, that is the one piece of judgment in this change worth scrutinizing most closely — everything else is a direct transcription of behavior `ACCEPTOR_RUNBOOK.md` already specifies.

## Remaining gate

None known. This PR is process-only, confined to `docs/zendev/AUTHOR_RUNBOOK.md`, and does not widen this run's own authority per `AGENTS.md`'s prospective-policy invariant. Live validation against a real same-account comment-verdict PR remains outstanding, as noted above, but is not a gate this run can close itself.