### PR TITLE
Treat the control plane as policy

### DIFF
--- a/scripts/policy_guard.py
+++ b/scripts/policy_guard.py
@@ -21,6 +21,11 @@ import sys
 POLICY_PREFIXES = (
     ".github/workflows/",
     "docs/zendev/",
+    # The control plane itself. Everything under scripts/ decides how the loop behaves:
+    # when agents wake, what may cross the mirror boundary, what this guard refuses.
+    # Left unclassified, an agent could weaken this very file, adjust its tests to
+    # match, and have the change merged with no person involved.
+    "scripts/",
 )
 POLICY_FILES = ("AGENTS.md",)
 

--- a/scripts/tests/test_policy_guard.py
+++ b/scripts/tests/test_policy_guard.py
@@ -31,6 +31,35 @@ class ClassificationTests(unittest.TestCase):
         self.assertEqual(policy, [])
         self.assertEqual(product, [])
 
+    def test_the_control_plane_counts_as_policy(self):
+        # The guard, the dispatcher and the mirror tooling decide how the loop behaves.
+        # A change to any of them is a policy change, including a change to this guard.
+        policy, product = guard.classify(
+            [
+                "scripts/policy_guard.py",
+                "scripts/schedule_watchdog.py",
+                "scripts/tests/test_policy_guard.py",
+            ]
+        )
+        self.assertEqual(
+            policy,
+            [
+                "scripts/policy_guard.py",
+                "scripts/schedule_watchdog.py",
+                "scripts/tests/test_policy_guard.py",
+            ],
+        )
+        self.assertEqual(product, [])
+
+    def test_weakening_the_guard_alongside_product_code_is_refused(self):
+        # The specific attack this closes: relax the guard and ship a product change in
+        # the same breath, with the guard passing because it no longer objects.
+        violations = guard.check(
+            ["scripts/policy_guard.py", "src/index.ts"], added_lines=[]
+        )
+        self.assertEqual(len(violations), 1)
+        self.assertIn("split them", violations[0])
+
     def test_canonical_typescript_counts_as_product(self):
         # From M1 the canonical engine lives in src/. If the guard did not know that,
         # a policy change could ride along inside a canonical diff unnoticed.


### PR DESCRIPTION
Closes #60

## Why a human merges this

It changes what the guard treats as policy, and the guard is the thing standing between
an agent and the rules it is judged by. That is not a change the acceptor should wave
through on its own, even though this one narrows rather than widens.

## Achieved outcome

`scripts/` is policy. The dispatcher, the mirror normaliser, the telemetry writer and
the guard itself can no longer ride along inside a product diff, and a change to any of
them lands in the class the acceptor is told to scrutinise.

## The hole this closes

Relaxing `policy_guard.py` and adjusting `scripts/tests/test_policy_guard.py` to
match produced a change that passed its own tests, passed the guard, and was mergeable
with no person involved. The acceptor's escalation rule names `.github/workflows/**`,
`AGENTS.md` and `docs/zendev/**` — every path except the file doing the enforcing.

Two new tests state that attack directly rather than only asserting classifications.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest discover -s scripts/tests` | `passed` | 48 tests, two new |
| `python scripts/policy_guard.py --base origin/master` | `passed` | policy-only diff |
| `build-and-test`, `typescript`, `policy-guard` | see checks tab | |

## Consequence worth accepting deliberately

Work on the control plane now costs a separate pull request whenever it would otherwise
have travelled with product code. That is the intended friction, and it applies to #59:
the dispatcher change will arrive alone, which is what you want for the component that
decides whether the loop runs at all.

## Not checked

Whether anything in the existing backlog assumed it could change `scripts/` alongside
product code. Nothing open does today; a future run will simply be refused and split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)