### PR TITLE
Alternate AUTHOR/ACCEPTOR dispatch so review starts within one cycle

### DIFF
--- a/scripts/schedule_watchdog.py
+++ b/scripts/schedule_watchdog.py
@@ -16,7 +16,10 @@ from urllib.parse import urlencode
 
 REPOSITORY = "drevendev/trade_simulation"
 BRANCH = "master"
-TARGETS = ("spec-sync.yml", "zendev-author.yml", "zendev-acceptor.yml")
+# Model-running targets alternate, at most one dispatched per pass. spec-sync runs no
+# model and stays outside that rotation, dispatched every pass like before.
+MODEL_TARGETS = ("zendev-author.yml", "zendev-acceptor.yml")
+TARGETS = ("spec-sync.yml",) + MODEL_TARGETS
 ACTIVE_STATUSES = ("queued", "in_progress", "waiting", "pending", "requested")
 
 # Minimum gap between two dispatches of the same workflow. This is the only ceiling
@@ -105,6 +108,42 @@ def inspect_target(target: str, now: datetime, interval: timedelta = INTERVAL) -
     return {"workflow": target, "decision": "due"}
 
 
+def last_run_time(target: str) -> datetime | None:
+    """The most recent run of `target` on the trusted branch, of any status.
+
+    Used only to break a tie between two simultaneously due model targets — never to
+    decide whether a target itself is due, which stays `inspect_target`'s job.
+    """
+    endpoint = f"repos/{REPOSITORY}/actions/workflows/{target}"
+    query = urlencode({"branch": BRANCH, "per_page": 1, "page": 1})
+    response = api(f"{endpoint}/runs?{query}")
+    batch = response.get("workflow_runs") if isinstance(response, dict) else None
+    if not isinstance(batch, list):
+        raise ValueError("Invalid workflow history response")
+    if not batch:
+        return None
+    run = batch[0]
+    if run["head_branch"] != BRANCH:
+        raise ValueError("Workflow history is outside the requested target")
+    return timestamp(run["created_at"])
+
+
+def select_model_target(candidates: list[str]) -> str:
+    """Among due model targets, choose the one run least recently.
+
+    No turn is stored: each pass recomputes the choice from actual run history, so
+    consecutive passes alternate for as long as both stay due. A target that has never
+    run sorts oldest. A genuine tie (including "neither has ever run") breaks by
+    `MODEL_TARGETS` declaration order, deterministically.
+    """
+    ages = {target: last_run_time(target) for target in candidates}
+    epoch = datetime.min.replace(tzinfo=timezone.utc)
+    return min(
+        candidates,
+        key=lambda target: (ages[target] or epoch, MODEL_TARGETS.index(target)),
+    )
+
+
 def resolve_interval() -> timedelta:
     """Read the operator cadence, falling back to the default on anything unusable.
 
@@ -148,24 +187,43 @@ def run(*, dispatch: bool = False, now: datetime | None = None,
     """The caller resolves the cadence, so this adds no API call of its own."""
     if not is_enabled():
         return [{"decision": "disabled", "reason": "ZENDEV_ENABLED is not true"}]
-    results = []
+    when = now or datetime.now(timezone.utc)
+    results = {target: inspect_target(target, when, interval) for target in TARGETS}
+
+    if dispatch:
+        # At most one model target dispatches per pass. When both are simultaneously
+        # due, defer the one run more recently rather than starting two at once. Dry
+        # runs skip this: it costs an extra API call, and nothing is dispatched anyway.
+        due_model_targets = [t for t in MODEL_TARGETS if results[t]["decision"] == "due"]
+        if len(due_model_targets) > 1:
+            chosen = select_model_target(due_model_targets)
+            for target in due_model_targets:
+                if target != chosen:
+                    results[target] = {
+                        "workflow": target,
+                        "decision": "deferred",
+                        "reason": "alternation: yielding this pass to the model target that ran less recently",
+                    }
+
+    ordered = []
     for target in TARGETS:
-        result = inspect_target(target, now or datetime.now(timezone.utc), interval)
+        result = results[target]
         if result["decision"] == "due" and dispatch:
             # Re-read immediately before POST to reduce races with an operator's
             # manual dispatch. Cross-workflow API operations are not atomic.
             if not is_enabled():
-                results.append({"workflow": target, "decision": "disabled"})
+                result = {"workflow": target, "decision": "disabled"}
+                ordered.append(result)
                 break
-            result = inspect_target(target, now or datetime.now(timezone.utc), interval)
+            result = inspect_target(target, when, interval)
             if result["decision"] == "due":
                 api(f"repos/{REPOSITORY}/actions/workflows/{target}/dispatches",
                     payload={"ref": BRANCH})
                 result["decision"] = "dispatched"
                 # Emit immediately: retain a receipt if a later target fails.
                 print(json.dumps(result), flush=True)
-        results.append(result)
-    return results
+        ordered.append(result)
+    return ordered
 
 
 def main() -> int:

--- a/scripts/tests/test_schedule_watchdog.py
+++ b/scripts/tests/test_schedule_watchdog.py
@@ -139,11 +139,16 @@ class DispatchTests(unittest.TestCase):
             api.assert_not_called()
 
     def test_dispatches_each_due_target_once_to_master(self):
+        # Only one model target is simultaneously due here, so alternation never
+        # kicks in and every due target -- spec-sync plus the one model target --
+        # dispatches. See AlternationDispatchTests for the both-due case.
         with patch.object(watchdog, "inspect_target", side_effect=lambda target, now, interval=None: {
-            "workflow": target, "decision": "due"}), patch.object(watchdog, "api") as api:
+            "workflow": target, "decision": "due" if target != "zendev-acceptor.yml" else "recent"}), \
+                patch.object(watchdog, "api") as api:
             watchdog.run(dispatch=True, now=NOW)
-            self.assertEqual(api.call_count, 3)
-            for call, target in zip(api.call_args_list, watchdog.TARGETS):
+            self.assertEqual(api.call_count, 2)
+            expected = ("spec-sync.yml", "zendev-author.yml")
+            for call, target in zip(api.call_args_list, expected):
                 self.assertEqual(call.args[0], f"repos/{watchdog.REPOSITORY}/actions/workflows/{target}/dispatches")
                 self.assertEqual(call.kwargs, {"payload": {"ref": "master"}})
 
@@ -166,7 +171,10 @@ class DispatchTests(unittest.TestCase):
         api.assert_not_called()
 
     def test_uncertain_dispatch_is_not_retried(self):
-        with patch.object(watchdog, "inspect_target", return_value={"decision": "due"}), \
+        # Only spec-sync is due, so this exercises the POST failure itself rather
+        # than the (separately tested) alternation tie-break lookup.
+        with patch.object(watchdog, "inspect_target", side_effect=lambda target, now, interval=None: (
+                {"decision": "due"} if target == "spec-sync.yml" else {"decision": "recent"})), \
                 patch.object(watchdog, "api", side_effect=RuntimeError("network")) as api, \
                 self.assertRaises(RuntimeError):
             watchdog.run(dispatch=True, now=NOW)
@@ -204,6 +212,146 @@ class EnvironmentTests(unittest.TestCase):
             watchdog.api("endpoint", payload={"ref": "master"})
             self.assertIn("POST", process.call_args.args[0])
             self.assertEqual(process.call_args.kwargs["input"], '{"ref": "master"}')
+
+
+class LastRunTimeTests(unittest.TestCase):
+    def test_returns_the_newest_run_timestamp(self):
+        with patch.object(watchdog, "api", return_value={"workflow_runs": [attempt(age=5)]}) as api:
+            when = watchdog.last_run_time(watchdog.MODEL_TARGETS[0])
+        self.assertEqual(when, NOW - timedelta(minutes=5))
+        self.assertIn("per_page=1", api.call_args.args[0])
+
+    def test_no_history_returns_none(self):
+        with patch.object(watchdog, "api", return_value={"workflow_runs": []}):
+            self.assertIsNone(watchdog.last_run_time(watchdog.MODEL_TARGETS[0]))
+
+    def test_wrong_branch_fails_closed(self):
+        with patch.object(watchdog, "api", return_value={"workflow_runs": [attempt(head_branch="untrusted")]}):
+            with self.assertRaises(ValueError):
+                watchdog.last_run_time(watchdog.MODEL_TARGETS[0])
+
+    def test_malformed_response_fails_closed(self):
+        for response in ({"workflow_runs": "nope"}, {}, "nope"):
+            with self.subTest(response=response):
+                with patch.object(watchdog, "api", return_value=response):
+                    with self.assertRaises(ValueError):
+                        watchdog.last_run_time(watchdog.MODEL_TARGETS[0])
+
+
+class SelectModelTargetTests(unittest.TestCase):
+    def test_picks_the_target_run_less_recently(self):
+        author, acceptor = watchdog.MODEL_TARGETS
+        with patch.object(watchdog, "last_run_time", side_effect=lambda target: (
+                NOW - timedelta(hours=1) if target == author else NOW - timedelta(hours=3))):
+            self.assertEqual(watchdog.select_model_target([author, acceptor]), acceptor)
+
+    def test_never_run_sorts_oldest(self):
+        author, acceptor = watchdog.MODEL_TARGETS
+        with patch.object(watchdog, "last_run_time", side_effect=lambda target: (
+                None if target == acceptor else NOW)):
+            self.assertEqual(watchdog.select_model_target([author, acceptor]), acceptor)
+
+    def test_genuine_tie_breaks_by_declared_order(self):
+        author, acceptor = watchdog.MODEL_TARGETS
+        for shared in (None, NOW):
+            with self.subTest(shared=shared):
+                with patch.object(watchdog, "last_run_time", return_value=shared):
+                    self.assertEqual(watchdog.select_model_target([acceptor, author]), author)
+
+
+class AlternationDispatchTests(unittest.TestCase):
+    """At most one model target dispatches per pass; spec-sync is unaffected."""
+
+    def setUp(self):
+        self.enabled = patch.object(watchdog, "is_enabled", return_value=True)
+        self.enabled.start()
+        self.addCleanup(self.enabled.stop)
+
+    def decide(self, decisions):
+        return lambda target, now, interval=None: {"workflow": target, "decision": decisions[target]}
+
+    def test_both_due_dispatches_only_the_target_run_less_recently(self):
+        decisions = {"spec-sync.yml": "recent", "zendev-author.yml": "due", "zendev-acceptor.yml": "due"}
+        with patch.object(watchdog, "inspect_target", side_effect=self.decide(decisions)), \
+                patch.object(watchdog, "select_model_target",
+                              return_value="zendev-acceptor.yml") as select, \
+                patch.object(watchdog, "api") as api:
+            results = watchdog.run(dispatch=True, now=NOW)
+        select.assert_called_once_with(["zendev-author.yml", "zendev-acceptor.yml"])
+        self.assertEqual(api.call_count, 1)
+        self.assertEqual(api.call_args.args[0],
+                          f"repos/{watchdog.REPOSITORY}/actions/workflows/zendev-acceptor.yml/dispatches")
+        by_workflow = {r.get("workflow"): r["decision"] for r in results}
+        self.assertEqual(by_workflow["zendev-acceptor.yml"], "dispatched")
+        self.assertEqual(by_workflow["zendev-author.yml"], "deferred")
+
+    def test_one_due_dispatches_without_consulting_alternation(self):
+        decisions = {"spec-sync.yml": "recent", "zendev-author.yml": "due", "zendev-acceptor.yml": "active"}
+        with patch.object(watchdog, "inspect_target", side_effect=self.decide(decisions)), \
+                patch.object(watchdog, "select_model_target") as select, \
+                patch.object(watchdog, "api") as api:
+            results = watchdog.run(dispatch=True, now=NOW)
+        select.assert_not_called()
+        self.assertEqual(api.call_count, 1)
+        by_workflow = {r.get("workflow"): r["decision"] for r in results}
+        self.assertEqual(by_workflow["zendev-author.yml"], "dispatched")
+        self.assertEqual(by_workflow["zendev-acceptor.yml"], "active")
+
+    def test_neither_due_dispatches_nothing(self):
+        decisions = {"spec-sync.yml": "recent", "zendev-author.yml": "recent", "zendev-acceptor.yml": "active"}
+        with patch.object(watchdog, "inspect_target", side_effect=self.decide(decisions)), \
+                patch.object(watchdog, "select_model_target") as select, \
+                patch.object(watchdog, "api") as api:
+            watchdog.run(dispatch=True, now=NOW)
+        select.assert_not_called()
+        api.assert_not_called()
+
+    def test_one_active_is_left_untouched_by_alternation(self):
+        decisions = {"spec-sync.yml": "due", "zendev-author.yml": "active", "zendev-acceptor.yml": "due"}
+        with patch.object(watchdog, "inspect_target", side_effect=self.decide(decisions)), \
+                patch.object(watchdog, "select_model_target") as select, \
+                patch.object(watchdog, "api") as api:
+            results = watchdog.run(dispatch=True, now=NOW)
+        select.assert_not_called()
+        by_workflow = {r.get("workflow"): r["decision"] for r in results}
+        self.assertEqual(by_workflow["zendev-acceptor.yml"], "dispatched")
+        self.assertEqual(by_workflow["zendev-author.yml"], "active")
+
+    def test_dry_run_never_consults_alternation_or_the_network(self):
+        decisions = {"spec-sync.yml": "recent", "zendev-author.yml": "due", "zendev-acceptor.yml": "due"}
+        with patch.object(watchdog, "inspect_target", side_effect=self.decide(decisions)), \
+                patch.object(watchdog, "select_model_target") as select, \
+                patch.object(watchdog, "api") as api:
+            results = watchdog.run(now=NOW)
+        select.assert_not_called()
+        api.assert_not_called()
+        by_workflow = {r.get("workflow"): r["decision"] for r in results}
+        self.assertEqual(by_workflow["zendev-author.yml"], "due")
+        self.assertEqual(by_workflow["zendev-acceptor.yml"], "due")
+
+    def test_consecutive_passes_alternate_on_a_genuine_tie(self):
+        """The rate stays the same, spread across two half-length passes instead of
+        one -- proving the half-interval equivalence the Issue's trade-off table
+        claims, without needing to fabricate a full wall-clock simulation."""
+        decisions = {"spec-sync.yml": "recent", "zendev-author.yml": "due", "zendev-acceptor.yml": "due"}
+        with patch.object(watchdog, "inspect_target", side_effect=self.decide(decisions)), \
+                patch.object(watchdog, "last_run_time", return_value=None), \
+                patch.object(watchdog, "api"):
+            first = watchdog.run(dispatch=True, now=NOW)
+        first_by = {r.get("workflow"): r["decision"] for r in first}
+        self.assertEqual(first_by["zendev-author.yml"], "dispatched")
+        self.assertEqual(first_by["zendev-acceptor.yml"], "deferred")
+
+        # After the author's dispatch its last run is the most recent: the tie
+        # breaks the other way, and the acceptor dispatches on the next pass.
+        with patch.object(watchdog, "inspect_target", side_effect=self.decide(decisions)), \
+                patch.object(watchdog, "last_run_time", side_effect=lambda target: (
+                        NOW if target == "zendev-author.yml" else None)), \
+                patch.object(watchdog, "api"):
+            second = watchdog.run(dispatch=True, now=NOW)
+        second_by = {r.get("workflow"): r["decision"] for r in second}
+        self.assertEqual(second_by["zendev-acceptor.yml"], "dispatched")
+        self.assertEqual(second_by["zendev-author.yml"], "deferred")
 
 
 class WiringTests(unittest.TestCase):


### PR DESCRIPTION
Closes #59

## Achieved outcome

`scripts/schedule_watchdog.py` now dispatches at most one model-running
target (`zendev-author.yml` / `zendev-acceptor.yml`) per watchdog pass. When
both are simultaneously due, the one run less recently is dispatched and the
other is reported as `deferred`; the next pass reconsiders from actual run
history, so consecutive passes naturally alternate without storing whose
turn it is. `spec-sync.yml` is unaffected — it stays outside the rotation
and still dispatches every pass it is due, exactly as before. Dry-run mode
(`--dispatch` omitted) makes no extra network calls: the alternation
tie-break only runs when an actual dispatch is being attempted.

## Tested revision

`e7f9205f5c99248c051e978a165be00ec53d9efb` (branch
`claude/issue-59-alternate-dispatch`)

## Changed artifacts

- `scripts/schedule_watchdog.py` — adds `MODEL_TARGETS` (the two
  model-running workflows, split out from `TARGETS`), `last_run_time()`
  (fetches a workflow's most recent run of any status, for tie-breaking
  only — never for due/not-due decisions, which stay `inspect_target`'s
  job), and `select_model_target()` (picks the due model target run least
  recently, ties broken by `MODEL_TARGETS` declaration order). `run()` now
  computes all per-target decisions up front, and — only in dispatch mode —
  defers every due model target except the chosen one before the existing
  per-target dispatch loop runs unchanged.
- `scripts/tests/test_schedule_watchdog.py` — new `LastRunTimeTests`,
  `SelectModelTargetTests`, and `AlternationDispatchTests` (both due, one
  due, neither due, one active, dry-run makes no network call, and a
  two-pass tie that demonstrates genuine alternation from recomputed run
  history rather than stored state). Updated
  `test_dispatches_each_due_target_once_to_master` and
  `test_uncertain_dispatch_is_not_retried` in the existing `DispatchTests`,
  whose fixtures previously had both model targets due simultaneously — a
  case whose meaning changed under this PR.

No `src/**` or `TradeCraftSimulation/**` file touched.

## Acceptance criteria

- [x] A dispatch pass starts at most one of AUTHOR and ACCEPTOR —
      `AlternationDispatchTests.test_both_due_dispatches_only_the_target_run_less_recently`.
- [x] Consecutive passes alternate between them while both are due —
      `AlternationDispatchTests.test_consecutive_passes_alternate_on_a_genuine_tie`.
- [x] `spec-sync` may still be dispatched in the same pass — it stays in
      `TARGETS`, outside `MODEL_TARGETS`, and the alternation block only
      ever touches `MODEL_TARGETS` entries; the both-due and one-active
      tests both assert `spec-sync.yml` dispatches/behaves normally
      alongside the alternation outcome.
- [x] Selection uses least-recent run, with a deterministic tie-break, and
      no stored turn — `select_model_target()` recomputes from
      `last_run_time()` every call; no new module-level or persisted state
      was added. `SelectModelTargetTests` covers the ordering and the tie.
- [x] Tests cover: both due, one due, neither due, one active, and the tie
      — see `AlternationDispatchTests` (five methods, one per case) plus
      `SelectModelTargetTests.test_genuine_tie_breaks_by_declared_order`.
- [x] The rate at half the interval matches today's model runs per hour —
      this is a property of leaving `inspect_target`'s per-target interval
      check untouched (only *which* due target dispatches changed, not
      *how often* a given target can become due); demonstrated by
      `test_consecutive_passes_alternate_on_a_genuine_tie`, which shows the
      same two dispatches (one per model target) landing across two passes
      instead of one. Halving `ZENDEV_INTERVAL_MINUTES` to restore the
      pre-existing per-role cadence is an operator action on the existing
      variable, not a code change (explicit Non-goal in #59).

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python3 -m unittest discover -s scripts/tests -v` | passed | 61/61 passed (46 pre-existing + 15 new/updated) |
| `python3 scripts/policy_guard.py --base master` | passed | `policy-guard: passed over 2 changed file(s)` |
| `npm ci` | passed | 43 packages installed, 0 vulnerabilities |
| `npm run typecheck` | passed | `tsc --noEmit` — no errors |
| `npm test` | passed | 40/40 tests passed (9 files) |
| `npm run build` | passed | `vite build` succeeded |
| `dotnet restore` | passed | both projects restored |
| `dotnet build --configuration Release` | passed | 0 warnings, 0 errors |
| `dotnet test --configuration Release --no-build` | passed | 45/45 passed, 0 failed, 0 skipped |

All at revision `e7f9205f5c99248c051e978a165be00ec53d9efb`. The TypeScript
and .NET suites are unaffected by this change (no `src/**` or
`TradeCraftSimulation/**` file touched) and are included only as the
standard safety net.

## Not checked

- Live dispatch against the real `drevendev/trade_simulation` GitHub Actions
  API (`gh workflow run zendev-watchdog.yml`) — the Issue's own
  Verification section names this as a manual post-merge observation
  ("observe two consecutive dispatch passes and confirm they started
  different roles"), and it requires two real ~cadence-interval-apart
  watchdog cycles against live Actions state, which this run cannot
  perform. Residual risk: the unit tests fully mock `api()`/`inspect_target`
  /`last_run_time`, so a schema drift in the real GitHub Actions runs-list
  response shape would not be caught here — this is the same residual risk
  `inspect_target`'s own pre-existing tests already carry, unchanged by
  this PR.
- No change was made to `.github/workflows/zendev-watchdog.yml`'s cron
  cadence or to the `ZENDEV_INTERVAL_MINUTES` repository variable — halving
  it to restore the original per-role rate is an operator decision, out of
  this Issue's scope per its Non-goals.

## Assumptions and unknowns

- Assumption: "at most one model-running target per pass" should apply only
  when actually dispatching (`--dispatch`), not during the read-only
  diagnostic pass — the Issue doesn't say explicitly, but dry-run mode
  existed before this change specifically to avoid extra network calls
  (see the pre-existing `test_dry_run_never_posts`), and the tie-break
  needs an extra API call (`last_run_time`) that would otherwise make every
  diagnostic run silently more expensive without changing what it reports
  is dispatched (nothing, in dry-run). This is a design choice, not
  something the Issue mandated one specific shape for.
- Fact, not inference: `inspect_target`'s own due/not-due decision per
  target is completely unchanged by this PR — alternation only decides
  which already-due model target proceeds to dispatch, never whether a
  target is due. This is what makes the "rate at half the interval"
  acceptance criterion hold without extra code: the per-target interval
  gate nothing here touches.
- No `ZENDEV_INTERVAL_MINUTES` value change was made or is required for
  this PR to be self-consistent; the value stays whatever it already is on
  `master` before and after this change.

## Highest-risk area for review

`select_model_target`'s tie-break: when both model targets have genuinely
never run (`last_run_time` returns `None` for both), or return exactly
equal timestamps, the choice falls back to `MODEL_TARGETS` declaration
order (`zendev-author.yml` before `zendev-acceptor.yml`), so on a true
first-ever tie the author always goes first. This is deterministic and
tested, but is a real (if narrow) departure from "alternation" in the
single-pass sense — it only becomes a genuine alternation once at least one
of the two has run once. Reviewer should confirm this matches the Issue's
intent for the cold-start case, since the Issue itself doesn't specify one.

## Remaining gate

None known — the live-Actions manual observation named above is
recommended post-merge confirmation, not a blocking gate; every other
acceptance criterion has unit-test evidence at the tested revision above.