### PR TITLE
Pin the model and record it in the ledger

### DIFF
--- a/.github/workflows/zendev-acceptor.yml
+++ b/.github/workflows/zendev-acceptor.yml
@@ -51,6 +51,16 @@ jobs:
           # Exactly this bot, never "*": on a public repository "*" would let any
           # external app invoke this action with a prompt it controls.
           allowed_bots: "github-actions"
+          # Pinned deliberately. Left unset, the action runs whatever it defaults to
+          # today, which can change under an unattended loop with no signal but the
+          # bill. The model is part of what governs a run, so it is declared here and
+          # recorded in the telemetry ledger for every run.
+          #
+          # Circuit breaker, not a budget: expected acceptor spend on this model is
+          # well under a dollar, so this only fires on a genuine runaway. A hard stop
+          # here is ungraceful — the run cannot report its own blocker — which is why
+          # the ceiling is generous rather than tight.
+          claude_args: --model claude-haiku-4-5 --max-budget-usd 2.00
           settings: |
             {
               "permissions": {

--- a/.github/workflows/zendev-author.yml
+++ b/.github/workflows/zendev-author.yml
@@ -53,6 +53,16 @@ jobs:
           # Exactly this bot, never "*": on a public repository "*" would let any
           # external app invoke this action with a prompt it controls.
           allowed_bots: "github-actions"
+          # Pinned deliberately. Left unset, the action runs whatever it defaults to
+          # today, which can change under an unattended loop with no signal but the
+          # bill. The model is part of what governs a run, so it is declared here and
+          # recorded in the telemetry ledger for every run.
+          #
+          # Circuit breaker, not a budget: expected author spend on this model is
+          # well under a dollar, so this only fires on a genuine runaway. A hard stop
+          # here is ungraceful — the run cannot report its own blocker — which is why
+          # the ceiling is generous rather than tight.
+          claude_args: --model claude-haiku-4-5 --max-budget-usd 3.00
           settings: |
             {
               "permissions": {

--- a/scripts/record_usage.py
+++ b/scripts/record_usage.py
@@ -55,6 +55,23 @@ def read_messages(path: str):
     return data, None
 
 
+def extract_model(messages):
+    """Which model produced this run.
+
+    Without it the ledger cannot be read back: a cost or quality change is
+    indistinguishable from a model change, and the model can change without anyone
+    editing the workflow. Checked in several places because the shape differs between
+    the final result message and the assistant messages.
+    """
+    for message in reversed(messages):
+        if not isinstance(message, dict):
+            continue
+        for candidate in (message.get("model"), (message.get("message") or {}).get("model")):
+            if isinstance(candidate, str) and candidate:
+                return candidate
+    return None
+
+
 def extract_usage(messages):
     """Prefer the final result message; fall back to summing assistant messages.
 
@@ -133,15 +150,19 @@ def main() -> int:
     if problem:
         warn(problem)
         tokens = {field: None for field in TOKEN_FIELDS}
-        extra, source = {}, "unavailable"
+        extra, source, model = {}, "unavailable", None
     else:
         tokens, extra, source = extract_usage(messages)
+        model = extract_model(messages)
+        if model is None:
+            warn("the execution file names no model; recording null")
 
     now = dt.datetime.now(dt.timezone.utc)
     record = {
         "recorded_at": now.isoformat(timespec="seconds"),
         "role": args.role,
         "conclusion": args.conclusion,
+        "model": model,
         "usage_source": source,
         **tokens,
         "total_cost_usd": extra.get("total_cost_usd"),

--- a/scripts/tests/test_record_usage.py
+++ b/scripts/tests/test_record_usage.py
@@ -54,6 +54,40 @@ class ExtractionTests(unittest.TestCase):
             self.assertIsNone(tokens[field], f"{field} must be null, not 0")
 
 
+class ModelTests(unittest.TestCase):
+    def test_model_from_the_result_message(self):
+        self.assertEqual(
+            rec.extract_model([{"type": "result", "model": "claude-haiku-4-5"}]),
+            "claude-haiku-4-5",
+        )
+
+    def test_model_from_a_nested_assistant_message(self):
+        self.assertEqual(
+            rec.extract_model(
+                [{"type": "assistant", "message": {"model": "claude-sonnet-5"}}]
+            ),
+            "claude-sonnet-5",
+        )
+
+    def test_the_last_model_wins(self):
+        # Service sub-calls can name a different model; the run's own model is the
+        # one that finished it.
+        self.assertEqual(
+            rec.extract_model(
+                [
+                    {"type": "assistant", "message": {"model": "claude-haiku-4-5"}},
+                    {"type": "result", "model": "claude-sonnet-5"},
+                ]
+            ),
+            "claude-sonnet-5",
+        )
+
+    def test_absent_model_is_null_not_guessed(self):
+        # A guessed model in the ledger is worse than a gap: it would make a silent
+        # default change look like a deliberate choice.
+        self.assertIsNone(rec.extract_model([{"type": "result"}, {"type": "system"}]))
+
+
 class ReadMessagesTests(unittest.TestCase):
     def test_missing_path_is_reported_not_raised(self):
         messages, problem = rec.read_messages("")


### PR DESCRIPTION
Closes #81

## Why a human merges this

It changes which model runs unattended and adds a spend ceiling — a deployment decision
with a cost and a quality consequence, not a refactor.

## What changes

| | Before | After |
| --- | --- | --- |
| Model | unset, action default (`claude-sonnet-5`) | `claude-haiku-4-5`, both roles |
| Spend ceiling | none | $3.00 author, $2.00 acceptor per run |
| Model in telemetry | absent | recorded, `null` when unreadable |

Haiku is your call, made with the numbers in #81 in front of you. On this
deployment's own token profile it works out at roughly $2.07 per closed requirement
against $4.14 on Sonnet.

I said before and will not repeat after this: the acceptor is the one role whose
mistakes nothing else catches. Your mitigation — re-checking the loop's output — is the
right one, and moving the mechanical half of acceptance into CI would make the choice
structurally safe rather than supervised. That is queued as the next piece of work.

## Two design points

**The ceiling is a circuit breaker, not a budget.** Expected Haiku spend is well under a
dollar per run, so $3 and $2 only fire on a genuine runaway. Tightening them would
make hard stops routine, and a run cut off by spend cannot report its own blocker — an
expensive run is better than an untraceable one.

**An unreadable model is recorded as `null`.** Guessing would be worse than a gap: it
would make a silent default change look like a deliberate choice, which is exactly the
failure this Issue is about.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest discover -s scripts/tests` | `passed` | 65 tests, four new |
| `policy-guard` on this branch | `passed` | policy-only diff |
| `build-and-test`, `typescript`, `policy-guard` in CI | see checks tab | |
| `--model` accepted by the action | `not_run` | dispatch runs the default-branch copy; provable only after merge |
| `--max-budget-usd` accepted | `not_run` | documented as headless-only, and the action runs headless — but unverified here |

## Not checked, and how I will check it

`claude_args` reaches the CLI verbatim, so a flag it rejects fails the run. I will
dispatch one run immediately after merge and confirm three things: the log names
`claude-haiku-4-5`, the run completes, and the ledger record carries the model. If the
budget flag is rejected, dropping that half is a one-line revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)