### PR TITLE
Refuse a local home-directory path in a diff

### DIFF
--- a/scripts/policy_guard.py
+++ b/scripts/policy_guard.py
@@ -5,7 +5,8 @@ Two rules the ACCEPTOR role must not be the only thing enforcing:
 1. A change to automation policy (workflows, AGENTS.md, runbooks) may not be bundled
    with a change to product code. Policy is reviewed alone, so that widening what
    agents may do can never ride along inside a feature diff.
-2. No credential-shaped string enters the repository.
+2. No credential-shaped string, and no path into a local home directory, enters the
+   repository.
 
 Exit code 0 means the change is allowed to proceed, 1 means it is refused.
 The guard is intentionally simple: it is a negative control, not a linter.
@@ -49,6 +50,25 @@ SECRET_PATTERNS = (
     ("AWS access key", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
 )
 
+# A path into somebody's home directory names the machine a change was made on, and
+# usually the person. It is not a credential, so it gets its own class and its own
+# message, but it is refused for the same reason: it must not enter a public
+# repository, and until now noticing it was left entirely to the reviewing model.
+LOCAL_PATH_PATTERNS = (
+    (
+        "Windows home directory path",
+        re.compile(r"\b[A-Za-z]:[\\/](?:Users|home)[\\/][^\\/\s\"']+"),
+    ),
+    (
+        "POSIX home directory path",
+        re.compile(r"(?<![\w.-])/(?:home|Users)/[^/\s\"']+"),
+    ),
+)
+
+# The hosted runner's own working directory is a fixed, published path that names no
+# person and no private machine. Workflows may legitimately refer to it.
+LOCAL_PATH_EXEMPTIONS = (re.compile(r"^/home/runner(?:/|$)"),)
+
 
 def is_policy(path: str) -> bool:
     return path in POLICY_FILES or path.startswith(POLICY_PREFIXES)
@@ -77,6 +97,21 @@ def scan_secrets(added_lines):
     return findings
 
 
+def scan_local_paths(added_lines):
+    """Return (label, line) for every added line carrying a local machine path."""
+    findings = []
+    for line in added_lines:
+        for label, pattern in LOCAL_PATH_PATTERNS:
+            match = pattern.search(line)
+            if not match:
+                continue
+            if any(e.match(match.group(0)) for e in LOCAL_PATH_EXEMPTIONS):
+                continue
+            findings.append((label, line.strip()[:120]))
+            break
+    return findings
+
+
 def check(paths, added_lines):
     """Pure policy decision. Returns a list of human-readable violations."""
     violations = []
@@ -91,6 +126,9 @@ def check(paths, added_lines):
 
     for label, line in scan_secrets(added_lines):
         violations.append(f"possible {label} in an added line: {line}")
+
+    for label, line in scan_local_paths(added_lines):
+        violations.append(f"{label} in an added line: {line}")
 
     return violations
 

--- a/scripts/policy_guard.py
+++ b/scripts/policy_guard.py
@@ -67,7 +67,13 @@ LOCAL_PATH_PATTERNS = (
 
 # The hosted runner's own working directory is a fixed, published path that names no
 # person and no private machine. Workflows may legitimately refer to it.
-LOCAL_PATH_EXEMPTIONS = (re.compile(r"^/home/runner(?:/|$)"),)
+#
+# Assembled from fragments, like the fixtures in the test: written as one literal, this
+# line is itself a home-directory path, and the guard refused the pull request that
+# introduced it. Exempting this file instead would have put a hole in the scanner at
+# the one place a hole is least acceptable.
+_RUNNER_HOME = "/" + "home/runner"
+LOCAL_PATH_EXEMPTIONS = (re.compile("^" + re.escape(_RUNNER_HOME) + r"(?:/|$)"),)
 
 
 def is_policy(path: str) -> bool:

--- a/scripts/tests/test_policy_guard.py
+++ b/scripts/tests/test_policy_guard.py
@@ -123,5 +123,47 @@ class SecretScanTests(unittest.TestCase):
         self.assertEqual(guard.scan_secrets(clean), [])
 
 
+class LocalPathTests(unittest.TestCase):
+    # Assembled from fragments for the same reason as the credential fixtures above:
+    # a literal home-directory path in a tracked file would make the guard refuse
+    # every pull request that touches this test.
+    def test_home_directory_paths_are_detected(self):
+        samples = [
+            "key = '" + "C:" + "\\Users\\" + "someone\\Downloads\\sa.json'",
+            "path: " + "D:" + "/Users/" + "someone/projects/sim",
+            "cfg = " + "/home/" + "someone/.config/app",
+            "open('" + "/Users/" + "someone/notes.md')",
+        ]
+        for sample in samples:
+            with self.subTest(sample=sample):
+                self.assertTrue(guard.scan_local_paths([sample]), f"missed: {sample}")
+
+    def test_the_hosted_runner_path_is_not_a_local_path(self):
+        # A fixed, published path on the hosted runner. It names no person and no
+        # private machine, and refusing it would make ordinary workflow work
+        # impossible — which is how a guard earns an exception it should not have.
+        exempt = [
+            "workspace: " + "/home/" + "runner/work/trade_simulation",
+            "cwd = " + "/home/" + "runner",
+        ]
+        self.assertEqual(guard.scan_local_paths(exempt), [])
+
+    def test_ordinary_text_is_not_flagged(self):
+        clean = [
+            "See docs/spec/mirror/REQUIREMENTS_REGISTRY.csv for the registry.",
+            "Users of the simulation API must call buildWorldRegistries first.",
+            "const url = 'https://example.com/home/index.html';",
+            "import { home } from './layout/home';",
+        ]
+        self.assertEqual(guard.scan_local_paths(clean), [])
+
+    def test_a_local_path_is_refused_by_the_full_check(self):
+        violations = guard.check(
+            ["src/index.ts"], added_lines=["// see " + "C:" + "\\Users\\" + "someone\\sim"]
+        )
+        self.assertEqual(len(violations), 1)
+        self.assertIn("Windows home directory path", violations[0])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Pull request

## Outcome

`policy_guard.py` refuses an added line carrying a path into a home directory —
`C:\Users\<name>\…`, `/home/<name>/…`, `/Users/<name>/…` — as its own violation class,
separate from the credential scanner.

Part of #89 (the gap named in its section 2, row 6).

## Scope

- `scripts/policy_guard.py`: two patterns, one exemption, one scan function, one line
  in the module contract.
- `scripts/tests/test_policy_guard.py`: four negative controls.

Nothing else. No workflow change — the guard already runs on every pull request.

## Why this is a real gap, not a tidy-up

Section 2 of the ACCEPTOR runbook refuses "secrets, credentials, tokens, personal
data, or **local machine paths**". The guard implemented the first four and not the
last, so a machine path was enforced only by a model reading a diff. That is exactly
the dependency this guard exists to remove, and it was invisible because the gate
*looked* enforced: the runbook named it and a check existed nearby.

## The exemption, stated plainly

`/home/runner/…` is allowed. It is the hosted runner's fixed, published working
directory; it names no person and no private machine, and refusing it would break
ordinary workflow authoring. It is one anchored regex, not a path allowlist — the
distinction matters, because a path allowlist is how a scanner acquires blind spots
(the same reasoning that kept the credential fixtures out of an exempted file).

## Verification

- [x] `python -m unittest discover -s scripts/tests -v` — 69 tests, all pass (65 before)
- [x] `python scripts/policy_guard.py --base origin/master` — passes on this branch
- [x] Negative controls fail without the change: each of the four sample shapes is
      unmatched by `scan_local_paths` if the patterns are removed
- [x] No false positive on `docs/spec/mirror/...`, `Users of the API...`,
      `https://example.com/home/index.html`, `./layout/home`

## Evidence and uncertainty

- **Established:** the guard had no machine-path pattern; the repository contains no
  such string today, so this cannot turn `master` red.
- **Reasoned:** the POSIX pattern's lookbehind (`(?<![\w.-])`) is what keeps
  `src/Users/…` and `example.com/home/…` from matching. That is reasoning about the
  regex, backed by the four clean fixtures, not an exhaustive proof over all inputs.
- **Assumption:** mirrored specification content should be refused too if it ever
  carries a machine path. That follows from the mirror gate, which already tells the
  ACCEPTOR to look for exactly this.
- **Not checked:** other machine-identifying shapes — UNC paths, hostnames, local IPs.
  Out of scope here; worth a separate look if the class matters.

## Review focus

Whether the runner exemption is drawn narrowly enough. It is the only hole, it is
anchored at the start of the match, and it exists because the alternative is a guard
that workflow authors route around.

## Completion

- [x] Satisfies the row of #89 that names this gap.
- [x] Documentation synchronized — the module contract states the new rule.
- [x] No private data, credentials, or machine-specific paths were added; the fixtures
      are assembled from fragments so that no literal path is tracked.
- [x] No ADR required — this narrows what may enter the repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
