### PR TITLE
Answer mergeability on the pull request, not in a review run

### DIFF
--- a/.github/workflows/mergeability.yml
+++ b/.github/workflows/mergeability.yml
@@ -1,0 +1,50 @@
+name: Mergeability
+
+# A pull request stops merging when its base moves, and GitHub does not re-run that
+# pull request's checks when `master` advances. So this runs in two places: on the
+# pull request itself, and on every push to `master` over all open pull requests.
+# The second trigger is the one that matters — it is the moment a conflict is created.
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+# `statuses: write` is the whole grant. This workflow writes one commit status and
+# reads pull request metadata; it never checks out a branch's code and never merges.
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+concurrency:
+  group: mergeability-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mergeability:
+    name: mergeability
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Prove the classifier fires
+        run: python -m unittest discover -s scripts/tests -v
+
+      - name: Status for this pull request
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: python scripts/mergeability.py --repo "${{ github.repository }}" --pull "${PR_NUMBER}"
+
+      - name: Status for every open pull request, because the base moved
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python scripts/mergeability.py --repo "${{ github.repository }}" --all-open

--- a/docs/zendev/ACCEPTOR_RUNBOOK.md
+++ b/docs/zendev/ACCEPTOR_RUNBOOK.md
@@ -129,6 +129,12 @@ gh pr diff <number>
 
 - Every required check must be green **at the current head revision**. `pending`,
   `skipped`, `neutral`, and `unknown` are not green.
+- The `mergeability` status is one of them. It is written by a workflow that runs both
+  on the pull request and on every push to `master`, so it answers the question the
+  pull request's own checks cannot: whether the branch still merges *now*, after the
+  base moved. Read it before you judge anything else — a conflicting branch cannot be
+  accepted whatever its contents, and discovering that after forming a verdict is how
+  a run comes to post two contradictory verdicts on one head.
 - Check out the head revision and run the verification commands yourself — both
   runtimes, whichever one the diff touched:
 
@@ -150,6 +156,12 @@ Exactly one of the following.
 **REQUEST_CHANGES** — post a review naming each defect, the file and line, why it
 matters, and what would satisfy it. Set the Issue back to `status:in-progress`.
 Vague dissatisfaction is not a verdict.
+
+Exactly one verdict per head revision, and it is the last thing the run does. Do not
+post a verdict and then continue checking; if a later check changes the answer, the
+first verdict is already standing and the AUTHOR — which has no memory and reads
+verdicts as its input — sees both. Name the head revision in the verdict so a reader
+can tell which revision it judged.
 
 **ACCEPT** — allowed only when all of the following hold, and you state each one in
 the merge comment:

--- a/scripts/mergeability.py
+++ b/scripts/mergeability.py
@@ -1,0 +1,143 @@
+"""Report, as a commit status, whether an open pull request still merges cleanly.
+
+A pull request stops being mergeable when its *base* moves, not when the pull request
+itself changes. GitHub's own pull request checks do not re-run on a push to `master`,
+so a branch that conflicted an hour ago still shows the green checks it earned before
+the conflict existed. Nothing in the loop noticed that, and the discovery fell to an
+ACCEPTOR run — which spends a model run and half an hour to learn something the forge
+already knew.
+
+This script closes that. It reads mergeability from the API and writes a commit
+status named `mergeability` onto the pull request's head revision, so the answer is
+visible where every other gate is visible, at the moment the base moves.
+
+Three outcomes, and the third is the point:
+
+* the pull request merges cleanly    -> `success`
+* it conflicts with its base         -> `failure`
+* GitHub has not computed it yet     -> `pending`, never `success`
+
+An unknown answer is not a passing answer. GitHub computes mergeability lazily and
+reports `null` while it works; treating that as green would make the check report
+health it never observed, which is the failure mode the check exists to prevent.
+`pending` is honest, and the next push to either branch re-evaluates it.
+
+This check reports conflicts and nothing else. Whether the tests pass, the policy
+guard is happy, or the review is done are other checks' business — a check that
+answers more than one question cannot be read.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+
+CONTEXT = "mergeability"
+
+# The API caps a status description; a truncated sentence reads as a bug in the check.
+MAX_DESCRIPTION = 140
+
+
+def classify(mergeable, mergeable_state):
+    """Map the API's answer to (state, description). Pure."""
+    if mergeable is False:
+        return (
+            "failure",
+            f"conflicts with the base branch ({mergeable_state}); rebase and push",
+        )
+    if mergeable is True:
+        return ("success", f"merges cleanly into the base branch ({mergeable_state})")
+    return (
+        "pending",
+        "mergeability not yet computed by GitHub; re-evaluated on the next push",
+    )
+
+
+def _gh(args):
+    return subprocess.run(
+        ["gh", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def read_pull(repo: str, number: int):
+    """Return (head_sha, mergeable, mergeable_state) for one pull request."""
+    raw = _gh(["api", f"repos/{repo}/pulls/{number}"])
+    data = json.loads(raw)
+    return data["head"]["sha"], data.get("mergeable"), data.get("mergeable_state")
+
+
+def resolve(repo: str, number: int, attempts: int, delay: float):
+    """Read mergeability, giving GitHub a bounded chance to finish computing it."""
+    head_sha = mergeable = state = None
+    for attempt in range(attempts):
+        head_sha, mergeable, state = read_pull(repo, number)
+        if mergeable is not None:
+            break
+        if attempt + 1 < attempts:
+            time.sleep(delay)
+    return head_sha, mergeable, state
+
+
+def post_status(repo: str, sha: str, state: str, description: str) -> None:
+    _gh(
+        [
+            "api",
+            "-X",
+            "POST",
+            f"repos/{repo}/statuses/{sha}",
+            "-f",
+            f"state={state}",
+            "-f",
+            f"context={CONTEXT}",
+            "-f",
+            f"description={description[:MAX_DESCRIPTION]}",
+        ]
+    )
+
+
+def open_pull_numbers(repo: str):
+    raw = _gh(["api", f"repos/{repo}/pulls?state=open&per_page=100"])
+    return [int(pull["number"]) for pull in json.loads(raw)]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="owner/name")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--pull", type=int, help="one pull request number")
+    group.add_argument(
+        "--all-open",
+        action="store_true",
+        help="every open pull request; use when the base branch moved",
+    )
+    parser.add_argument("--attempts", type=int, default=8)
+    parser.add_argument("--delay", type=float, default=4.0)
+    args = parser.parse_args()
+
+    numbers = [args.pull] if args.pull else open_pull_numbers(args.repo)
+
+    conflicted = []
+    for number in numbers:
+        head_sha, mergeable, state = resolve(
+            args.repo, number, args.attempts, args.delay
+        )
+        status, description = classify(mergeable, state)
+        post_status(args.repo, head_sha, status, description)
+        print(f"{CONTEXT}: #{number} {head_sha[:8]} -> {status} ({description})")
+        if status == "failure":
+            conflicted.append(number)
+
+    # Exit 0 either way. The verdict for a pull request is the status written onto it,
+    # not this run's own conclusion: a red run over a list of pull requests says
+    # nothing about which one is broken, and a red run on the base branch would
+    # report the repository as unhealthy because one branch drifted.
+    if conflicted:
+        print(f"::notice::{CONTEXT}: conflicting pull request(s): {conflicted}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_mergeability.py
+++ b/scripts/tests/test_mergeability.py
@@ -1,0 +1,85 @@
+"""Negative controls for the mergeability status.
+
+The interesting case is the third one. A check that quietly reports `success` when it
+does not know the answer is worse than no check at all, because it converts an
+unmeasured property into a green tick that a reviewer is entitled to trust.
+"""
+
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import mergeability  # noqa: E402
+
+
+class ClassifyTests(unittest.TestCase):
+    def test_a_conflicting_pull_request_fails(self):
+        state, description = mergeability.classify(False, "dirty")
+        self.assertEqual(state, "failure")
+        self.assertIn("conflicts", description)
+        self.assertIn("rebase", description)
+
+    def test_a_clean_pull_request_passes(self):
+        state, _ = mergeability.classify(True, "clean")
+        self.assertEqual(state, "success")
+
+    def test_unknown_is_pending_and_never_success(self):
+        state, description = mergeability.classify(None, "unknown")
+        self.assertEqual(state, "pending")
+        self.assertNotEqual(state, "success")
+        self.assertIn("not yet computed", description)
+
+    def test_other_blocked_states_are_still_mergeable(self):
+        # `blocked` means another gate has not passed — a required check, a review.
+        # That is not this check's question, and answering it here would make two
+        # different failures indistinguishable on the pull request.
+        for api_state in ("blocked", "unstable", "behind", "has_hooks"):
+            with self.subTest(api_state=api_state):
+                state, _ = mergeability.classify(True, api_state)
+                self.assertEqual(state, "success")
+
+    def test_every_description_fits_the_api_limit(self):
+        for mergeable in (True, False, None):
+            with self.subTest(mergeable=mergeable):
+                _, description = mergeability.classify(mergeable, "some_longer_state")
+                self.assertLessEqual(len(description), mergeability.MAX_DESCRIPTION)
+
+
+class ResolveTests(unittest.TestCase):
+    def test_resolve_retries_while_the_answer_is_unknown(self):
+        answers = [("sha", None, "unknown"), ("sha", None, "unknown"), ("sha", True, "clean")]
+        calls = []
+
+        def fake_read(repo, number):
+            calls.append(number)
+            return answers[len(calls) - 1]
+
+        original = mergeability.read_pull
+        mergeability.read_pull = fake_read
+        try:
+            head, mergeable, state = mergeability.resolve("o/r", 7, attempts=5, delay=0)
+        finally:
+            mergeability.read_pull = original
+
+        self.assertEqual(len(calls), 3)
+        self.assertEqual((head, mergeable, state), ("sha", True, "clean"))
+
+    def test_resolve_gives_up_and_reports_unknown_rather_than_guessing(self):
+        def always_unknown(repo, number):
+            return ("sha", None, "unknown")
+
+        original = mergeability.read_pull
+        mergeability.read_pull = always_unknown
+        try:
+            _, mergeable, _ = mergeability.resolve("o/r", 7, attempts=3, delay=0)
+        finally:
+            mergeability.read_pull = original
+
+        self.assertIsNone(mergeable)
+        self.assertEqual(mergeability.classify(mergeable, "unknown")[0], "pending")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Pull request

## Outcome

A `mergeability` commit status is written onto every open pull request's head — both
when the pull request changes and, crucially, when `master` moves. The ACCEPTOR
runbook binds the role to it, and to one verdict per head revision.

Part of #89 (defects 1 and 3 of its Evidence section; the two share one cause).

## Scope

- `scripts/mergeability.py` — reads mergeability, writes one commit status.
- `scripts/tests/test_mergeability.py` — 7 negative controls.
- `.github/workflows/mergeability.yml` — new workflow, `statuses: write` only.
- `docs/zendev/ACCEPTOR_RUNBOOK.md` — §3 gains the status, §4 gains the one-verdict rule.

Policy paths only. No product code, no change to any existing workflow.

## The problem this solves

GitHub does not re-run a pull request's checks when its base advances, so a branch
that has just been made unmergeable still displays the green checks it earned an hour
earlier. On #84 the conflict was created the moment #79 merged and discovered half an
hour later by an ACCEPTOR run — which had already posted `ACCEPT` on the contents, and
posted `REQUEST_CHANGES` eighteen seconds later on the same head. Two contradictory
verdicts stand on that revision to this day, read by a role with no memory.

Both defects have one cause: the forge knew, and nothing asked it.

## The design decision worth reviewing

**Unknown is `pending`, never `success`.** GitHub computes mergeability lazily and
returns `null` while it works. The script retries a bounded number of times and, if
the answer is still unknown, writes `pending` — which blocks, and is re-evaluated on
the next push to either branch. Writing `success` there would convert an unmeasured
property into a green tick a reviewer is entitled to trust, which is exactly the
class of failure the check exists to remove. There is a negative control asserting
that the unknown case is not `success`.

**The check reports conflicts and nothing else.** `blocked`, `unstable`, `behind` and
`has_hooks` all classify as success, because they mean some *other* gate is unsatisfied.
Folding them in would make two different failures indistinguishable on the pull request.

**The run exits 0 even when a pull request conflicts.** The verdict is the status
written onto the pull request, not this run's own conclusion. A red run over a list of
pull requests would not say which one is broken, and a red run on `master` would
report the repository as unhealthy because one branch drifted.

## Verification

- [x] `python -m unittest discover -s scripts/tests -v` — 72 tests pass (65 on `master`)
- [x] `python scripts/policy_guard.py --base origin/master` — passed over 4 changed files
- [x] The workflow file parses as YAML
- [x] **Observed live on the pull request path.** This pull request's own checks now
      list `mergeability=SUCCESS` twice — once as the job, once as the commit status it
      wrote onto the head revision.
- [ ] **The `push: master` fan-out is still unobserved.** It cannot run until this is
      on `master`, so its first real execution is its first evidence. I will watch the
      first push after merge and report what the status actually said.

## Evidence and uncertainty

- **Established:** #84's timeline (conflict at #79's merge 05:42, ACCEPT 06:13:05,
  REQUEST_CHANGES 06:13:23); GitHub does not re-run pull request checks on a base push.
- **Reasoned:** that the `push: master` fan-out is the right trigger. It follows from
  when conflicts are created, and the retry loop is sized from GitHub computing
  mergeability in seconds — a guess bounded by the fact that the failure mode is
  `pending`, not a wrong answer.
- **Assumption:** `github.token` on a `push` event may write commit statuses on the
  same repository. Standard, but unproven here until the first run.
- **Not done:** this status is not yet *required* in branch protection. The runbook
  binds the ACCEPTOR to it, which is what the loop obeys; making it required is a
  repository setting and yours to make. I would wait until it has been seen working.

## Review focus

Whether `pending` on unknown is the right choice given that a stuck `pending` blocks
a merge. My argument is that blocking is the safe direction and self-healing, but it
is a trade and you may want a bounded escalation instead.

## Completion

- [x] Satisfies the two rows of #89 this addresses.
- [x] Documentation synchronized — the runbook states both new obligations.
- [x] No private data, credentials, or machine paths added.
- [x] Consequential decisions — no ADR; this adds a check, it changes no architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
