### PR TITLE
Compute the review target before starting the model

### DIFF
--- a/.github/workflows/zendev-acceptor.yml
+++ b/.github/workflows/zendev-acceptor.yml
@@ -37,8 +37,20 @@ jobs:
         with:
           python-version: '3.12'
 
+      # Section 1 of the runbook is a computation, and running it in the model cost
+      # two consecutive runs on one ineligible pull request while three others went
+      # unreviewed. It happens here instead, and when nothing is eligible the model
+      # is never started — the run ends having spent nothing, which is the correct
+      # outcome for a loop with no work.
+      - name: Choose the pull request to review
+        id: select
+        env:
+          GH_TOKEN: ${{ secrets.ZENDEV_PAT || github.token }}
+        run: python scripts/select_review_target.py --repo "${{ github.repository }}"
+
       - name: Review one pull request
         id: claude
+        if: steps.select.outputs.target != 'none'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -74,8 +86,17 @@ jobs:
             Read AGENTS.md and then docs/zendev/ACCEPTOR_RUNBOOK.md, and follow the
             runbook exactly, in order, from section 1 to the end.
 
+            Review pull request #${{ steps.select.outputs.target }}. Section 1 of the
+            runbook has already been evaluated mechanically and selected it, so do not
+            re-run selection and do not review any other pull request. Selection is
+            not acceptance: every refusal, verification and merge gate in the runbook
+            still applies to this one in full.
+
             Non-negotiable for this run:
             - Review exactly one pull request, reach one verdict, then stop.
+            - Post the verdict once, as the last thing you do, naming the head
+              revision it judges. If a later check changes your answer, the earlier
+              verdict is already standing and the AUTHOR will read both.
             - You never implement and never push commits to a pull request branch. If
               code must change, request changes and stop.
             - Merge only after you have observed every required check green at the
@@ -95,7 +116,7 @@ jobs:
         run: |
           python scripts/record_usage.py \
             --execution-file "${{ steps.claude.outputs.execution_file }}" \
-            --conclusion "${{ steps.claude.outputs.conclusion }}" \
+            --conclusion "${{ steps.select.outputs.target == 'none' && 'no_work' || steps.claude.outputs.conclusion }}" \
             --role acceptor \
             --ledger-repo drevendev/zen-telemetry \
             --run-id "${{ github.run_id }}" \

--- a/docs/zendev/ACCEPTOR_RUNBOOK.md
+++ b/docs/zendev/ACCEPTOR_RUNBOOK.md
@@ -9,11 +9,23 @@ that makes this review real.
 
 ## 1. Select
 
+**Your run already carries its target.** `scripts/select_review_target.py` evaluates
+this section before the model starts and names one pull request, or names none — in
+which case the run ends without starting the model at all. Review the pull request
+you were given and no other; do not re-derive the choice.
+
+The rest of this section is the specification that script implements. Read it to
+understand what eligibility means, and say so in a comment if the selection you were
+handed contradicts it — a selector that picks the wrong pull request is a defect in
+the control plane, and the run that notices is the only thing that can report it.
+
 ```sh
 gh pr list --state open --json number,title,headRefName,labels,statusCheckRollup,mergeable
 ```
 
 Take the oldest eligible open, non-draft pull request. One pull request per run.
+A pull request labelled `status:needs-decision` is never eligible: that label means
+the decision was handed to a person, and a review run cannot take it back.
 A head revision without a prior verdict is eligible as before. Inspect both formal
 reviews and verdict comments: a verdict posted as a comment because GitHub refuses
 a same-account review counts equally.

--- a/scripts/select_review_target.py
+++ b/scripts/select_review_target.py
@@ -1,0 +1,201 @@
+"""Choose the one pull request an ACCEPTOR run should review, or choose nothing.
+
+Section 1 of the ACCEPTOR runbook is a computation: take the oldest open, non-draft
+pull request whose current head has no verdict yet, with one narrow exception for a
+metadata correction on an unchanged head. Nothing in it requires reading a diff or
+weighing an argument.
+
+Leaving that computation to the model cost real runs. Two consecutive runs selected
+the same pull request, whose head had not moved and whose last verdict was a
+refusal, and re-posted the same refusal — which section 1 explicitly forbids
+("stop without re-reviewing an unchanged rejection"). Meanwhile three other pull
+requests were never reached, because the ineligible one was the oldest.
+
+So the selection happens here, before the model is started, and when nothing is
+eligible the model is not started at all.
+
+## What makes a pull request ineligible
+
+* it is a draft, or closed;
+* a human owns it — `status:needs-decision` means the decision was handed to a
+  person, and a review run cannot take it back;
+* its current head already carries a verdict, and no correction has been posted since.
+
+## How a verdict is tied to a head
+
+Two independent signals, either of which counts:
+
+* the verdict names the head revision (the runbook requires this);
+* the verdict was posted after the head commit was made.
+
+Either alone is enough. The effect is deliberately conservative: when in doubt this
+treats the head as already judged and moves on. A missed review costs one cycle of
+latency, while a repeated one costs a run *and* leaves contradictory comments on the
+pull request — the asymmetry says which way to lean.
+
+A verdict is not final if a correction followed it. A non-verdict comment newer than
+the newest verdict is read as the AUTHOR's correction handoff, which is what section
+1's same-head exception turns on.
+
+## What this does not do
+
+It does not decide anything about the change. Eligibility is not acceptance: every
+refusal, verification and merge gate in the runbook still applies afterwards, and
+the model is still the only thing that reaches a verdict.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+# A verdict announces itself, and the two shapes below are the two ways it does.
+#
+# Both anchor to the start of a line, so a sentence *about* a verdict stays prose —
+# "the previous REQUEST_CHANGES asked for a label fix" must remain a correction, or
+# the same-head exception could never fire and a corrected pull request would be
+# stuck forever.
+#
+# A heading or bold marker is matched case-insensitively, because a model writing
+# "## Accept" means the verdict and missing it would restart the re-review loop this
+# exists to stop. A bare word with no marker must be the shouted form the runbook
+# specifies; anything less would swallow ordinary sentences that open with "Accept".
+MARKED_VERDICT = re.compile(
+    r"^\s*(?:#{1,4}\s*|\*\*)\s*(?:VERDICT\s*[:\-—]\s*)?"
+    r"(?:ACCEPT|REQUEST_CHANGES)\b",
+    re.MULTILINE | re.IGNORECASE,
+)
+BARE_VERDICT = re.compile(r"^\s*(?:ACCEPT|REQUEST_CHANGES)\b", re.MULTILINE)
+
+HUMAN_OWNED_LABEL = "status:needs-decision"
+
+
+def is_verdict(body: str) -> bool:
+    body = body or ""
+    return bool(MARKED_VERDICT.search(body) or BARE_VERDICT.search(body))
+
+
+def judges_head(comment, head_sha: str, head_committed_at: str) -> bool:
+    """Whether this comment is a verdict on the current head revision."""
+    if not is_verdict(comment["body"]):
+        return False
+    if head_sha[:7] and head_sha[:7] in (comment["body"] or ""):
+        return True
+    return comment["createdAt"] >= head_committed_at
+
+
+def eligible(pull, head_committed_at: str, comments):
+    """Return (bool, reason). Pure: no network, no clock."""
+    if pull.get("isDraft"):
+        return False, "draft"
+    labels = {label["name"] for label in pull.get("labels", [])}
+    if HUMAN_OWNED_LABEL in labels:
+        return False, f"{HUMAN_OWNED_LABEL}: a person owns this decision"
+
+    head_sha = pull["headRefOid"]
+    verdicts = [c for c in comments if judges_head(c, head_sha, head_committed_at)]
+    if not verdicts:
+        return True, "no verdict on the current head"
+
+    newest_verdict = max(c["createdAt"] for c in verdicts)
+    corrections = [
+        c
+        for c in comments
+        if not is_verdict(c["body"]) and c["createdAt"] > newest_verdict
+    ]
+    if corrections:
+        return True, "a correction was posted after the last verdict on this head"
+    return False, f"already judged at {head_sha[:8]}; no correction since"
+
+
+def choose(candidates):
+    """candidates: [(number, created_at, is_eligible, reason)] -> number or None."""
+    for number, _, ok, _ in sorted(candidates, key=lambda c: (c[1], c[0])):
+        if ok:
+            return number
+    return None
+
+
+def _gh(args):
+    return subprocess.run(
+        ["gh", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def load_pulls(repo: str):
+    raw = _gh(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            "100",
+            "--json",
+            "number,createdAt,isDraft,labels,headRefOid",
+        ]
+    )
+    return json.loads(raw)
+
+
+def load_comments(repo: str, number: int):
+    raw = _gh(
+        ["pr", "view", str(number), "--repo", repo, "--json", "comments,reviews"]
+    )
+    data = json.loads(raw)
+    comments = [
+        {"body": c.get("body", ""), "createdAt": c.get("createdAt", "")}
+        for c in data.get("comments", [])
+    ]
+    # A formal review counts equally; the role posts comments only because GitHub
+    # refuses a same-account review, which is an accident of identity, not of meaning.
+    comments += [
+        {"body": r.get("body", ""), "createdAt": r.get("submittedAt", "")}
+        for r in data.get("reviews", [])
+        if r.get("submittedAt")
+    ]
+    return comments
+
+
+def head_commit_date(repo: str, sha: str) -> str:
+    raw = _gh(["api", f"repos/{repo}/commits/{sha}"])
+    return json.loads(raw)["commit"]["committer"]["date"]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="owner/name")
+    args = parser.parse_args()
+
+    candidates = []
+    for pull in load_pulls(args.repo):
+        number = pull["number"]
+        committed_at = head_commit_date(args.repo, pull["headRefOid"])
+        ok, reason = eligible(pull, committed_at, load_comments(args.repo, number))
+        candidates.append((number, pull["createdAt"], ok, reason))
+
+    # Every pull request and why, always. When this picks nothing, the reason it
+    # picked nothing is the only evidence that the loop is idle by decision rather
+    # than broken — and a silent selector is indistinguishable from a stalled one.
+    for number, created_at, ok, reason in sorted(candidates, key=lambda c: c[1]):
+        print(f"  #{number} ({created_at}) {'eligible' if ok else 'skipped'}: {reason}")
+
+    target = choose(candidates)
+    value = str(target) if target else "none"
+    print(f"target={value}")
+
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        with open(output, "a", encoding="utf-8") as handle:
+            handle.write(f"target={value}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_select_review_target.py
+++ b/scripts/tests/test_select_review_target.py
@@ -1,0 +1,136 @@
+"""Negative controls for review selection.
+
+The first test is the one that matters: it is the exact situation that burned two
+consecutive ACCEPTOR runs on #84 and starved three other pull requests of review.
+"""
+
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import select_review_target as select  # noqa: E402
+
+HEAD = "d8e28d3e2df15c93c1df3e41eceb640996024907"
+COMMITTED = "2026-09-05T05:35:00Z"
+
+
+def pull(number=84, created="2026-09-05T05:35:16Z", draft=False, labels=()):
+    return {
+        "number": number,
+        "createdAt": created,
+        "isDraft": draft,
+        "labels": [{"name": name} for name in labels],
+        "headRefOid": HEAD,
+    }
+
+
+def comment(body, created):
+    return {"body": body, "createdAt": created}
+
+
+class EligibilityTests(unittest.TestCase):
+    def test_an_unchanged_rejection_is_not_reviewed_again(self):
+        # #84, exactly: refused at 06:13, nothing pushed, nothing corrected. The
+        # 06:40 run reviewed it again and re-posted the same refusal.
+        comments = [
+            comment("## ACCEPT\n\nAll conditions hold.", "2026-09-05T06:13:05Z"),
+            comment("## REQUEST_CHANGES\n\nMerge conflicts.", "2026-09-05T06:13:23Z"),
+        ]
+        ok, reason = select.eligible(pull(), COMMITTED, comments)
+        self.assertFalse(ok)
+        self.assertIn("no correction since", reason)
+
+    def test_a_fresh_head_is_eligible(self):
+        ok, reason = select.eligible(pull(), COMMITTED, [])
+        self.assertTrue(ok)
+        self.assertIn("no verdict", reason)
+
+    def test_a_verdict_older_than_the_head_does_not_count(self):
+        # The author pushed a fix after the refusal, so the head moved and the old
+        # verdict judged a revision that no longer exists.
+        stale = [comment("## REQUEST_CHANGES\n\nfix it", "2026-09-05T05:00:00Z")]
+        ok, _ = select.eligible(pull(), COMMITTED, stale)
+        self.assertTrue(ok)
+
+    def test_a_correction_after_the_verdict_reopens_the_same_head(self):
+        comments = [
+            comment("## REQUEST_CHANGES\n\nmetadata", "2026-09-05T06:13:23Z"),
+            comment("## AUTHOR handoff\n\nCorrected the labels.", "2026-09-05T06:20:00Z"),
+        ]
+        ok, reason = select.eligible(pull(), COMMITTED, comments)
+        self.assertTrue(ok)
+        self.assertIn("correction", reason)
+
+    def test_a_second_verdict_after_a_correction_closes_it_again(self):
+        comments = [
+            comment("## REQUEST_CHANGES\n\nmetadata", "2026-09-05T06:13:23Z"),
+            comment("## AUTHOR handoff\n\nCorrected.", "2026-09-05T06:20:00Z"),
+            comment("## REQUEST_CHANGES\n\nstill wrong", "2026-09-05T06:40:00Z"),
+        ]
+        ok, _ = select.eligible(pull(), COMMITTED, comments)
+        self.assertFalse(ok)
+
+    def test_a_verdict_naming_the_head_counts_even_if_posted_earlier(self):
+        # Clock skew between the commit date and the comment date must not reopen a
+        # head that a verdict explicitly named.
+        comments = [
+            comment(f"**ACCEPT** at revision {HEAD}", "2026-09-05T05:34:00Z"),
+        ]
+        ok, _ = select.eligible(pull(), COMMITTED, comments)
+        self.assertFalse(ok)
+
+    def test_a_human_owned_pull_request_is_left_alone(self):
+        ok, reason = select.eligible(
+            pull(labels=["status:needs-decision"]), COMMITTED, []
+        )
+        self.assertFalse(ok)
+        self.assertIn("person owns", reason)
+
+    def test_a_draft_is_skipped(self):
+        ok, reason = select.eligible(pull(draft=True), COMMITTED, [])
+        self.assertFalse(ok)
+        self.assertEqual(reason, "draft")
+
+
+class VerdictDetectionTests(unittest.TestCase):
+    def test_the_shapes_the_role_actually_posts_are_recognised(self):
+        for body in (
+            "## ACCEPT",
+            "**ACCEPT** at revision abc1234",
+            "## VERDICT: REQUEST_CHANGES",
+            "REQUEST_CHANGES\n\nreasons follow",
+            "#### Accept",
+        ):
+            with self.subTest(body=body):
+                self.assertTrue(select.is_verdict(body))
+
+    def test_prose_about_a_verdict_is_not_a_verdict(self):
+        # A handoff that mentions the refusal it is answering must stay a correction,
+        # or the same-head exception can never fire.
+        for body in (
+            "The previous REQUEST_CHANGES asked for a label fix; done.",
+            "I would ACCEPT this once the conflict is resolved.",
+            "## AUTHOR handoff\n\nRebased onto master.",
+        ):
+            with self.subTest(body=body):
+                self.assertFalse(select.is_verdict(body))
+
+
+class ChoiceTests(unittest.TestCase):
+    def test_the_oldest_eligible_wins_not_the_oldest(self):
+        candidates = [
+            (84, "2026-09-05T05:35:16Z", False, "already judged"),
+            (85, "2026-09-05T06:00:53Z", True, "no verdict"),
+            (88, "2026-09-05T06:37:46Z", True, "no verdict"),
+        ]
+        self.assertEqual(select.choose(candidates), 85)
+
+    def test_nothing_eligible_selects_nothing_rather_than_the_least_bad(self):
+        candidates = [(84, "2026-09-05T05:35:16Z", False, "already judged")]
+        self.assertIsNone(select.choose(candidates))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Pull request

## Outcome

`scripts/select_review_target.py` evaluates section 1 of the ACCEPTOR runbook before
the model starts and hands the run one pull request number, or none — in which case
the model is never started and the run is recorded as `no_work`.

Part of #89 (defect 2 of its Evidence section, and the §1 row of its second table).

## Scope

- `scripts/select_review_target.py` — the selector.
- `scripts/tests/test_select_review_target.py` — 12 negative controls, the first of
  which is the #84 situation exactly.
- `.github/workflows/zendev-acceptor.yml` — a step before the model, a condition on
  the model step, the target in the prompt, `no_work` in the telemetry conclusion.
- `docs/zendev/ACCEPTOR_RUNBOOK.md` — §1 says the target arrives with the run, and
  states the `status:needs-decision` exclusion.

Policy paths only.

## Live evidence

Run against the repository as it stands:

```
  #88 (06:37:46Z) eligible: no verdict on the current head
  #91 (07:06:02Z) eligible: no verdict on the current head
  #92 (07:06:09Z) skipped: status:needs-decision: a person owns this decision
  #93 (07:10:09Z) skipped: status:needs-decision: a person owns this decision
  #94 (07:11:45Z) eligible: no verdict on the current head
target=88
```

## Two additions beyond a literal transcription

**`status:needs-decision` is never eligible.** The label means a person owns the
decision, and a review run cannot take it back. Without this, the four policy pull
requests in this series would each consume a review run to conclude they must not be
reviewed.

**Verdict detection leans one way on purpose.** A heading or bold marker matches
case-insensitively (`## Accept` means the verdict); a bare word matches only in the
shouted form the runbook specifies. That asymmetry protects the same-head exception:
prose about a verdict — "the previous REQUEST_CHANGES asked for a label fix" — must
stay a correction, or a corrected pull request could never be re-reviewed.

More generally the selector is conservative: where the evidence is ambiguous it
treats a head as already judged. A missed review costs one cycle of latency; a
repeated one costs a run *and* leaves contradictory comments behind.

## Verification

- [x] `python -m unittest discover -s scripts/tests -v` — 77 tests pass (65 on `master`)
- [x] `python scripts/policy_guard.py --base origin/master` — passed over 4 files
- [x] `zendev-acceptor.yml` parses as YAML
- [x] Executed against the live repository, output above
- [ ] **The `no_work` path has not run live.** It needs a moment when nothing is
      eligible, which has not happened since the change was written.

## Evidence and uncertainty

- **Established:** the #84 double selection, from the two run IDs and comment
  timestamps; the live selector output above.
- **Reasoned:** that "a non-verdict comment newer than the newest verdict" is a
  faithful mechanical reading of the runbook's correction-handoff clause. It is a
  reading, not a proof — the runbook's clause also asks that the handoff *name* the
  unchanged head and link the rejection, which this does not check. The looser test
  errs toward re-reviewing a corrected pull request, which is the recoverable
  direction.
- **Assumption:** `gh` is on the runner and `ZENDEV_PAT` can read pull requests. Both
  already hold for the steps around it.
- **Not done:** the selector does not check `mergeability` (that is #93's status) and
  does not look at required checks. Eligibility is about whether a review is owed,
  not whether it will succeed.

## The risk to weigh

This moves the decision of *what gets reviewed* out of the model. A bug here stalls
the loop silently rather than loudly — the failure mode is "nothing was ever
selected", which looks exactly like "there was nothing to do".

Two things blunt it: the selector prints every pull request and the reason it was
skipped on every run, so the log always distinguishes idle from broken; and the
runbook now tells the reviewing run to report a selection that contradicts section 1
rather than silently accepting it. Neither eliminates the risk. If you would rather
keep selection in the model and enforce it another way, this is the pull request to
say so on.

## Completion

- [x] Satisfies the rows of #89 it addresses.
- [x] Documentation synchronized — §1 states the new arrangement and the exclusion.
- [x] No private data, credentials, or machine paths added.
- [x] No ADR — this implements an existing written rule rather than changing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
