### PR TITLE
Do not hand the reviewer work whose outcome a check already settled

### DIFF
--- a/scripts/select_review_target.py
+++ b/scripts/select_review_target.py
@@ -19,7 +19,13 @@ eligible the model is not started at all.
 * it is a draft, or closed;
 * a human owns it — `status:needs-decision` means the decision was handed to a
   person, and a review run cannot take it back;
+* the `mergeability` check is failing, so a control has already established that the
+  branch cannot be accepted whatever its contents; the next move belongs to the
+  author, and the failing check is already on the author's own ladder;
 * its current head already carries a verdict, and no correction has been posted since.
+
+Eligibility means a review is *owed and possible*, not merely owed. Handing the role
+work whose outcome is already determined spends a run to restate a check.
 
 ## How a verdict is tied to a head
 
@@ -72,6 +78,7 @@ MARKED_VERDICT = re.compile(
 BARE_VERDICT = re.compile(r"^\s*(?:ACCEPT|REQUEST_CHANGES)\b", re.MULTILINE)
 
 HUMAN_OWNED_LABEL = "status:needs-decision"
+MERGEABILITY_CHECK = "mergeability"
 
 
 def is_verdict(body: str) -> bool:
@@ -88,6 +95,24 @@ def judges_head(comment, head_sha: str, head_committed_at: str) -> bool:
     return comment["createdAt"] >= head_committed_at
 
 
+def conflicts_with_base(pull) -> bool:
+    """Whether the mergeability check has already ruled this branch out.
+
+    Only an explicit failure counts. A missing check is not a failure — a pull request
+    opened before the check existed must stay reviewable — and `pending` is not one
+    either: it means GitHub has not answered yet, it clears within a minute, and
+    treating it as a refusal would let a transient unknown stall the queue.
+    """
+    for check in pull.get("statusCheckRollup") or []:
+        name = check.get("name") or check.get("context")
+        if name != MERGEABILITY_CHECK:
+            continue
+        outcome = (check.get("conclusion") or check.get("state") or "").upper()
+        if outcome == "FAILURE":
+            return True
+    return False
+
+
 def eligible(pull, head_committed_at: str, comments):
     """Return (bool, reason). Pure: no network, no clock."""
     if pull.get("isDraft"):
@@ -95,6 +120,9 @@ def eligible(pull, head_committed_at: str, comments):
     labels = {label["name"] for label in pull.get("labels", [])}
     if HUMAN_OWNED_LABEL in labels:
         return False, f"{HUMAN_OWNED_LABEL}: a person owns this decision"
+
+    if conflicts_with_base(pull):
+        return False, f"{MERGEABILITY_CHECK} is failing: the author must rebase first"
 
     head_sha = pull["headRefOid"]
     verdicts = [c for c in comments if judges_head(c, head_sha, head_committed_at)]
@@ -138,7 +166,7 @@ def load_pulls(repo: str):
             "--limit",
             "100",
             "--json",
-            "number,createdAt,isDraft,labels,headRefOid",
+            "number,createdAt,isDraft,labels,headRefOid,statusCheckRollup",
         ]
     )
     return json.loads(raw)

--- a/scripts/status_lint.py
+++ b/scripts/status_lint.py
@@ -107,7 +107,10 @@ def lint(rows, summary, merged_pull_numbers, requirements_claimed_by_merged):
         for number in unmerged:
             violations.append(
                 f"{row['req']}: the Merged in column cites #{number}, which has not "
-                "merged; this document may not assert the outcome of an open change"
+                "merged; write (open) instead and let a later reconciliation record "
+                "the pull request and its squash commit once it lands. A pull request "
+                "may not cite itself here either: it is not true when this check runs, "
+                "and a pull request closed without merging would leave it false forever"
             )
         if row["status"] == IMPLEMENTED and not cited:
             violations.append(

--- a/scripts/tests/test_select_review_target.py
+++ b/scripts/tests/test_select_review_target.py
@@ -16,14 +16,19 @@ HEAD = "d8e28d3e2df15c93c1df3e41eceb640996024907"
 COMMITTED = "2026-09-05T05:35:00Z"
 
 
-def pull(number=84, created="2026-09-05T05:35:16Z", draft=False, labels=()):
+def pull(number=84, created="2026-09-05T05:35:16Z", draft=False, labels=(), checks=()):
     return {
         "number": number,
         "createdAt": created,
         "isDraft": draft,
         "labels": [{"name": name} for name in labels],
         "headRefOid": HEAD,
+        "statusCheckRollup": list(checks),
     }
+
+
+def check(name, conclusion):
+    return {"name": name, "conclusion": conclusion}
 
 
 def comment(body, created):
@@ -87,6 +92,35 @@ class EligibilityTests(unittest.TestCase):
         )
         self.assertFalse(ok)
         self.assertIn("person owns", reason)
+
+    def test_a_conflicting_branch_is_not_handed_to_the_reviewer(self):
+        # A control has already established that this cannot be accepted whatever it
+        # contains. Selecting it spends a run to restate a check, and the failing
+        # check is already item 2 on the AUTHOR's own ladder.
+        conflicting = pull(checks=[check("mergeability", "FAILURE")])
+        ok, reason = select.eligible(conflicting, COMMITTED, [])
+        self.assertFalse(ok)
+        self.assertIn("rebase", reason)
+
+    def test_a_pending_mergeability_does_not_block_selection(self):
+        # Pending means GitHub has not answered yet and clears within a minute.
+        # Refusing on it would let a transient unknown stall the queue.
+        waiting = pull(checks=[check("mergeability", None)])
+        waiting["statusCheckRollup"][0]["state"] = "PENDING"
+        ok, _ = select.eligible(waiting, COMMITTED, [])
+        self.assertTrue(ok)
+
+    def test_a_missing_mergeability_check_is_not_a_failure(self):
+        # A pull request opened before the check existed must stay reviewable.
+        ok, _ = select.eligible(pull(checks=[check("typescript", "SUCCESS")]), COMMITTED, [])
+        self.assertTrue(ok)
+
+    def test_other_failing_checks_do_not_block_selection(self):
+        # A red test suite is a defect for the reviewer to name, not a reason to
+        # withhold the review. Only an unmergeable branch has a predetermined outcome.
+        red = pull(checks=[check("typescript", "FAILURE")])
+        ok, _ = select.eligible(red, COMMITTED, [])
+        self.assertTrue(ok)
 
     def test_a_draft_is_skipped(self):
         ok, reason = select.eligible(pull(draft=True), COMMITTED, [])

--- a/scripts/tests/test_status_lint.py
+++ b/scripts/tests/test_status_lint.py
@@ -73,6 +73,21 @@ class UnmergedCitationTests(unittest.TestCase):
         self.assertIn("#84", violations[0])
         self.assertIn("has not merged", violations[0])
 
+    def test_a_row_may_not_cite_the_pull_request_that_writes_it(self):
+        # Observed on #91 within the hour: the author recorded its own open number as
+        # the merge. It is false when the check runs, and a pull request closed
+        # without merging — as #84 was — would leave it false forever.
+        row = "| REQ-CONFIG-003 | `IN_PROGRESS` | #83 | #91 | slice two |\n"
+        text = document([row], implemented=0, in_progress=1)
+        violations = status_lint.lint(
+            status_lint.parse_rows(text),
+            status_lint.parse_summary(text),
+            merged_pull_numbers={79},
+            requirements_claimed_by_merged={},
+        )
+        self.assertEqual(len(violations), 1)
+        self.assertIn("write (open) instead", violations[0])
+
     def test_the_issue_column_may_cite_an_open_issue(self):
         # Issues are cited while open by design; only the Merged in column is checked.
         text = document([ROW_OPEN], implemented=0, in_progress=1)


### PR DESCRIPTION
# Pull request

## Outcome

Two corrections found in the first hour of running the gates merged this morning.

1. Selection skips a pull request whose `mergeability` check is failing.
2. `status-lint`'s refusal now says what to write instead, and refuses self-citation
   explicitly.

Part of #89. Control plane only; no product code.

## 1. A conflicting branch is not the reviewer's work

A branch that does not merge cannot be accepted whatever it contains, so handing it to
the reviewer spends a run to restate a check. The failing check is already item 2 on
the AUTHOR's ladder — *an open pull request of yours with a failing required check —
fix it* — so the next move belongs to the author either way.

The principle behind it: **eligibility means a review is owed *and possible*, not
merely owed.**

The boundaries are deliberate, and each has a negative control:

| Signal | Selects? | Why |
| --- | --- | --- |
| `mergeability` = failure | no | outcome already determined |
| `mergeability` = pending | **yes** | clears within a minute; a transient unknown must not stall the queue |
| `mergeability` absent | **yes** | a pull request older than the check must stay reviewable — absence is not failure |
| `typescript` = failure | **yes** | a defect for the reviewer to name, not a predetermined outcome |

The last row is the one that keeps this narrow. If any red check withheld a review,
the reviewer would stop being the thing that tells an author what is wrong.

## 2. status-lint now teaches rather than only refuses

It fired on #91 within the hour of merging:

```
::error::status-lint: REQ-CONFIG-003: the Merged in column cites #91, which has not
merged; this document may not assert the outcome of an open change
```

Correct refusal, unhelpful message: the author had written that pull request's *own*
number, which is a natural thing to do and which the message did not address. The
convention the document already follows is `(open)` while open, with a later
reconciliation recording the pull request and its squash commit — visible in every
`IMPLEMENTED` row, each of which cites a squash commit that did not exist while its
branch was open.

Self-citation is refused for the same reason as any other open citation: it is false
when the check runs, and a pull request closed without merging — as #84 was — would
leave it false forever.

## Verification

- [x] `python -m unittest discover -s scripts/tests -v` — 103 tests pass (93 before)
- [x] `python scripts/policy_guard.py --base origin/master` — passed over 4 files
- [x] Selector run live: skips #94 (`mergeability is failing: the author must rebase
      first`), selects #88

## Evidence and uncertainty

- **Established:** the fan-out marked #91 and #94 red within a minute of the merges;
  #91's head then changed and its `mergeability` went green without anyone asking, so
  the AUTHOR ladder picked up the rebase on its own; status-lint's refusal on #91.
- **Reasoned:** that `pending` should still select. It rests on mergeability clearing
  in seconds, which held in the one fan-out observed. If it turns out to linger, this
  becomes a slow leak of runs onto pull requests that are about to be found
  unmergeable — cheap to change, but worth watching rather than assuming.
- **Assumption:** the reconciliation convention (`(open)` now, merge recorded later)
  is the one to keep. #98 proposes generating the coverage table instead, which would
  make this moot; nothing here blocks that.
- **Not done:** the selector still does not know about a red `policy-guard`. That is a
  genuine defect for the reviewer to name, so it selects — but if it turns out that
  every such review just restates the check, the same argument would apply.

## Review focus

Whether "eligibility means owed *and possible*" is drawn tightly enough. It is one
step from "do not review anything that will fail", which would hollow out the role —
the table above is the line I drew, and only a determined outcome, not a bad one,
withholds the review.

## Completion

- [x] Both corrections trace to observations from this morning's merges.
- [x] Documentation synchronized — the selector's module contract lists the new
      exclusion and states the eligibility principle.
- [x] No private data, credentials, or machine paths added.
- [x] No ADR — refinements to two existing checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
