### PR TITLE
Correct why a conflicting branch is skipped

### DIFF
--- a/scripts/select_review_target.py
+++ b/scripts/select_review_target.py
@@ -24,8 +24,16 @@ eligible the model is not started at all.
   author, and the failing check is already on the author's own ladder;
 * its current head already carries a verdict, and no correction has been posted since.
 
-Eligibility means a review is *owed and possible*, not merely owed. Handing the role
-work whose outcome is already determined spends a run to restate a check.
+Eligibility means a review is *owed and possible*, not merely owed. Withhold one only
+when it could add nothing the checks have not already said. An unmergeable branch is
+that case: it cannot be accepted whatever it contains, and the diff on offer is not
+the diff that would land, so the reviewer would be judging a text that no longer
+applies.
+
+Not "skip whatever will fail". Every failing required check determines the outcome,
+since none of them may be red at acceptance — so that reading would withhold most of
+the reviews worth having. A red test suite still selects, because the reviewer can
+judge the criteria too and return one complete list instead of two partial ones.
 
 ## How a verdict is tied to a head
 

--- a/scripts/tests/test_select_review_target.py
+++ b/scripts/tests/test_select_review_target.py
@@ -117,7 +117,9 @@ class EligibilityTests(unittest.TestCase):
 
     def test_other_failing_checks_do_not_block_selection(self):
         # A red test suite is a defect for the reviewer to name, not a reason to
-        # withhold the review. Only an unmergeable branch has a predetermined outcome.
+        # withhold the review: the reviewer can judge the criteria as well and return
+        # one complete list. Certainty is not the test — every red required check makes
+        # the refusal certain — what the review can add is.
         red = pull(checks=[check("typescript", "FAILURE")])
         ok, _ = select.eligible(red, COMMITTED, [])
         self.assertTrue(ok)


### PR DESCRIPTION
# Pull request

## Outcome

Corrects the rationale for why the selector skips a conflicting branch. Wording only —
no behaviour changes, and the 103 tests pass unchanged.

Part of #89.

## The error I shipped in #102

The docstring said the selector withholds work *"whose outcome is already determined"*.
That is wrong. Every failing required check determines the outcome, because none of
them may be red at acceptance — so read literally, the rule withholds most of the
reviews worth having. It also contradicted the test sitting a few lines below it, which
asserts that a red `typescript` check still selects.

Wrong in the direction that quietly deletes reviews, which is the direction this whole
line of work has to be watched in.

## The correction

Withhold a review only when it could add nothing the checks have not already said.

An unmergeable branch is that case, for a stronger reason than certainty: the diff on
offer is not the diff that would land, so the reviewer would be judging a text that no
longer applies. A red test suite is not that case — the reviewer can judge the criteria
as well and hand back one complete list instead of two partial ones.

## Why a wording-only change is worth a pull request

A rationale that contradicts the code it explains is what a later change follows
instead of the code. This one sits in the module contract of the file that decides what
gets reviewed at all.

## Verification

- [x] `python -m unittest discover -s scripts/tests -v` — 103 tests, unchanged
- [x] `python scripts/policy_guard.py --base origin/master` — passed over 2 files
- [x] No executable line touched; the diff is a docstring and a comment

## Evidence and uncertainty

- **Established:** the docstring and the test contradicted each other; the acceptance
  contract requires every required check green, which makes any red check
  outcome-determining.
- **Reasoned:** that "what the review can add" is the right criterion. It explains both
  cases without a special case, but it is a criterion needing judgement, not a
  predicate, and it will be argued over at the margin.
- **Open, and not settled here:** whether reviews of red-but-mergeable pull requests
  actually add anything in practice. #91 is a live instance — its only defect is a
  one-cell table edit that `status-lint` already names, and the AUTHOR's own ladder
  already routes it. If such reviews turn out to only restate the check, the criterion
  stays and its answer changes. That is measurable by reading the next few; I would
  rather decide it from those than from this argument.

## Review focus

Whether the corrected criterion is one a reviewing run can actually apply, or whether
it needs to become a list of specific checks. I prefer the criterion, but a rule that
requires judgement to apply is a rule that will be applied differently on different
runs — the very thing this series exists to reduce.

## Completion

- [x] Corrects merged text; no new Issue, as #89's criteria are unchanged.
- [x] Documentation synchronized — the correction *is* the documentation.
- [x] No private data, credentials, or machine paths added.
- [x] No ADR — no decision changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
