### PR TITLE
Run the bookkeeper from outside the tree the model left behind

### DIFF
--- a/.github/workflows/zendev-acceptor.yml
+++ b/.github/workflows/zendev-acceptor.yml
@@ -37,6 +37,19 @@ jobs:
         with:
           python-version: '3.12'
 
+      # Stage the bookkeeper before the model runs, and run the staged copy
+      # afterwards. The model checks out other revisions during a run — the ACCEPTOR
+      # runbook tells it to, so it can verify a pull request independently — and every
+      # step after it would otherwise execute whatever `scripts/` the working tree was
+      # left holding. That is how one ledger record came back with no model field: the
+      # reviewed branch predated the field, so its copy of this script ran.
+      #
+      # The token in the recording step makes this more than a bookkeeping bug. A pull
+      # request that edited that script would have had its version executed by the
+      # reviewing workflow, with the ledger credential in the environment.
+      - name: Stage the usage recorder outside the working tree
+        run: cp scripts/record_usage.py "${RUNNER_TEMP}/record_usage.py"
+
       # Section 1 of the runbook is a computation, and running it in the model cost
       # two consecutive runs on one ineligible pull request while three others went
       # unreviewed. It happens here instead, and when nothing is eligible the model
@@ -114,7 +127,7 @@ jobs:
         env:
           TELEMETRY_TOKEN: ${{ secrets.TELEMETRY_PAT }}
         run: |
-          python scripts/record_usage.py \
+          python "${RUNNER_TEMP}/record_usage.py" \
             --execution-file "${{ steps.claude.outputs.execution_file }}" \
             --conclusion "${{ steps.select.outputs.target == 'none' && 'no_work' || steps.claude.outputs.conclusion }}" \
             --role acceptor \

--- a/.github/workflows/zendev-author.yml
+++ b/.github/workflows/zendev-author.yml
@@ -37,6 +37,19 @@ jobs:
         with:
           python-version: '3.12'
 
+      # Stage the bookkeeper before the model runs, and run the staged copy
+      # afterwards. The model checks out other revisions during a run — the ACCEPTOR
+      # runbook tells it to, so it can verify a pull request independently — and every
+      # step after it would otherwise execute whatever `scripts/` the working tree was
+      # left holding. That is how one ledger record came back with no model field: the
+      # reviewed branch predated the field, so its copy of this script ran.
+      #
+      # The token in the recording step makes this more than a bookkeeping bug. A pull
+      # request that edited that script would have had its version executed by the
+      # reviewing workflow, with the ledger credential in the environment.
+      - name: Stage the usage recorder outside the working tree
+        run: cp scripts/record_usage.py "${RUNNER_TEMP}/record_usage.py"
+
       - name: Run one AUTHOR unit of work
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -98,7 +111,7 @@ jobs:
         env:
           TELEMETRY_TOKEN: ${{ secrets.TELEMETRY_PAT }}
         run: |
-          python scripts/record_usage.py \
+          python "${RUNNER_TEMP}/record_usage.py" \
             --execution-file "${{ steps.claude.outputs.execution_file }}" \
             --conclusion "${{ steps.claude.outputs.conclusion }}" \
             --role author \

--- a/scripts/tests/test_workflow_bookkeeping.py
+++ b/scripts/tests/test_workflow_bookkeeping.py
@@ -1,0 +1,80 @@
+"""The bookkeeper must not be executed from the working tree the model left behind.
+
+A run's later steps execute whatever `scripts/` the working directory holds when they
+start, and the model changes that directory during the run — the ACCEPTOR runbook
+tells it to check out a pull request's head so it can verify independently. One ledger
+record came back missing its `model` field for exactly this reason: the reviewed
+branch predated the field, and its copy of the recorder ran.
+
+The recording step carries the ledger credential, so this is also the shape of a
+credential-handling defect: a pull request that edited the recorder would have had its
+version executed by the reviewing workflow with that token in the environment.
+
+These are text assertions rather than a YAML parse, deliberately — the check must run
+in the policy-guard job with nothing installed but the standard library.
+"""
+
+import pathlib
+import unittest
+
+WORKFLOWS = pathlib.Path(__file__).resolve().parents[2] / ".github" / "workflows"
+MODEL_RUNNERS = ("zendev-author.yml", "zendev-acceptor.yml")
+
+STAGE_LINE = 'cp scripts/record_usage.py "${RUNNER_TEMP}/record_usage.py"'
+STAGED_CALL = 'python "${RUNNER_TEMP}/record_usage.py"'
+WORKING_TREE_CALL = "python scripts/record_usage.py"
+MODEL_STEP = "uses: anthropics/claude-code-action"
+
+
+def lines(name):
+    return (WORKFLOWS / name).read_text(encoding="utf-8").splitlines()
+
+
+def index_of(rows, needle, name):
+    for i, row in enumerate(rows):
+        if needle in row:
+            return i
+    raise AssertionError(f"{name}: {needle!r} not found")
+
+
+class BookkeeperIsolationTests(unittest.TestCase):
+    def test_the_recorder_is_staged_before_the_model_runs(self):
+        for name in MODEL_RUNNERS:
+            with self.subTest(workflow=name):
+                rows = lines(name)
+                staged = index_of(rows, STAGE_LINE, name)
+                model = index_of(rows, MODEL_STEP, name)
+                self.assertLess(
+                    staged,
+                    model,
+                    f"{name}: staging after the model copies the tree the model left",
+                )
+
+    def test_the_recording_step_runs_the_staged_copy(self):
+        for name in MODEL_RUNNERS:
+            with self.subTest(workflow=name):
+                rows = lines(name)
+                index_of(rows, STAGED_CALL, name)
+
+    def test_no_workflow_runs_the_recorder_from_the_working_tree(self):
+        for name in MODEL_RUNNERS:
+            with self.subTest(workflow=name):
+                offenders = [r for r in lines(name) if WORKING_TREE_CALL in r]
+                self.assertEqual(
+                    offenders,
+                    [],
+                    f"{name}: recorder invoked from the working tree: {offenders}",
+                )
+
+    def test_the_fixtures_still_match_the_files(self):
+        # Guards the test itself: if a workflow is renamed or the recorder invocation
+        # is rewritten, these assertions must fail loudly rather than pass vacuously
+        # by finding nothing to check.
+        for name in MODEL_RUNNERS:
+            with self.subTest(workflow=name):
+                self.assertTrue((WORKFLOWS / name).is_file(), f"{name} is missing")
+                self.assertIn(MODEL_STEP, "\n".join(lines(name)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Pull request

## Outcome

Both model-running workflows stage `scripts/record_usage.py` to the runner's temp
directory **before** the model starts, and run the staged copy afterwards. Four
negative controls hold the arrangement in place.

Part of #89.

## How this was found

Validating the ledger after the model pin. Twelve records, eleven naming the model,
one — `20260905T054248Z-acceptor` — with no `model` key at all, sitting between two
records that have it:

```
05:35 author   claude-haiku-4-5-20251001   $0.589
05:42 acceptor <no model key>              $0.173
06:05 author   claude-haiku-4-5-20251001   $0.337
```

The pin had merged at 05:07, and the run's own revision (`36d58fb`) contains
`extract_model`. So the script that ran was not the script the run checked out.

It was the reviewed branch's. That run was reviewing #79, whose head `086bd38` was cut
before the pin and contains no `extract_model` — and §3 of the ACCEPTOR runbook
instructs the role to check out a pull request's head and run the verification
commands itself. Every step after the model therefore executes whatever `scripts/` the
working tree was left holding.

## Why this is not only a bookkeeping bug

The recording step has `TELEMETRY_PAT` in its environment. A pull request that edited
`scripts/record_usage.py` would have had **its** version executed by the reviewing
workflow, with the ledger credential available to it.

Self-authored code today. But the structural controls in this repository exist
precisely so that "the author is trustworthy" is not what stands between a change and
a credential — the same reasoning that put `scripts/` under `POLICY_PREFIXES` in the
first place.

## The fix, and why it is this one

`cp scripts/record_usage.py "${RUNNER_TEMP}/record_usage.py"` before the model; run the
copy after. `record_usage.py` imports only the standard library, so a detached copy
behaves identically.

Considered and rejected: restoring the working tree before the recording step. It is
heavier, it would fight the model's own checkout for no benefit, and it would leave the
same hole open for any future post-model step. Staging what a step needs is the narrow
answer to "a step must not execute code the run did not choose".

## Verification

- [x] `python -m unittest discover -s scripts/tests -v` — 107 tests pass (103 before)
- [x] `python scripts/policy_guard.py --base origin/master` — passed over 3 files
- [x] Both workflows parse, and the step order is `checkout → setup → stage → model →
      record` in each
- [x] **Negative control observed firing:** with the fix stashed from one workflow, the
      suite fails with `recorder invoked from the working tree` and `'cp
      scripts/record_usage.py …' not found`

## Evidence and uncertainty

- **Established:** the record's missing key; the run's own revision containing the
  field; #79's head not containing it; the runbook instructing the checkout that
  changes the tree.
- **Reasoned:** that the checkout is what did it. Every element is confirmed
  separately, but no run log was read showing the checkout command itself — the chain
  is inference over four verified facts rather than a single observation.
- **Not done:** the missing record is not backfilled. It cannot be: what produced it is
  now unknowable, and writing a guess into a ledger whose whole value is that unknown
  is not zero would be worse than the gap.
- **Also not done:** no audit of whether any other step reads the working tree after
  the model. Today there is none in either workflow — the tests would catch a new
  `scripts/record_usage.py` invocation, but not some other script added later.

## Review focus

Whether the four tests are the right shape. The fourth exists because the other three
pass vacuously if a workflow is renamed — a control that silently stops having anything
to check is the failure mode this repository keeps finding.

## Completion

- [x] The defect is fixed and the fix is proven to fail without it.
- [x] Documentation synchronized — the workflows carry the reasoning inline.
- [x] No private data, credentials, or machine paths added.
- [x] No ADR — this closes a hole rather than choosing a design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
