### PR TITLE
Measure a head before handing it to the reviewer

### DIFF
--- a/.github/workflows/mergeability.yml
+++ b/.github/workflows/mergeability.yml
@@ -1,14 +1,25 @@
 name: Mergeability
 
 # A pull request stops merging when its base moves, and GitHub does not re-run that
-# pull request's checks when `master` advances. So this runs in two places: on the
-# pull request itself, and on every push to `master` over all open pull requests.
-# The second trigger is the one that matters — it is the moment a conflict is created.
+# pull request's checks when `master` advances. So this also runs on pushes, fanning
+# out over every open pull request.
+#
+# The fan-out runs on pushes to **any** branch, not only `master`, because of a
+# property that cost a review run to discover: a conflicting pull request gets no
+# checks at all. GitHub runs `pull_request` workflows against `refs/pull/N/merge`, and
+# for a conflicting pull request that ref cannot be built — so no workflow fires, this
+# one included. A branch force-pushed into a conflicting state would therefore carry
+# stale checks or none, be selected for review as if unmeasured meant clean, and be
+# invisible to the AUTHOR's own "failing required check" rule, since there is no
+# failing check to see.
+#
+# A commit status does not need the merge ref, so the fan-out can still mark that head
+# red from a push event. That single status is what returns the pull request to the
+# author's queue.
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
   push:
-    branches: [master]
   workflow_dispatch:
 
 # `statuses: write` is the whole grant. This workflow writes one commit status and

--- a/scripts/select_review_target.py
+++ b/scripts/select_review_target.py
@@ -25,6 +25,11 @@ eligible the model is not started at all.
 * the `mergeability` check is failing, so a control has already established that the
   branch cannot be accepted whatever its contents; the next move belongs to the
   author, and the failing check is already on the author's own ladder;
+* nothing has run on its head at all. An unmeasured revision is not a clean one, and
+  the runbook forbids accepting one anyway, so a run spent on it can only rediscover
+  by hand what a check is about to report. This is not the same as a head that has
+  other checks but no `mergeability`: that one is old enough to predate the check and
+  stays reviewable;
 * its current head already carries a verdict, and no correction has been posted since.
 
 Eligibility means a review is *owed and possible*, not merely owed. Withhold one only
@@ -126,6 +131,17 @@ def conflicts_with_base(pull) -> bool:
     return False
 
 
+def is_unmeasured(pull) -> bool:
+    """Whether nothing at all has reported on this head yet.
+
+    A head seconds old has no checks because none have started. A head that conflicts
+    with its base may have none for much longer: GitHub runs pull-request workflows
+    against the merge ref, and a conflicting pull request has no merge ref, so nothing
+    fires. Either way the revision is unmeasured, which is not the same as clean.
+    """
+    return not (pull.get("statusCheckRollup") or [])
+
+
 def eligible(pull, head_committed_at: str, comments):
     """Return (bool, reason). Pure: no network, no clock."""
     if pull.get("isDraft"):
@@ -147,6 +163,9 @@ def eligible(pull, head_committed_at: str, comments):
 
     if conflicts_with_base(pull):
         return False, f"{MERGEABILITY_CHECK} is failing: the author must rebase first"
+
+    if is_unmeasured(pull):
+        return False, "nothing has reported on this head yet: unmeasured is not clean"
 
     head_sha = pull["headRefOid"]
     verdicts = [c for c in comments if judges_head(c, head_sha, head_committed_at)]

--- a/scripts/tests/test_select_review_target.py
+++ b/scripts/tests/test_select_review_target.py
@@ -16,14 +16,22 @@ HEAD = "d8e28d3e2df15c93c1df3e41eceb640996024907"
 COMMITTED = "2026-09-05T05:35:00Z"
 
 
-def pull(
-    number=84,
-    created="2026-09-05T05:35:16Z",
-    draft=False,
-    labels=(),
-    checks=(),
-    head_ref="claude/issue-84-example",
-):
+def check(name, conclusion):
+    return {"name": name, "conclusion": conclusion}
+
+
+# A head that has been measured and is clean. This is the default because it is the
+# ordinary case; an empty rollup means *nothing has reported yet*, which is its own
+# condition and is asserted for explicitly below.
+MEASURED_CLEAN = (
+    check("mergeability", "SUCCESS"),
+    check("typescript", "SUCCESS"),
+    check("build-and-test", "SUCCESS"),
+    check("policy-guard", "SUCCESS"),
+)
+
+
+def pull(number=84, created="2026-09-05T05:35:16Z", draft=False, labels=(), checks=None, head_ref="claude/issue-84-example"):
     return {
         "number": number,
         "createdAt": created,
@@ -31,12 +39,8 @@ def pull(
         "labels": [{"name": name} for name in labels],
         "headRefName": head_ref,
         "headRefOid": HEAD,
-        "statusCheckRollup": list(checks),
+        "statusCheckRollup": list(MEASURED_CLEAN if checks is None else checks),
     }
-
-
-def check(name, conclusion):
-    return {"name": name, "conclusion": conclusion}
 
 
 def comment(body, created):
@@ -130,6 +134,23 @@ class EligibilityTests(unittest.TestCase):
         # the refusal certain — what the review can add is.
         red = pull(checks=[check("typescript", "FAILURE")])
         ok, _ = select.eligible(red, COMMITTED, [])
+        self.assertTrue(ok)
+
+    def test_a_head_nothing_has_reported_on_is_not_selected(self):
+        # Observed at 08:10: a branch force-pushed minutes earlier had no checks at
+        # all, so the mergeability rule found nothing to object to and the head was
+        # handed to the model — which spent a run discovering the conflict by hand.
+        # Unmeasured is not clean.
+        ok, reason = select.eligible(pull(checks=()), COMMITTED, [])
+        self.assertFalse(ok)
+        self.assertIn("unmeasured is not clean", reason)
+
+    def test_a_head_with_other_checks_but_no_mergeability_is_still_selected(self):
+        # The legacy case this must not swallow: a pull request older than the
+        # mergeability check has been measured, just not by that check.
+        ok, _ = select.eligible(
+            pull(checks=[check("typescript", "SUCCESS")]), COMMITTED, []
+        )
         self.assertTrue(ok)
 
     def test_a_draft_is_skipped(self):


### PR DESCRIPTION
# Pull request

## Outcome

The `mergeability` fan-out runs on pushes to **any** branch, and selection skips a head
that nothing has reported on.

Part of #89.

## The property that caused this

**A conflicting pull request gets no checks at all.** GitHub runs `pull_request`
workflows against `refs/pull/N/merge`; a conflicting pull request has no such ref, so
nothing fires — including the mergeability workflow, whose whole job is to say so.

Not red checks. None.

## What happened at 08:10

1. An AUTHOR run force-pushed #91 onto a base that had moved under it. New head
   `99c096f1`, conflicting.
2. Five minutes later that head had **zero** check runs and **zero** statuses. Every
   earlier head of the same branch had triggered CI within seconds.
3. The selector's rule "a missing `mergeability` check is not a failure" — written so
   pull requests older than the check stay reviewable — matched, and #91 was selected.
4. The ACCEPTOR spent a run discovering the conflict by hand and refused. The verdict
   was correct; the run should never have happened.
5. And with no failing check to see, the AUTHOR's own *open pull request with a failing
   required check — fix it* had nothing to match either.

Step 5 is the serious one. The pull request belonged to **no** queue: not the
reviewer's, because there was nothing to review; not the author's, because there was
no red check to notice. It would have sat there until a push to `master` happened to
fan out over it.

## The two changes

**The fan-out runs on any push.** A commit status is written through the statuses API
and does not need a merge ref, so the fan-out can mark a conflicting head red from a
`push` event even though no `pull_request` workflow can run for it. That one status is
what puts the pull request back in the author's queue. This is the fix; the second is
a safety net for the window before it runs.

**Selection skips an unmeasured head.** Nothing has reported, so the revision is not
clean — it is unmeasured, and the runbook forbids accepting an unmeasured revision
anyway. Deliberately distinct from a head that carries other checks but no
`mergeability`: that one has been measured, just not by that check, and stays
reviewable. Both cases have a negative control.

## Verification

- [x] `python -m unittest discover -s scripts/tests -v` — 109 tests pass (107 before)
- [x] `python scripts/policy_guard.py --base origin/master` — passed over 3 files
- [x] `mergeability.yml` parses
- [x] **Live:** the selector now prints `#91 … skipped: nothing has reported on this
      head yet: unmeasured is not clean` and selects #94, which had been rebased back
      to clean meanwhile
- [ ] **The any-push fan-out has not run yet.** Its first execution is its first
      evidence, as with the `master` fan-out before it. I will confirm that a
      conflicting head actually receives a red status from a branch push.

## Evidence and uncertainty

- **Established:** head `99c096f1` had no check runs and no statuses five minutes after
  it was pushed, while three earlier heads of the same branch each triggered CI;
  `mergeable_state: dirty` on that head; the ACCEPTOR's run and its refusal.
- **Reasoned:** that the missing merge ref is why no workflow fired. It is the
  documented behaviour and it fits exactly, but I did not observe GitHub refusing to
  create the ref — the inference is from the absence of runs.
- **Not fixed here:** that refusal was posted with three empty placeholders — *"At
  revision , the branch has a merge conflict in  …"*. Correct in substance, unusable in
  form. A verdict with blank slots should be impossible; the likely fix is passing the
  head revision and check states into the prompt as text so the model is not fetching
  values it can silently omit. Separate change.
- **Cost:** the fan-out now runs on every branch push rather than only on `master`.
  It is a ~20 second job over the open pull requests; at this repository's push rate
  that is negligible, and it would need revisiting on a busy repository.

## Review focus

Whether "no checks at all" can be a legitimate steady state for a pull request that
*should* be reviewed. I could not construct one — a head with nothing reporting is
either seconds old or unable to produce a merge ref — but if such a case exists, this
change makes it permanently unreviewable, which is the failure mode worth catching in
review.

## Completion

- [x] Both defects trace to one observed incident.
- [x] Documentation synchronized — the workflow and the selector each carry the
      reasoning inline.
- [x] No private data, credentials, or machine paths added.
- [x] No ADR — closes a hole in an existing control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
