### PR TITLE
Arm an existing mirror pull request, not only a new one

### DIFF
--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -177,14 +177,31 @@ jobs:
       # A failure here is a warning, never a failed sync. The mirror is already proposed
       # at this point; being unable to arm auto-merge means it waits for a person, which
       # is the previous behaviour and not an emergency.
+      #
+      # Not conditioned on this run having produced a pull request. The action reports
+      # a number only when it creates or updates one, so a run that finds Drive
+      # unchanged would skip arming — and a pull request whose first arming failed
+      # would then never be armed again. Nothing else can recover it: the acceptor no
+      # longer selects a mirror, and no agent may push to this branch, so it would sit
+      # open with nobody responsible for it. That is exactly how #101 came to need an
+      # operator.
       - name: Arm auto-merge on the mirror
-        if: steps.mirror_pr.outputs.pull-request-number != ''
         env:
           GH_TOKEN: ${{ secrets.ZENDEV_PAT || github.token }}
+          REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.mirror_pr.outputs.pull-request-number }}
         run: |
           set -uo pipefail
-          if gh pr merge "${PR_NUMBER}" --auto --squash --delete-branch; then
+          if [ -z "${PR_NUMBER}" ]; then
+            # Restricted to this branch by name, so this can never reach for anything
+            # but the mirror.
+            PR_NUMBER=$(gh pr list --repo "${REPO}" --head spec-mirror --state open               --json number --jq '.[0].number // empty')
+          fi
+          if [ -z "${PR_NUMBER}" ]; then
+            echo "no open mirror pull request; nothing to arm"
+            exit 0
+          fi
+          if gh pr merge "${PR_NUMBER}" --repo "${REPO}" --auto --squash --delete-branch; then
             echo "auto-merge armed on #${PR_NUMBER}"
           else
             echo "::warning::could not arm auto-merge on #${PR_NUMBER}. Check that the"


### PR DESCRIPTION
Closes #107. Follow-up to #94, found by running it.

## Achieved outcome

`spec-sync.yml` arms auto-merge on whichever open `spec-mirror` pull request exists, not only on one this run created or updated. A mirror whose first arming failed is now armed by the next sync instead of sitting open forever.

## Tested revision

`dcb966b`.

## Changed artifacts

`.github/workflows/spec-sync.yml` — the arming step loses its `if:` condition and falls back to `gh pr list --head spec-mirror --state open` when this run produced no pull request number. Ten lines, no other file.

## Acceptance criteria

- [x] **With no open mirror pull request the step runs and says so.** Measured on dispatch [33955669177](https://github.com/drevendev/trade_simulation/actions/runs/33955669177) against this branch: step outcome `success`, log line `no open mirror pull request; nothing to arm`. Before this change the same situation produced `skipped` — run [33955578949](https://github.com/drevendev/trade_simulation/actions/runs/33955578949).
- [x] **The lookup cannot reach anything but the mirror.** `--head spec-mirror --state open` in this repository, and `.[0].number // empty` yields nothing rather than an error when the list is empty.
- [x] **Arming stays a warning.** The `if gh pr merge ... else echo ::warning::` shape is unchanged, and the new early return is `exit 0`.
- [ ] **Arming a pre-existing pull request** — not provoked; see below.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| live `workflow_dispatch` on this branch | passed | run 33955669177, step `success`, correct message |
| `python -m unittest discover -s scripts/tests` | passed | 128 tests at this revision |
| `python scripts/policy_guard.py` | passed | 1 changed file, policy-only |
| workflow YAML parses | passed | `yaml.safe_load`; the last step of `sync` now carries no `if` |
| `build-and-test`, `typescript`, `policy-guard`, `mergeability` | see the checks tab | this body asserts none of them |

## Not checked

**The path this exists for has not been exercised**: arming a mirror pull request that a previous run left open. Provoking it needs a pending Drive change plus a failed arming, and I will not fake either. What is measured is that the step now *runs* in the case that used to skip it, which is the precondition for that path; the fallback branch itself is read, not observed.

## Assumptions and unknowns

- **Assumption:** `gh pr merge --auto` on an already-armed pull request is harmless. It is idempotent in `gh`, and the step will now run on every sync rather than once per pull request, so a run where nothing changed will re-arm an armed pull request. If that turns out to be noisy rather than harmless, the fix is to check `autoMergeRequest` first.
- **Fact:** #101 needed an operator precisely because nothing in the loop could arm it. That is the failure this closes, not a hypothetical.

## Highest-risk area for review

That the step now runs unconditionally. It executes `gh pr merge --auto` on every sync, including runs that changed nothing, so a transient API failure now produces a warning on runs that previously stayed silent. The alternative — leaving the condition and accepting an unreachable pull request — is worse, but the noise is real and it is the thing to watch.

## Remaining gate

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)