### PR TITLE
Read changed paths in the form git does not escape

### DIFF
--- a/scripts/machine_pr_guard.py
+++ b/scripts/machine_pr_guard.py
@@ -151,13 +151,29 @@ def check(head_ref: str, paths, allowlist_text, tip_committer):
 
 
 def _git(args):
+    # UTF-8 explicitly, not by locale: a path this guard classifies may carry bytes
+    # that a cp1252 console would decode into a different string.
     return subprocess.run(
-        ["git", *args], check=True, capture_output=True, text=True
+        ["git", *args], check=True, capture_output=True, text=True, encoding="utf-8"
     ).stdout
 
 
 def changed_paths(base: str):
-    return [p for p in _git(["diff", "--name-only", base + "...HEAD"]).splitlines() if p]
+    """Changed paths, as git actually spells them.
+
+    Read with `-z` and split on NUL, never `splitlines()` over the default output.
+    Without `-z`, git C-quotes any path holding a byte outside ASCII: it wraps the path
+    in double quotes and replaces each such byte with an octal escape, so a mirrored
+    handoff document whose name contains an em dash arrives as a quoted string carrying
+    three escape sequences where the dash was. That string starts with a quote, so no
+    prefix test can match it, and this guard refused the first real mirror to reach it,
+    #109, for being outside a directory it was inside. Every file under
+    `06 - Handoff/` carries an em dash, which was most of the specification.
+
+    `-z` also keeps a newline inside a filename from splitting one path into two.
+    """
+    out = _git(["diff", "--name-only", "-z", base + "...HEAD"])
+    return [path for path in out.split("\x00") if path]
 
 
 def commit_author(sha: str):

--- a/scripts/policy_guard.py
+++ b/scripts/policy_guard.py
@@ -140,13 +140,20 @@ def check(paths, added_lines):
 
 
 def _git(args):
+    # UTF-8 explicitly, not by locale: a path this guard classifies may carry bytes
+    # that a cp1252 console would decode into a different string.
     return subprocess.run(
-        ["git", *args], check=True, capture_output=True, text=True
+        ["git", *args], check=True, capture_output=True, text=True, encoding="utf-8"
     ).stdout
 
 
 def collect(base: str):
-    paths = [p for p in _git(["diff", "--name-only", f"{base}...HEAD"]).splitlines() if p]
+    # `-z` and a NUL split. Without it git C-quotes any path holding a byte outside
+    # ASCII, and a quoted path matches neither POLICY_PREFIXES nor PRODUCT_PREFIXES —
+    # so a policy/product mix involving such a filename would pass unrefused. That is
+    # the quiet half of the defect that made machine_pr_guard refuse #109 loudly.
+    listing = _git(["diff", "--name-only", "-z", f"{base}...HEAD"])
+    paths = [path for path in listing.split("\x00") if path]
     diff = _git(["diff", "--unified=0", f"{base}...HEAD"])
     added = [
         line[1:]

--- a/scripts/tests/test_changed_paths.py
+++ b/scripts/tests/test_changed_paths.py
@@ -1,0 +1,121 @@
+"""Both guards must read the paths git actually changed, not git's display form.
+
+This builds a real repository, because that is where the defect lived: `check()` and
+`classify()` were tested with hand-written path lists and were never wrong, while
+`changed_paths()` — the thing that produced those lists in production — had never been
+run against a repository at all.
+
+The name that matters is the one from #109: `06 - Handoff/99 — PROJECT_MANIFEST.md`.
+Its em dash makes `git diff --name-only` C-quote the whole path, and the guard then
+refused a file for being outside a directory it was inside.
+"""
+
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import machine_pr_guard as guard  # noqa: E402
+import policy_guard  # noqa: E402
+
+MIRROR = "docs/spec/mirror"
+EM_DASH_PATH = MIRROR + "/06 - Handoff/99 — PROJECT_MANIFEST.md"
+SPACED_PATH = MIRROR + "/06 - Handoff/README notes.md"
+ASCII_PATH = MIRROR + "/SPEC_CHANGELOG.md"
+
+
+def git(cwd, *args):
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+
+class RepositoryFixture:
+    """A repository with one commit on master and one on a branch off it."""
+
+    def __enter__(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        root = pathlib.Path(self.tmp.name)
+        git(root, "init", "-b", "master")
+        git(root, "config", "user.email", "test@example.invalid")
+        git(root, "config", "user.name", "Test")
+        git(root, "config", "core.quotepath", "true")  # git's default; be explicit
+
+        (root / "README.md").write_text("base\n", encoding="utf-8")
+        git(root, "add", "-A")
+        git(root, "commit", "-m", "base")
+
+        for relative in (EM_DASH_PATH, SPACED_PATH, ASCII_PATH):
+            path = root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("content\n", encoding="utf-8")
+        git(root, "add", "-A")
+        git(root, "commit", "-m", "mirror sync")
+
+        self.root = root
+        self.previous = os.getcwd()
+        os.chdir(root)
+        return self
+
+    def __exit__(self, *exc):
+        os.chdir(self.previous)
+        self.tmp.cleanup()
+        return False
+
+
+class ChangedPathsTests(unittest.TestCase):
+    def test_machine_guard_reads_a_non_ascii_path_unquoted(self):
+        with RepositoryFixture():
+            paths = guard.changed_paths("master~1")
+        self.assertIn(EM_DASH_PATH, paths)
+        self.assertFalse(
+            [p for p in paths if p.startswith('"')],
+            "git's C-quoted display form reached the guard",
+        )
+
+    def test_a_path_with_a_space_survives_the_split(self):
+        with RepositoryFixture():
+            paths = guard.changed_paths("master~1")
+        self.assertIn(SPACED_PATH, paths)
+        self.assertNotIn("", paths)
+        self.assertEqual(len(paths), 3)
+
+    def test_the_mirror_is_accepted_end_to_end(self):
+        # #109 exactly: three mirrored files, one of them em-dashed, refused for being
+        # outside the directory it is inside.
+        with RepositoryFixture():
+            paths = guard.changed_paths("master~1")
+            allowlist = "+ /SPEC_CHANGELOG.md*\n+ /06 - Handoff/**\n- *\n"
+            violations = guard.check(
+                "spec-mirror", paths, allowlist, "github-actions[bot]"
+            )
+        self.assertEqual(violations, [])
+
+    def test_policy_guard_reads_the_same_path_unquoted(self):
+        with RepositoryFixture():
+            paths, _ = policy_guard.collect("master~1")
+        self.assertIn(EM_DASH_PATH, paths)
+        self.assertFalse([p for p in paths if p.startswith('"')])
+
+    def test_policy_guard_still_classifies_a_non_ascii_policy_path(self):
+        # The quiet half: a quoted path matches no prefix, so a mix would pass. This
+        # proves the classification actually reaches a policy path with an em dash.
+        self.assertTrue(policy_guard.is_policy("scripts/tools/héritage.py"))
+        policy, product = policy_guard.classify(
+            ["scripts/tools/héritage.py", "src/domain/id.ts"]
+        )
+        self.assertEqual(policy, ["scripts/tools/héritage.py"])
+        self.assertEqual(product, ["src/domain/id.ts"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #110. Found in production by #94's own guard, on the first mirror that reached it.

## Achieved outcome

`machine_pr_guard` and `policy_guard` read changed paths with `git diff --name-only -z` and split on NUL, so a filename holding a byte outside ASCII is classified by its real path. #109 — refused for changing `docs/spec/mirror/06 - Handoff/99 — PROJECT_MANIFEST.md`, a path inside `docs/spec/mirror/` — now passes.

## Tested revision

`84a3c374`.

## Changed artifacts

| File | Change |
| --- | --- |
| `scripts/machine_pr_guard.py` | `changed_paths` uses `-z` and a NUL split; `_git` decodes UTF-8 explicitly. |
| `scripts/policy_guard.py` | `collect` likewise. |
| `scripts/tests/test_changed_paths.py` | New. Builds a real repository containing the filename from #109 and runs both readers against it. |

## Acceptance criteria

- [x] **`changed_paths` returns the unquoted path** — `test_machine_guard_reads_a_non_ascii_path_unquoted`, which also asserts no returned path begins with a quote.
- [x] **`policy_guard.collect` returns the same shape** — `test_policy_guard_reads_the_same_path_unquoted`, plus `test_policy_guard_still_classifies_a_non_ascii_policy_path` for the quiet half.
- [x] **The guard accepts #109's actual head.** Run against `refs/pull/109/head` with the fixed script: `machine-pr-guard: passed over 3 changed file(s) on machine class spec-mirror`, exit 0. Against the same head before the fix: refused, exit 1.
- [x] **A path containing a space survives, and the split yields no empty entries** — `test_a_path_with_a_space_survives_the_split`.
- [x] **The existing suites pass** — 150 tests, 0 failures.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest discover -s scripts/tests` | passed | 150 tests at `84a3c374` |
| guard against `refs/pull/109/head` | passed | exit 0, three files, class `spec-mirror` |
| same, before the fix | refused | exit 1, naming the quoted path — the production failure reproduced locally |
| `dotnet` / `npm` suites | not_run | no product file touched; measured by the required checks on this head |

## Not checked

That the fix ends the incident. It cannot: #109's checks ran against the workflow revision current when it opened, and re-running a workflow replays that revision rather than picking up a newer one — observed on #101. #109 has to be closed once this merges, so the next sync opens a fresh pull request whose checks run the fixed guard. That step is in **Remaining gate**.

## Assumptions and unknowns

- **Fact, not assumption:** `git diff --name-only` quotes these paths. Reproduced against `63f8682`, where the default output is `"docs/spec/mirror/06 - Handoff/01 ... CORE_SCHEMA_AND_LIFECYCLES.md"` and the `-z` output is the plain path.
- **Assumption:** no other caller reads paths this way. `status_lint`, `implementation_status`, `select_review_target` and `schedule_watchdog` invoke no `git diff`; checked by reading them.
- **Unknown:** whether `policy_guard`'s half ever mattered in practice. No non-ASCII path exists under `src/`, `TradeCraftSimulation*` or `scripts/` today, so the mix it would have missed has never been possible.

## Highest-risk area for review

That this is the *whole* defect and not one instance of it. The guards compare strings against ASCII prefixes throughout, and the allowlist parser reads the rclone filter file the same way; that file is ASCII today, and a non-ASCII rule in it would be a separate reading problem this change does not address. Worth a look, not a claim.

## Remaining gate

Close #109 after this merges, so the next sync reopens it against the fixed guard. Everything else is automatic: the sync arms auto-merge on whatever mirror pull request is open (#108).

🤖 Generated with [Claude Code](https://claude.com/claude-code)