### PR TITLE
Gate the mirror on its committer, not on who triggered the sync

### DIFF
--- a/docs/zendev/MACHINE_PULL_REQUESTS.md
+++ b/docs/zendev/MACHINE_PULL_REQUESTS.md
@@ -15,7 +15,10 @@ check on every pull request — not by a reader.
 1. its head branch is exactly a branch named in `MACHINE_CLASSES` in that script;
 2. every changed path is inside the roots that class owns;
 3. every changed path satisfies that class's own allowlist, where it has one;
-4. the head commit is authored by the identity the producing workflow writes under.
+4. the head commit is **committed** by the identity the producing workflow writes
+   under. Its *author* is whoever triggered the sync and may be a person: dispatching
+   `spec-sync.yml` by hand is a supported operating path, and the author field is the
+   record of that. The committer is what wrote the bytes, and that is the question.
 
 The classes today:
 

--- a/scripts/machine_pr_guard.py
+++ b/scripts/machine_pr_guard.py
@@ -9,7 +9,9 @@ This guard is that predicate. It decides two things and nothing else:
 
 1. A pull request whose head branch belongs to a machine class must stay inside the
    paths that class owns, must satisfy that class's own allowlist, and its head commit
-   must be authored by the workflow identity that produces it.
+   must be *committed* by the workflow identity that produces it. The author of that
+   commit records who triggered the run and may be a person; the committer records what
+   wrote it, and only that answers the question this guard is asking.
 2. Nobody else may write those paths. An agent branch — or a person — editing
    ``docs/spec/mirror/**`` by hand is refused, because the mirror's whole value is
    that it is a verifiable copy of Drive rather than a place where anything can be
@@ -42,8 +44,11 @@ class MachineClass:
     # Path prefixes this class owns. Nothing else may appear in its diff, and no other
     # branch may touch them.
     roots: tuple[str, ...]
-    # The commit identity the producing workflow writes under. A commit under any
-    # other name on this branch means something other than the workflow wrote it.
+    # The commit identity the producing workflow writes under — the *committer*, which
+    # is what wrote the bytes. Not the author: `peter-evans/create-pull-request`
+    # defaults the author to whoever triggered the run, so an operator dispatching the
+    # sync by hand legitimately appears there. A commit committed under any other name
+    # on this branch means something other than the workflow wrote it.
     committer: str
     # An rclone filter file deciding what may exist under the roots, or None when the
     # roots themselves are the whole rule.
@@ -142,9 +147,9 @@ def check(head_ref: str, paths, allowlist_text, tip_committer):
 
     if tip_committer is not None and tip_committer != cls.committer:
         violations.append(
-            "the head commit of %s was authored by '%s', not by '%s'; only %s may "
-            "write this branch"
-            % (cls.branch, tip_committer, cls.committer, cls.producer)
+            "the head commit of %s was committed by '%s', not by '%s'; only %s may "
+            "write this branch. The commit's author may be whoever triggered the sync; "
+            "its committer may not" % (cls.branch, tip_committer, cls.committer, cls.producer)
         )
 
     return violations
@@ -176,10 +181,16 @@ def changed_paths(base: str):
     return [path for path in out.split("\x00") if path]
 
 
-def commit_author(sha: str):
-    """The author name of one commit, or None when it is not in this clone."""
+def commit_committer(sha: str):
+    """The committer name of one commit, or None when it is not in this clone.
+
+    `%cn`, not `%an`. A sync dispatched by an operator is authored by that operator and
+    committed by the workflow identity; refusing it on the author would break a
+    documented operating path — `spec-sync.yml` keeps `workflow_dispatch` precisely so
+    a person can run it — while proving nothing about who wrote the bytes.
+    """
     try:
-        return _git(["log", "-1", "--format=%an", sha]).strip()
+        return _git(["log", "-1", "--format=%cn", sha]).strip()
     except subprocess.CalledProcessError:
         return None
 
@@ -201,7 +212,7 @@ def main() -> int:
     parser.add_argument(
         "--head-sha",
         default=None,
-        help="head commit; its author is checked against the producing workflow",
+        help="head commit; its committer is checked against the producing workflow",
     )
     args = parser.parse_args()
 
@@ -210,11 +221,11 @@ def main() -> int:
 
     tip = None
     if cls is not None and args.head_sha:
-        tip = commit_author(args.head_sha)
+        tip = commit_committer(args.head_sha)
         if tip is None:
             print(
                 "::error::machine-pr-guard: the head revision %s is not present in "
-                "this clone, so its author is unavailable; refusing rather than "
+                "this clone, so its committer is unavailable; refusing rather than "
                 "assuming it" % args.head_sha
             )
             return 1

--- a/scripts/tests/test_machine_pr_guard.py
+++ b/scripts/tests/test_machine_pr_guard.py
@@ -98,6 +98,15 @@ class MirrorBranchTests(unittest.TestCase):
         violations = self.check([MIRROR + "SPEC_INDEX.md"], committer="Dreven")
         self.assertEqual(len(violations), 1)
         self.assertIn("only .github/workflows/spec-sync.yml may write", violations[0])
+        self.assertIn("committed by", violations[0])
+
+    def test_an_operator_dispatched_sync_is_permitted(self):
+        # #112 exactly. peter-evans/create-pull-request defaults the commit author to
+        # whoever triggered the run and the committer to the bot, so a sync a person
+        # dispatches by hand — a supported path, which is why spec-sync.yml keeps
+        # workflow_dispatch — is authored by that person and committed by the workflow.
+        # The gate reads the committer, so this passes.
+        self.assertEqual(self.check([MIRROR + "SPEC_CHANGELOG.md"], committer=SYNC_BOT), [])
 
     def test_an_unreadable_allowlist_is_refused_rather_than_skipped(self):
         violations = self.check([MIRROR + "SPEC_INDEX.md"], allowlist=None)


### PR DESCRIPTION
Closes #113. Second defect in #94's guard found by production; #111 was the first.

## Achieved outcome

`machine-pr-guard` reads the head commit's **committer** rather than its author, so a sync an operator dispatches by hand is judged by what wrote the bytes rather than by who asked. #112 — refused because its commit was authored by `drevendev` — now passes.

## Tested revision

`7ba65de1`.

## Changed artifacts

| File | Change |
| --- | --- |
| `scripts/machine_pr_guard.py` | `commit_author` becomes `commit_committer` and reads `%cn`; the violation message names the committer and says the author may differ; the dataclass comment and module docstring explain which field answers which question. |
| `scripts/tests/test_machine_pr_guard.py` | The operator-dispatched case, which is what failed, plus an assertion that the refusal says "committed by". |
| `docs/zendev/MACHINE_PULL_REQUESTS.md` | Condition 4 of the class says committer, and why the author is allowed to vary. |

## The distinction, measured

`peter-evans/create-pull-request` defaults the committer to `github-actions[bot]` and the author to `github.actor`:

| Head | `%an` | `%cn` | Dispatched by |
| --- | --- | --- | --- |
| #109 `bab227c` | `github-actions[bot]` | `github-actions[bot]` | watchdog |
| #112 `877a0ff` | `drevendev` | `github-actions[bot]` | operator |

Reading the author made the class depend on who pressed the button. `spec-sync.yml` keeps `workflow_dispatch` enabled specifically so a person can run it, so the guard was refusing a path the workflow it guards deliberately supports.

## Acceptance criteria

- [x] **An operator-dispatched sync is permitted** — `test_an_operator_dispatched_sync_is_permitted`, and against #112's real head: `machine-pr-guard: passed over 5 changed file(s) on machine class spec-mirror`, exit 0. Against the same head before this change: refused, exit 1.
- [x] **A commit committed by anything else is still refused, naming the committer** — `test_a_commit_from_another_identity_is_refused`.
- [x] **Existing suites pass** — 151 tests, 0 failures.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest discover -s scripts/tests` | passed | 151 tests at `7ba65de1` |
| guard against `refs/pull/112/head` | passed | exit 0, five files, class `spec-mirror` |
| same, before this change | refused | exit 1, naming the author — the production failure reproduced |
| `dotnet` / `npm` suites | not_run | no product file touched; measured by the required checks on this head |

## Not checked

That the guard has now passed in CI on a real mirror pull request. It has not: both mirrors that reached it were refused, first by #110's defect and then by this one. The first green mirror is the evidence, and it does not exist yet.

## Assumptions and unknowns

- **Assumption:** `peter-evans/create-pull-request` keeps defaulting the committer to `github-actions[bot]`. Measured on both mirror heads, not guaranteed across a future major version — and if it changes, the guard refuses rather than admits.
- **Known narrowness, not fixed here:** only the tip commit's committer is checked. A branch whose tip is the bot's but whose earlier commits are not would pass this gate. The content gates do not care who committed what, so the exposure is identity provenance only, and the action force-pushes the branch on every sync, which replaces history rather than appending to it.

## Highest-risk area for review

Whether committer is genuinely the right field, or whether the gate should require *both* to be the workflow identity except on `workflow_dispatch`. I argue not: that would encode the trigger type into a content guard, and the author field carries no authority — anyone can set it locally. The committer is the field the forge writes, and it is the one the class contract already described.

## Remaining gate

Close #112 after this merges, so the next sync reopens it against the fixed guard. Same shape as #110's recovery, for the same reason: a re-run replays the workflow revision the run started with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)