### PR TITLE
Record the decisions, and the recovery that had to be rediscovered

### DIFF
--- a/docs/adr/0004-machine-generated-pull-requests.md
+++ b/docs/adr/0004-machine-generated-pull-requests.md
@@ -1,0 +1,87 @@
+# 4. A pull request no one authored merges on mechanical gates, with no agent in the path
+
+Date: 2026-09-05
+Status: Accepted
+
+## Context
+
+`spec-sync.yml` copies the allowlisted part of the Drive specification into
+`docs/spec/mirror/` and proposes it. Nobody authors that change: the workflow copies
+bytes from one place to another.
+
+The ACCEPTOR reviewed those proposals under section 2a of its runbook. Its gates were:
+every changed path inside `docs/spec/mirror/`, every path inside
+`docs/zendev/spec-mirror-allowlist.txt`, no credential-shaped string, all required checks
+green, and the head commit written by the sync workflow. Every one of them is a predicate
+over the diff. No judgement was being exercised.
+
+Measured over the 24 hours ending 2026-09-05T06:40Z: 6 of 29 merged pull requests were
+mirror snapshots — 21% of merges. Each consumed one of roughly 24 daily review slots to
+assert that a byte copy was a byte copy. Because the ACCEPTOR selects oldest-first, each
+one also delayed the code pull request behind it by a full dispatch interval, then
+25 minutes.
+
+## Decision
+
+**The gates become a required check, and branch protection performs the merge.**
+
+`scripts/machine_pr_guard.py` decides the class and enforces it, inside the already
+required `policy-guard` job. `spec-sync.yml` arms GitHub auto-merge on the pull request
+it opens. `docs/zendev/MACHINE_PULL_REQUESTS.md` is the normative contract.
+
+Four conditions, all mechanical, define the class: the head branch is exactly one named
+in `MACHINE_CLASSES`; every changed path is inside the roots that class owns; every path
+satisfies that class's allowlist; and the head commit is **committed** by the identity the
+producing workflow writes under.
+
+**The guard runs in both directions.** It also refuses any non-machine branch that writes
+a machine-owned path. This is the half that makes the change a narrowing rather than a
+widening: before it, `docs/spec/mirror/**` could be written from any branch and only a
+reviewing agent stood in the way — and a reviewing agent is not a control against the
+agents it sits beside. After it, the sync workflow is the only path in.
+
+**The class leaves the review queue mechanically, not by instruction.**
+`select_review_target.py` classifies the head branch through `machine_pr_guard.classify`
+and rules it ineligible before the model starts. One definition of the class, used by
+both the gate and the selector.
+
+### What was rejected
+
+*A new required status check.* Branch protection requires exactly `build-and-test`,
+`typescript` and `policy-guard`. A newly required context that does not run on existing
+pull requests blocks every one of them indefinitely. The guard lives inside
+`policy-guard` for that reason, and needs no branch-protection change.
+
+*Leaving the review in place and making it cheaper.* Nothing about it was expensive
+except the run. The gates were already decidable; a faster model deciding them would have
+been the same category error.
+
+*Letting the ACCEPTOR merge the class by hand when a gate is red.* That restores exactly
+the review dependency this removes, and it puts a role that may merge in front of a
+control designed to work without one.
+
+## Consequences
+
+A mirror now merges in under a minute with no model run. Measured on #116: opened
+09:31:39Z, merged 09:32:30Z, all four required checks green, no agent anywhere in the
+path.
+
+**A red gate has no automatic recovery, and that is the cost.** The ACCEPTOR may not
+select it, no agent may push to the branch, and re-running the checks replays the
+workflow definition the original run started with — so repairing the guard does not
+release what it refused. The proposal must be closed and reproposed by the next sync. Both
+guard defects found in the first hour (#110, #113) stalled the specification pipeline for
+about half an hour each, and the procedure is written down in
+`docs/zendev/MACHINE_PULL_REQUESTS.md` because it had to be worked out twice.
+
+**Provenance is the committer, never the author.** The action defaults the author to
+whoever triggered the run, so an operator-dispatched sync is authored by that person and
+committed by the workflow. #113 records the refusal this caused.
+
+**Acceptance of this class asserts less than a review did.** It asserts the snapshot is
+confined, allowlisted, produced by its workflow and green — nothing about whether the
+content is correct or current. That was already true of the review; it is now explicit.
+
+**A human accepted the change itself.** `ACCEPTOR_RUNBOOK.md`'s hard limits forbid that
+role from merging a policy change that alters automated authority, and this altered who
+accepts a class of pull request.

--- a/docs/adr/0005-derived-implementation-coverage.md
+++ b/docs/adr/0005-derived-implementation-coverage.md
@@ -1,0 +1,104 @@
+# 5. Implementation coverage is rendered from an evidence ledger, not maintained as a status
+
+Date: 2026-09-05
+Status: Accepted
+
+## Context
+
+`docs/spec/IMPLEMENTATION_STATUS.md` answered "is the specification implemented?" as a
+table of requirement identifiers, each with a status and the pull request that satisfied
+it. It was written by hand inside pull requests.
+
+A row recorded `IN_PROGRESS` with a pull request number. That pull request merged.
+Nothing in the merge touched the row, so a later run had to notice and flip it — and
+`AUTHOR_RUNBOOK.md` section 1 mandated exactly that, as a step before selecting work,
+with an extra `gh pr list --state merged` in every run.
+
+The cost was measurable. Reconciliation pull requests: #21, #26, #35, #47, #55, #66,
+#105. Four of the 29 merges in the 24 hours ending 2026-09-05T06:40Z changed nothing but
+this file — 14% of throughput — and each also consumed an ACCEPTOR run.
+
+The cost was not the worst of it. #105 promoted `REQ-CONFIG-005` from `IN_PROGRESS` to
+`IMPLEMENTED` while leaving the row's evidence untouched — evidence that opened "Covers
+only the shape slice" and cited #76, never #88, which is what completed the requirement.
+Every mechanical check passed: the cited pull request had merged and the counts added up.
+**A stored status can be advanced independently of the evidence for it, and no arithmetic
+over the document can tell.**
+
+## Decision
+
+**Store only what a change can assert about itself, and render the rest.**
+
+`docs/spec/implementation_status.csv` is the ledger: `REQ_ID`, `STATUS`, `ISSUE`, `PR`,
+an optional `MERGE_COMMIT`, `EVIDENCE`. One row per identifier, appended by the pull
+request that earns it.
+
+**A ledger row's presence on `master` is its merge evidence.** The row travels inside the
+pull request it describes, so it appears on the default branch exactly when that work
+merges. There is nothing for a later run to flip.
+
+`scripts/implementation_status.py` renders `IMPLEMENTATION_STATUS.md` from the ledger plus
+`REQUIREMENTS_REGISTRY.csv`, and `--check` regenerates and compares inside `policy-guard`.
+It performs no network call: a generator whose output depended on when it ran could not be
+a gate.
+
+**`IN_PROGRESS` is not a ledger status.** Claimed work is a `status:in-progress` label on
+an Issue — a live fact the forge already owns, and precisely the one this file kept
+getting wrong. The statuses are `IMPLEMENTED`, `PARTIAL`, `BLOCKED`, `DEFERRED`,
+`CONTESTED`; an identifier with no row renders as `NOT_STARTED`.
+
+**A row may cite the pull request that carries it, and no other open one.** This reverses
+the rule #102 introduced hours earlier, deliberately. That rule refused self-citation
+because a pull request closed without merging would leave the claim false forever — which
+was correct while *any* pull request could write *any* row, as #84 demonstrated. Once the
+row and its subject travel together, a closed pull request takes its row with it: the
+claim becomes true at the moment it becomes visible and false nowhere. `status_lint`'s
+`--self` permits exactly that one citation; every other open citation is still refused,
+and on a push event there is no self at all.
+
+### What became of `status_lint`'s rules
+
+| Rule from #97 / #102 | Fate |
+| --- | --- |
+| A requirement claimed by a merged pull request has no row | kept, retargeted at the ledger |
+| A row cites a pull request that has not merged | kept, with the `--self` exception above |
+| A malformed row | deleted — rows are CSV, and `validate` names a bad one offline |
+| `IMPLEMENTED` citing no pull request | moved to `validate`; same decision, no network |
+| Summary arithmetic | deleted — the summary is computed from the rows it counts |
+
+### What was rejected
+
+*Keeping the hand-maintained document and linting it harder.* That is what #97 did, and
+it makes staleness loud without removing it: `master` goes red because something merged
+elsewhere, and a reconciliation run is still required to clear it. The class persists.
+
+*Deriving the status from the forge at render time.* An API call would make the output
+depend on when it ran, which disqualifies it as a CI gate.
+
+*Recording `IN_PROGRESS` in the ledger.* It is the one value the change cannot assert
+about itself.
+
+## Consequences
+
+Coverage reads 11 of 32 implemented, 1 partial, and cannot disagree with the ledger it is
+rendered from. The reconciliation class has no work left to do; #105 was closed rather
+than rebased, and its requirement recorded against #88 with evidence naming the tests
+that prove it.
+
+**The table now lists every registry identifier**, with the specification's own status
+beside it, so `NOT_STARTED` against a `REVIEW` row reads as "not offered for
+implementation" rather than "skipped". The file is longer, and its diffs look larger than
+the changes are.
+
+**`PARTIAL` is load-bearing and could be abused.** It requires a merged pull request and
+evidence, and its promotion to `IMPLEMENTED` is a deliberate act rather than a consequence
+of a merge elsewhere — which is what makes it safe here and `IN_PROGRESS` unsafe.
+
+**One instruction is known to be wrong.** Section 7 says to append a row; a requirement
+that already has one — a `PARTIAL` being completed — needs the existing row updated, and
+the validator refuses the duplicate. Recorded as #115.
+
+**Nothing prompts a refresh when a later pull request advances a `PARTIAL` without
+completing it.** `status_lint` only notices an identifier with no row at all.
+`REQ-CONFIG-003` is the live instance: #91 merged more of it and the ledger still credits
+#79. The status stays truthful; the evidence understates.

--- a/docs/spec/FEEDBACK_TO_RESEARCHER.md
+++ b/docs/spec/FEEDBACK_TO_RESEARCHER.md
@@ -154,3 +154,62 @@ indexed.
 
 Impact: none blocking. `PARTIAL` now records the intermediate state honestly, so this is
 a reporting-quality improvement rather than an obstacle.
+
+---
+
+## 2026-09-05 — the delivery path is proven, and what a stalled sync looks like from your side
+
+`PROTOCOL-UPDATE-001` received. All five items are on `master` and nothing about them
+needs revisiting; the ledger read, the allowlist request form, the rename announcement,
+the indexing granularity rule from M4 and the write-protected mirror are all as you
+stated them.
+
+### The path now works end to end
+
+The first specification revision to travel the mechanical path merged **51 seconds** after
+the synchronization opened it, with no agent anywhere in the route. Expect a revision to
+appear in the repository within roughly one synchronization interval of your writing it.
+
+Two attempts before that one were refused by defects in our own guard — not by anything
+about the specification. The first read the paths in the form the version control tool
+prints them rather than the form it stores them in, so every document under `06 - Handoff`
+looked to it like a file outside the mirror; every one of those filenames carries an em
+dash. The second checked which identity *triggered* the synchronization rather than which
+identity *wrote* the commit, so a run started by an operator was refused. Both are fixed.
+Neither ever put the content in question.
+
+### If your revisions stop appearing
+
+This is the part that is now actionable for you, because the class no longer has a
+reviewing agent that would notice.
+
+A synchronization pull request whose checks fail stays open. No agent selects it, no agent
+may push to its branch, and recovering it is an operator action. Nothing on your side can
+distinguish that from "not synced yet" — but you can detect it, because you know what you
+wrote.
+
+The check is cheap: compare the newest `SPEC_CHANGELOG` revision you authored against the
+one visible in the mirror at
+
+```
+https://raw.githubusercontent.com/drevendev/trade_simulation/master/docs/spec/mirror/SPEC_CHANGELOG.md
+```
+
+If two or more of your revisions are missing from it, the pipeline is stalled rather than
+lagging. Say so in `ANSWERS_TO_IMPLEMENTER`, naming the newest revision you expect to see
+and the one you actually see. That entry is what reaches an operator. Do not treat it as
+an allowlist problem unless the missing content is a file you asked to have added — a
+stalled sync withholds everything equally, while an allowlist gap withholds exactly one
+path.
+
+We do not need you to do anything else about it. Reporting the gap is the whole ask; the
+recovery is ours and is written down now.
+
+### One asymmetry worth knowing
+
+The mirror is a snapshot, and merging one asserts only that it is confined, allowlisted,
+produced by the synchronization workflow and green. It asserts nothing about whether the
+content is current — Drive may have moved on, and that is neither visible from here nor a
+reason to refuse. If it has, the next synchronization proposes the newer snapshot.
+Merging an older one first is harmless and correct, so a revision briefly appearing
+"behind" is normal rather than a fault to report.

--- a/docs/zendev/MACHINE_PULL_REQUESTS.md
+++ b/docs/zendev/MACHINE_PULL_REQUESTS.md
@@ -78,7 +78,34 @@ The pull request stays open. That is the whole failure mode, and it is deliberat
 
 The selector prints every open pull request and why it was skipped, so a machine pull
 request sitting on a red gate appears in that log on every acceptor run rather than only
-in the pull request list.
+in the pull request list. That is visibility, not ownership. The owner is a person.
+
+### Recovering one
+
+**Repairing the gate does not release what it refused.** A pull request's checks ran
+against the workflow definition their run started with, and re-running a completed
+workflow replays that same definition rather than resolving the current one. Observed on
+#101: the guard step did not exist in the replayed run at all, because the run predated
+it. So the ordinary repair for human-authored work — fix CI, press re-run — is not
+available for a class nobody may push to.
+
+The procedure is:
+
+1. **Fix the cause and merge the fix**, as an ordinary policy change through the ordinary
+   path. A guard defect is a defect like any other.
+2. **Close the refused pull request**, with a comment recording why it was refused, what
+   fixed it, and the evidence that the fix accepts its head — running the repaired guard
+   against `refs/pull/<n>/head` locally is enough and takes a moment.
+3. **Let the producer propose again.** The branch still holds the content, so the next
+   sync opens a fresh pull request whose checks resolve the current definition. Dispatch
+   the sync rather than waiting, if the pipeline is stalled behind it.
+
+Do not force-push the branch, do not push a commit to unstick it, and do not merge it by
+hand. Each of those defeats a different one of the four conditions above, and the guard is
+built to refuse the result.
+
+This was worked out twice from first principles, under a stalled specification pipeline
+both times — #109 and #112 — which is why it is written here.
 
 ## Cost, and why this exists
 


### PR DESCRIPTION
Closes #117.

## Achieved outcome

The two expensive-to-reverse decisions this work established have ADRs; the recovery procedure for a refused machine pull request is written where the class is defined; the researcher is told the delivery path is proven and given the one signal they can act on.

## Tested revision

`8f17f6f6`.

## Changed artifacts

| File | Change |
| --- | --- |
| `docs/adr/0004-machine-generated-pull-requests.md` | New. The class, the bidirectional guard, the rejected alternatives, what merging one asserts, and the recovery cost. |
| `docs/adr/0005-derived-implementation-coverage.md` | New. The ledger, the `--self` reversal of #102 and the condition that decides between the two forms, the disposition of `status_lint`'s five rules, and the two known gaps (#115, and the un-refreshed `PARTIAL`). |
| `docs/zendev/MACHINE_PULL_REQUESTS.md` | A **Recovering one** subsection: the re-run mechanic, the three-step procedure, and the three things not to do. |
| `docs/spec/FEEDBACK_TO_RESEARCHER.md` | One appended entry. |

Documentation only. No script, workflow, ledger row or rule changes.

## Acceptance criteria

- [x] **Each ADR states context, decision, rejected alternative and observable consequences.** 0004 rejects a new required status check (it would block every open pull request), a cheaper review, and letting the ACCEPTOR merge the class by hand. 0005 rejects linting the hand-maintained document harder — which is what #97 did, and which leaves the reconciliation class intact — deriving status from the forge at render time, and storing `IN_PROGRESS`.
- [x] **0005 records that it reversed #102, and on what grounds.** The reversal is stated as conditional: self-citation was correctly forbidden while any pull request could write any row, and becomes safe once the row travels inside the pull request it cites. Both forms are recorded with the condition that selects between them, so neither reads as a correction of the other.
- [x] **The recovery section names the owner, the mechanic and the procedure.** Owner: a person. Mechanic: a replayed workflow resolves its original definition, observed on #101 where the guard step was absent from the replay. Procedure: fix, close with evidence, let the producer repropose. Plus the three prohibited shortcuts and which condition each defeats.
- [x] **The researcher entry is actionable and confirms receipt.** It acknowledges `PROTOCOL-UPDATE-001`, states the measured 51-second end-to-end merge, explains that a stalled sync is indistinguishable from lag on their side, and gives the concrete detection — compare their newest `SPEC_CHANGELOG` revision against the mirrored one, report a gap of two or more in `ANSWERS_TO_IMPLEMENTER`. It also tells them what *not* to conclude: a stall withholds everything equally, an allowlist gap withholds one path.
- [x] **No file outside `docs/` changes.**

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest discover -s scripts/tests` | passed | 151 tests at `8f17f6f6` |
| `python scripts/implementation_status.py --check` | passed | 12 ledger rows over 32 registry rows, unchanged |
| `python scripts/policy_guard.py` | passed | documentation only |
| `python scripts/machine_pr_guard.py` | passed | ordinary branch; no machine-owned path touched |
| `dotnet` / `npm` suites | not_run | no product file touched; measured by the required checks on this head |

## Not checked

Whether the recovery procedure is correct as written. It describes what was done twice and what worked both times, but it has not been followed *from the document* — the next refused machine pull request is the first test of it, and if the procedure is wrong that is where it shows.

Whether the researcher acts on the stall-detection instruction. Their side is out of reach; the durable record is the whole of what this can do, and the same content went to them out of band.

## Assumptions and unknowns

- **Assumption:** a replayed workflow always resolves its original definition. Observed once, on #101, where the replayed `policy-guard` job had no `machine-pr-guard` step. One observation, consistent with the documented behaviour, not a proof across event types.
- **Fact:** #109 and #112 were both recovered by closing and reproposing, and #116 then merged in 51 seconds. The procedure is a record of what happened, not a proposal.
- **Unknown:** whether ADR 0005's `PARTIAL` will hold up. It is safe because promotion is deliberate rather than a side effect of a merge elsewhere, but nothing yet forces a run to refresh a `PARTIAL` row when a later pull request advances it — `REQ-CONFIG-003` is the live instance, and the ADR records it as an open consequence rather than a solved one.

## Highest-risk area for review

ADR 0005's account of the `--self` reversal. If the condition it names is wrong — if there is a way for a row to reach `master` without its pull request merging — then the reversal is a hole rather than a refinement, and this ADR would be enshrining it. The argument is that the row and the citation are the same commit, so no such path exists; that is the sentence to disagree with.

## Remaining gate

None. #115 remains open as separate work, and is named in ADR 0005 as a known-wrong instruction rather than left implicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)