### PR TITLE
docs: Clarify ledger row update behavior for existing requirements

### DIFF
--- a/docs/zendev/AUTHOR_RUNBOOK.md
+++ b/docs/zendev/AUTHOR_RUNBOOK.md
@@ -167,9 +167,15 @@ hopeful pull request. Record the failure on the Issue and stop.
 
 ## 7. Hand off
 
-Record your evidence in the ledger **inside this same pull request**: append one row
-to `docs/spec/implementation_status.csv` for the requirement identifier your change
-resolves, then regenerate the table.
+Record your evidence in the ledger **inside this same pull request**: add or update
+exactly one row in `docs/spec/implementation_status.csv` for the requirement identifier
+your change resolves, then regenerate the table.
+
+Each requirement identifier has at most one ledger row. If a row for your requirement
+already exists (as `PARTIAL`, `BLOCKED`, `DEFERRED`, or `CONTESTED`), update it:
+change the `STATUS` to reflect your work, update the `PR` field to this pull request's
+number, and in the `EVIDENCE` cell name every pull request that contributed to that
+requirement (both prior work and this one). Then regenerate the table.
 
 ```sh
 python scripts/implementation_status.py


### PR DESCRIPTION
Closes #115

## Achieved outcome

Section 7 of AUTHOR_RUNBOOK.md now correctly instructs a run to update an existing ledger row (if one exists for the requirement identifier) rather than attempting to append a duplicate, which would be rejected by validation.

## Tested revision

97eaf05 (commit on claude/issue-115-ledger-row-update)

## Changed artifacts

- `docs/zendev/AUTHOR_RUNBOOK.md`: Section 7 expanded to clarify the "at most one row per identifier" invariant and the update behavior for existing rows. Added guidance to name all contributing pull requests in the evidence cell.

## Acceptance criteria

- [x] Section 7 states that a requirement identifier has at most one ledger row.
- [x] It says to update the existing row — status, pull request, evidence — rather than appending a second, and to name each contributing pull request in the evidence.
- [x] It names `python scripts/implementation_status.py --check` as the way to confirm the result.
- [x] No other file changes.

All four criteria met.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest discover -s scripts/tests` | passed | 153/153 tests passed |
| `python scripts/implementation_status.py --check` | passed | implementation-status: IMPLEMENTATION_STATUS.md matches 12 ledger row(s) over 32 registry row(s) |

## Not checked

TypeScript and C# builds are not applicable; this is a documentation-only change. Legacy builds remain green, canonical builds unaffected by runbook documentation.

## Assumptions and unknowns

None. The issue scope is clear and acceptance criteria are fully satisfied.

## Highest-risk area for review

The wording around "update the existing row" should be clear to future AUTHOR runs encountering this case. Review for clarity of instruction.

## Remaining gate

None. No mandatory work remains; all acceptance criteria met.