### PR TITLE
Say who decides each section 2 gate, and why the expensive one stays

### DIFF
--- a/docs/zendev/ACCEPTOR_RUNBOOK.md
+++ b/docs/zendev/ACCEPTOR_RUNBOOK.md
@@ -85,6 +85,55 @@ Post REQUEST_CHANGES and stop if any of these is true:
 - an invariant test (money conservation, stock conservation, non-negative stock or
   balance) was relaxed without an explicit, justified Decision record.
 
+### Who decides each of these
+
+Two of them are already decided before you see the pull request, and six are yours. A
+gate belonging to neither would be the worst outcome — the contract would make it look
+enforced while nothing enforced it — so each is named here.
+
+| Gate | Decided by |
+| --- | --- |
+| Policy paths mixed with product paths | `scripts/policy_guard.py`, required |
+| Credentials, tokens, and local machine paths | `scripts/policy_guard.py`, required |
+| No linked Issue, or the Issue lacks a required section | you |
+| Label axes on the Issue | you |
+| The handoff record is incomplete | you |
+| The diff touches files outside the Issue's declared scope | you |
+| Tests deleted, disabled, or weakened | you |
+| An invariant test relaxed without a Decision record | you |
+
+**For the two a check decides: read the check, do not re-derive it.** `policy-guard` runs
+on every pull request and its result is on the checks tab. Restating its finding costs a
+run and invites you to disagree with a control you cannot overrule. This does not excuse
+you from reading the diff — you read it for everything else in this section, and a guard
+that refused nothing is not a statement that there was nothing to find.
+
+**For the six that are yours, the reason no check decides them** — each is a property of
+the gate, not a gap someone has yet to fill:
+
+- *Issue completeness and label axes* could be checked, and no run has yet failed them.
+  A check here would encode a shape the Issue standard already states, and would have to
+  be revised in step with it. They remain yours until a run gets one wrong.
+- *Handoff completeness* splits: whether every section is present is mechanical, whether
+  the evidence honestly separates what was measured from what was assumed is the thing
+  you exist to judge. Checking the first half alone would report a complete handoff for a
+  record that says nothing.
+- *Declared scope* cannot be checked while `Scope` is prose. Making it checkable means
+  every Issue carrying a machine-readable path set — a tax on every future task for a
+  gate you close by reading the diff.
+- *Tests deleted or disabled* is mechanically visible in its crudest forms — a removed
+  file, `it.skip`, a fall in the discovered count — but a falling count is also what a
+  legitimate consolidation looks like, and *weakened* is invisible to any count. A
+  loosened assertion, a narrowed case, an `expect` that no longer distinguishes pass from
+  fail: to a check these are indistinguishable from a good test.
+- *An invariant relaxed without justification* is a judgement about whether a relaxation
+  is warranted. A check could report that an invariant suite changed with no Decision
+  record nearby, but reporting is not refusing, and a control that never refuses teaches
+  its reader to scroll past it.
+
+If you find a defect in one of the six, say so in your verdict and open an Issue for the
+check. An observed failure is what moves a gate; symmetry is not.
+
 ## 2a. Machine-generated pull requests are not yours
 
 `spec-sync.yml` copies the allowlisted specification from Drive and proposes it as a
@@ -138,6 +187,20 @@ gh pr diff <number>
 
   A canonical TypeScript change that leaves the legacy .NET build red does not satisfy
   `REQ-MIGRATION-003`, however green its own suite is.
+
+  **This re-execution is deliberate, and it is the most expensive thing you do.** The
+  required checks already ran these commands at this revision, so re-running them proves
+  nothing about the code — it proves something about the checks. What it defends against
+  is a pull request that edits the workflow that judges it: a diff can make a check green
+  by changing what the check runs, and only an independent execution notices. Every other
+  gate in this runbook trusts the checks tab; this one does not, on purpose.
+
+  It was proposed on 2026-09-05 to make this conditional — mandatory when the diff
+  touches build or test configuration, and otherwise satisfied by the measured green
+  check. The operator deferred that trade rather than take it blind. **Revisit it when
+  acceptance latency becomes a measured bottleneck** — when pull requests are observed
+  waiting on review turns rather than on authoring. While the queue clears in minutes,
+  the trade buys speed that is not needed at a cost that is real.
 - Judge the diff against the acceptance criteria of the Issue, one by one. A criterion
   without evidence is not met.
 - Confirm the claimed requirement IDs are actually implemented, not merely mentioned.


### PR DESCRIPTION
Closes #123. Part of #89, satisfying its first acceptance criterion by the recording route rather than by building six checks.

## Achieved outcome

Each of section 2's eight gates is marked as decided by a named check or as the role's judgement, with the reason for the latter. The two `policy_guard` already decides say so, and the role is told to read the check instead of re-deriving it. Section 3's manual re-execution is recorded as a deliberate defence with its deferral and the condition for revisiting.

## Tested revision

`a98bd612`.

## Changed artifacts

`docs/zendev/ACCEPTOR_RUNBOOK.md` only — a **Who decides each of these** subsection under section 2, and a paragraph under section 3's re-execution step. Documentation; no rule changes.

## Acceptance criteria

- [x] **All eight gates marked.** Two to `policy_guard`, six to the role, in one table.
- [x] **Every judgement gate carries a reason about the gate.** Declared scope cannot be checked while `Scope` is prose without taxing every future Issue with a glob list. A falling test count is indistinguishable from a legitimate consolidation, and a weakened assertion is invisible to any count. An invariant relaxation is a judgement about whether the relaxation is warranted; a check could report but not refuse, and a control that never refuses teaches its reader to scroll past it. Issue completeness and label axes are checkable and simply have never failed — stated as such, with the trigger that would move them.
- [x] **The checked gates instruct citing, not re-deriving**, and the obligation to read the diff is explicitly preserved: "a guard that refused nothing is not a statement that there was nothing to find".
- [x] **Section 3 records what the re-execution defends against** — a diff that turns a check green by editing what the check runs — **and the revisit condition**: when acceptance latency becomes a measured bottleneck, which it is not while the queue clears in minutes.
- [x] **No behavioural change.** Every refusal in section 2 is still a refusal; the table says who decides, not whether.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest discover -s scripts/tests` | passed | 153 tests at `a98bd612` |
| `python scripts/implementation_status.py --check` | passed | 12 ledger rows over 32 registry rows, unchanged |
| `python scripts/policy_guard.py` | passed | documentation only |
| `dotnet` / `npm` suites | not_run | no product file touched; measured by the required checks on this head |

## Not checked

Whether the role actually stops re-deriving `policy_guard`'s findings. That shows in the next few verdicts, not here, and the failure mode if it does not is wasted turns rather than a wrong decision.

Whether recording six gates as judgement is the right call rather than a deferral dressed as a decision. The argument is that none has an observed defect and each has a property that makes a check weak — but #89's own standard says a check never observed refusing anything is evidence of nothing, and that cuts against building them as much as against skipping them. The disposition is stated so it can be reversed on evidence: one defect in any of the six is the trigger.

## Assumptions and unknowns

- **Assumption:** the two `policy_guard` gates are genuinely fully decided by it, so citing is safe. It refuses eight credential shapes plus both home-directory forms, and the policy/product split by prefix — that is the whole of what section 2 states for those two rows.
- **Fact:** the deferral of section 3's conditional re-execution is an operator decision taken on 2026-09-05, recorded here rather than inferred.
- **Unknown:** whether acceptance latency will ever become the bottleneck the revisit condition names. It has not been so far; authoring and conflict repair have dominated.

## Highest-risk area for review

The instruction to cite `policy-guard` rather than re-derive it. If it reads as licence to skip reading the diff, it removes the reading on which the six judgement gates depend. The paragraph says the opposite explicitly, and that sentence is the one to check.

## Remaining gate

None. #121 and #122 carry the two checks worth building and are `status:ready` for the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)