### PR TITLE
Refuse a branch whose base has moved, as a check rather than a setting

### DIFF
--- a/docs/zendev/ACCEPTOR_RUNBOOK.md
+++ b/docs/zendev/ACCEPTOR_RUNBOOK.md
@@ -177,6 +177,12 @@ gh pr diff <number>
   base moved. Read it before you judge anything else — a conflicting branch cannot be
   accepted whatever its contents, and discovering that after forming a verdict is how
   a run comes to post two contradictory verdicts on one head.
+
+  It fails on two conditions, not one. A branch that **conflicts** cannot merge. A
+  branch that is merely **behind** merges cleanly and is still refused, because its
+  green checks were measured against a base that no longer exists: they say nothing
+  about what would actually land. Two changes can be textually independent and
+  semantically incompatible, and that combination is invisible to every other gate.
 - Check out the head revision and run the verification commands yourself — both
   runtimes, whichever one the diff touched:
 

--- a/scripts/mergeability.py
+++ b/scripts/mergeability.py
@@ -41,12 +41,31 @@ CONTEXT = "mergeability"
 MAX_DESCRIPTION = 140
 
 
+# The base moved and this branch has not caught up. It merges cleanly, but its green
+# checks were measured against a base that no longer exists, so they say nothing about
+# what would actually land — the case where two changes are textually independent and
+# semantically not.
+#
+# Reported as a failure rather than left to branch protection's "require branches to be
+# up to date". That setting blocks the merge and produces no check, so the branch shows
+# nothing red: selection would keep offering it and the AUTHOR's own "open pull request
+# with a failing required check" rule would match nothing. It would belong to no queue,
+# which is the trap this control plane has already had to close once. A red check
+# blocks the same merge and routes the work.
+STALE_BASE = "behind"
+
+
 def classify(mergeable, mergeable_state):
     """Map the API's answer to (state, description). Pure."""
     if mergeable is False:
         return (
             "failure",
             f"conflicts with the base branch ({mergeable_state}); rebase and push",
+        )
+    if mergeable is True and mergeable_state == STALE_BASE:
+        return (
+            "failure",
+            "the base has moved since this branch was measured; update the branch",
         )
     if mergeable is True:
         return ("success", f"merges cleanly into the base branch ({mergeable_state})")

--- a/scripts/tests/test_mergeability.py
+++ b/scripts/tests/test_mergeability.py
@@ -35,10 +35,26 @@ class ClassifyTests(unittest.TestCase):
         # `blocked` means another gate has not passed — a required check, a review.
         # That is not this check's question, and answering it here would make two
         # different failures indistinguishable on the pull request.
-        for api_state in ("blocked", "unstable", "behind", "has_hooks"):
+        for api_state in ("blocked", "unstable", "has_hooks"):
             with self.subTest(api_state=api_state):
                 state, _ = mergeability.classify(True, api_state)
                 self.assertEqual(state, "success")
+
+    def test_a_branch_behind_its_base_fails(self):
+        # It merges cleanly, and its green checks were measured against a base that no
+        # longer exists. #88 and #91 were textually independent and semantically not:
+        # the merge result did not typecheck.
+        state, description = mergeability.classify(True, "behind")
+        self.assertEqual(state, "failure")
+        self.assertIn("update the branch", description)
+
+    def test_being_behind_is_reported_rather_than_left_to_branch_protection(self):
+        # The alternative — GitHub's "require branches to be up to date" — blocks the
+        # merge and produces no check. Nothing shows red, so selection keeps offering
+        # the pull request and the AUTHOR's "failing required check" rule matches
+        # nothing: it belongs to no queue. This assertion is the difference.
+        self.assertEqual(mergeability.classify(True, "behind")[0], "failure")
+        self.assertNotEqual(mergeability.classify(True, "behind")[0], "success")
 
     def test_every_description_fits_the_api_limit(self):
         for mergeable in (True, False, None):


### PR DESCRIPTION
# Pull request

## Outcome

`mergeability` now fails on two conditions instead of one: a branch that **conflicts**,
and a branch that is merely **behind** its base.

This is the second half of "require branches to be up to date" — implemented as a check
rather than as the branch-protection setting, for a reason worth reading before merging.

## Why not the setting

The obvious remedy is GitHub's `strict` flag, *require branches to be up to date before
merging*. It is the wrong instrument here.

`strict` blocks the merge and **produces no check**. Nothing shows red. So:

- selection keeps offering the pull request, because no gate is failing;
- the AUTHOR's ladder — *an open pull request of yours with a failing required check —
  fix it* — matches nothing.

The change belongs to no queue. That is precisely the trap closed a few hours ago in
#106 for conflicting branches, and turning `strict` on would reopen it in a new shape:
same invisibility, different cause.

A red check blocks the same merge **and** routes the work. So `strict` stays off, as
redundant, and `behind` becomes a mergeability failure.

## Why `behind` matters at all

A branch behind its base merges cleanly, and its green checks were measured against a
base that no longer exists — so they describe something other than what would land.

Not hypothetical. #88 and #91 were textually independent and semantically incompatible:
#88 introduced code casting seed types to `Record<string, unknown>` while #91 narrowed
exactly those types. The merge result did not typecheck. No other gate can see that
combination, because each branch is fine on its own.

## Scope

- `scripts/mergeability.py` — one condition, one message, the reasoning inline.
- `scripts/tests/test_mergeability.py` — two negative controls.
- `docs/zendev/ACCEPTOR_RUNBOOK.md` — §3 says the status fails on two conditions.

`blocked`, `unstable` and `has_hooks` still pass: they mean some *other* gate is
unsatisfied, which is that gate's business, not this one's.

## Verification

- [x] `python -m unittest discover -s scripts/tests -v` — 155 tests pass (153 before)
- [x] `python scripts/policy_guard.py --base origin/master` — passed over 3 files
- [x] Classifier exercised directly across every state:

```
clean    -> success    behind   -> failure ("update the branch")
dirty    -> failure    blocked  -> success
unstable -> success    unknown  -> pending
```

## Evidence and uncertainty

- **Established:** #88 and #91's incompatibility and the typecheck failure it produced;
  that `strict` blocks without producing a check.
- **Reasoned:** that `behind` should be red unconditionally rather than only while some
  setting is on. It follows from the check's own claim — it answers "can this merge
  now" — and a stale base means the answer is no on the evidence available. An operator
  who disagrees would be arguing that stale green checks are good enough, which is the
  position this whole series rejects.
- **Cost, and it is real:** every merge to `master` now turns every other open pull
  request red until its author updates it. On a loop that merges two or three an hour
  with a handful open, that is author runs spent rebasing rather than implementing. It
  is the price of never merging a stale measurement, and it is measurable — if the
  ledger starts showing rebase runs dominating, this is the change to revisit.
- **Not done:** nothing shortens the rebase loop. GitHub's "update branch" could be
  automated for a behind-but-clean branch, which would remove most of that cost. Worth
  doing if the cost shows up; not worth building before it does.

## Review focus

The cost paragraph above. Everything else here is a straightforward correctness gain;
that one is a trade, and it is the reviewer's call whether the throughput hit is
acceptable before this merges rather than after.

## Completion

- [x] Documentation synchronized — the runbook states both failure conditions.
- [x] No private data, credentials, or machine paths added.
- [x] No ADR — this extends an existing check.
- [ ] **Operator action still outstanding:** adding `mergeability` to the required-check
      list is a repository setting and is not part of this pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
