### PR TITLE
Regenerate the coverage table inside the sync that moves the registry

### DIFF
--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -109,6 +109,26 @@ jobs:
           mkdir -p docs/spec
           cp -a "${RUNNER_TEMP}/mirror" docs/spec/mirror
 
+      # The coverage table is generated from the registry this sync just replaced, and
+      # a check compares the two. A mirror that brought a changed registry and left the
+      # table alone would carry a snapshot contradicting its own source, fail that
+      # check, and be unmergeable — and unfixable from outside, because on `master` the
+      # old registry and the old table agree. The regeneration has to happen here, in
+      # the pull request that moves the registry.
+      #
+      # A failure is warned about rather than fatal, on purpose. The generator refuses
+      # when the registry and the ledger disagree — a ledger row for an identifier the
+      # specification dropped, say — and that disagreement is worth seeing on the pull
+      # request, where the content that caused it is visible, rather than in a red sync
+      # run nobody opens. The stale table then fails the check on the pull request,
+      # which is the outcome we want: proposed, refused, and legible.
+      - name: Regenerate the coverage table from the new registry
+        run: |
+          python scripts/implementation_status.py || {
+            echo "::warning::could not regenerate docs/spec/IMPLEMENTATION_STATUS.md;"
+            echo "::warning::the mirror will be proposed and its check will refuse it."
+          }
+
       - name: Report what arrived
         run: |
           set -euo pipefail
@@ -138,7 +158,9 @@ jobs:
           token: ${{ secrets.ZENDEV_PAT || github.token }}
           branch: spec-mirror
           base: master
-          add-paths: docs/spec/mirror
+          add-paths: |
+            docs/spec/mirror
+            docs/spec/IMPLEMENTATION_STATUS.md
           commit-message: "spec: sync specification mirror from Drive"
           title: "spec: sync specification mirror from Drive"
           labels: |

--- a/docs/zendev/MACHINE_PULL_REQUESTS.md
+++ b/docs/zendev/MACHINE_PULL_REQUESTS.md
@@ -22,12 +22,37 @@ check on every pull request — not by a reader.
 
 The classes today:
 
-| Branch | Produced by | Owns | Allowlist |
-| --- | --- | --- | --- |
-| `spec-mirror` | `.github/workflows/spec-sync.yml` | `docs/spec/mirror/**` | `docs/zendev/spec-mirror-allowlist.txt` |
+| Branch | Produced by | Owns | Also regenerates | Allowlist |
+| --- | --- | --- | --- | --- |
+| `spec-mirror` | `.github/workflows/spec-sync.yml` | `docs/spec/mirror/**` | `docs/spec/IMPLEMENTATION_STATUS.md` | `docs/zendev/spec-mirror-allowlist.txt` |
 
 Adding a class is a policy change to the guard, its tests and this table, reviewed like
 any other policy change and accepted by a person.
+
+### Owning a path is not the same as regenerating one
+
+The fourth column exists because a machine class can be blocked by its own correctness.
+The coverage table is rendered from the registry the mirror replaces, and a check
+compares the two, so a sync that changed a registry status and left the table alone
+proposed a snapshot contradicting its own source. That pull request could not merge —
+and could not be repaired from anywhere else either, because on `master` the old
+registry and the old table still agreed. The contradiction existed only inside the
+proposal. It happened, on #125, and it would have happened on every sync that moved a
+status.
+
+So the producing workflow regenerates the derived file in the same pull request, and
+the guard permits that one named file alongside the roots.
+
+**Regenerating is not owning.** A path in the fourth column is not machine-exclusive:
+an AUTHOR adding a ledger row regenerates the same table, and a rule that made the file
+machine-owned would refuse every one of those pull requests. Only the third column is
+enforced against other branches.
+
+Nor does permitting the file assert its contents. The guard checks paths; the
+generator's own `--check` runs in CI over the same diff and refuses a table that does
+not match its sources. A sync writing a fabricated table would pass this guard and fail
+that check, which is the correct division: this one answers *may these paths change*,
+that one answers *is the derived file derived*.
 
 ## The gate runs in both directions
 

--- a/scripts/machine_pr_guard.py
+++ b/scripts/machine_pr_guard.py
@@ -8,8 +8,10 @@ a code pull request is waiting for.
 This guard is that predicate. It decides two things and nothing else:
 
 1. A pull request whose head branch belongs to a machine class must stay inside the
-   paths that class owns, must satisfy that class's own allowlist, and its head commit
-   must be *committed* by the workflow identity that produces it. The author of that
+   paths that class owns — plus any file generated from them, which the producing
+   workflow has to regenerate in the same pull request or ship a snapshot that
+   contradicts its own sources — must satisfy that class's own allowlist, and its head
+   commit must be *committed* by the workflow identity that produces it. The author of that
    commit records who triggered the run and may be a person; the committer records what
    wrote it, and only that answers the question this guard is asking.
 2. Nobody else may write those paths. An agent branch — or a person — editing
@@ -44,6 +46,15 @@ class MachineClass:
     # Path prefixes this class owns. Nothing else may appear in its diff, and no other
     # branch may touch them.
     roots: tuple[str, ...]
+    # Files derived from the roots that the producing workflow must regenerate in the
+    # same pull request, because a check compares them against their sources.
+    #
+    # These are *not* owned. An ordinary branch may write them too — an AUTHOR adding a
+    # ledger row regenerates the same table — so they are excluded from the
+    # exclusive-write rule below and only widen what this class may carry. Nothing here
+    # asserts the generated content is right: the generator's own `--check` runs in CI
+    # over the same diff and refuses a table that does not match its sources.
+    generated: tuple[str, ...]
     # The commit identity the producing workflow writes under — the *committer*, which
     # is what wrote the bytes. Not the author: `peter-evans/create-pull-request`
     # defaults the author to whoever triggered the run, so an operator dispatching the
@@ -60,6 +71,7 @@ MACHINE_CLASSES = (
         branch="spec-mirror",
         producer=".github/workflows/spec-sync.yml",
         roots=("docs/spec/mirror/",),
+        generated=("docs/spec/IMPLEMENTATION_STATUS.md",),
         committer="github-actions[bot]",
         allowlist="docs/zendev/spec-mirror-allowlist.txt",
     ),
@@ -122,11 +134,17 @@ def check(head_ref: str, paths, allowlist_text, tip_committer):
             )
         return violations
 
-    outside = sorted(p for p in paths if not p.startswith(cls.roots))
+    permitted = sorted(p for p in paths if not p.startswith(cls.roots))
+    outside = [p for p in permitted if p not in cls.generated]
     if outside:
         violations.append(
-            "%s must stay inside %s; it also changed:\n  %s"
-            % (cls.branch, ", ".join(cls.roots), "\n  ".join(outside))
+            "%s must stay inside %s (or regenerate %s); it also changed:\n  %s"
+            % (
+                cls.branch,
+                ", ".join(cls.roots),
+                ", ".join(cls.generated) or "nothing",
+                "\n  ".join(outside),
+            )
         )
 
     if cls.allowlist is not None:

--- a/scripts/tests/test_machine_pr_guard.py
+++ b/scripts/tests/test_machine_pr_guard.py
@@ -74,6 +74,32 @@ class MirrorBranchTests(unittest.TestCase):
             [],
         )
 
+    def test_the_generated_coverage_table_may_ride_along(self):
+        # The table is rendered from the registry this branch replaces, and a check
+        # compares the two. Without this, a sync that changed any registry status
+        # produced a pull request contradicting its own source — unmergeable, and
+        # unfixable from outside, because on master the old registry and the old table
+        # still agree.
+        self.assertEqual(
+            self.check(
+                [
+                    MIRROR + "REQUIREMENTS_REGISTRY.csv",
+                    "docs/spec/IMPLEMENTATION_STATUS.md",
+                ]
+            ),
+            [],
+        )
+
+    def test_the_exception_covers_that_file_and_nothing_near_it(self):
+        # A named file, not a prefix. The ledger it is rendered from lives one
+        # directory up from the mirror and is written by AUTHOR runs; a sync that
+        # rewrote it would be editing the evidence rather than the specification.
+        violations = self.check(
+            [MIRROR + "SPEC_INDEX.md", "docs/spec/implementation_status.csv"]
+        )
+        self.assertEqual(len(violations), 1)
+        self.assertIn("docs/spec/implementation_status.csv", violations[0])
+
     def test_a_path_outside_the_mirror_is_refused(self):
         violations = self.check(
             [MIRROR + "SPEC_INDEX.md", ".github/workflows/spec-sync.yml"]
@@ -136,6 +162,20 @@ class OrdinaryBranchTests(unittest.TestCase):
                     "docs/spec/IMPLEMENTATION_STATUS.md",
                     "docs/spec/FEEDBACK_TO_RESEARCHER.md",
                 ]
+            ),
+            [],
+        )
+
+    def test_an_ordinary_branch_may_still_write_the_generated_table(self):
+        # The exception widens what the mirror may carry; it claims nothing. An AUTHOR
+        # adding a ledger row regenerates the same table, and a rule that made the file
+        # machine-owned would refuse every one of those pull requests.
+        self.assertEqual(
+            guard.check(
+                "claude/issue-42-example",
+                ["docs/spec/implementation_status.csv", "docs/spec/IMPLEMENTATION_STATUS.md"],
+                REAL_ALLOWLIST,
+                None,
             ),
             [],
         )


### PR DESCRIPTION
# Pull request

## Outcome

`spec-sync.yml` regenerates `docs/spec/IMPLEMENTATION_STATUS.md` in the same pull
request that moves the registry, and `machine_pr_guard.py` permits that one named file
alongside the mirror roots.

This unblocks the mirror pipeline, which is currently deadlocked with #125 in it.

## The deadlock

The coverage table is rendered from the mirrored registry, and a check compares the two.
A sync bringing a registry with any changed status therefore proposes a snapshot that
contradicts its own source:

```
FAIL: test_the_rendered_table_is_current
'… | `READY`  | `NOT_STARTED` …'  !=  '… | `REVIEW` | `NOT_STARTED` …'
```

The check refuses it, and **nothing outside can repair it**: on `master` the old
registry and the old table still agree, so there is no failing state to fix there. The
contradiction exists only inside the proposal. Every future sync that moved a status
would have hit this, and the specification would have stopped flowing into the
repository.

Nothing here was wrong on its own. The generated table refused to drift from its
source; the machine guard refused a diff reaching outside the mirror roots; the ACCEPTOR
is not permitted near a mirror at all. Three correct controls, one missing step between
them.

## The change

**The producer regenerates what it invalidates.** One step in `spec-sync.yml` after the
mirror is staged, and `docs/spec/IMPLEMENTATION_STATUS.md` added to `add-paths`.

**The guard grows a `generated` field**, distinct from `roots`:

| | `roots` | `generated` |
| --- | --- | --- |
| The class may write it | yes | yes |
| Other branches are refused | **yes** | no |
| Allowlist applies | yes | no |

**Regenerating is not owning.** An AUTHOR adding a ledger row regenerates the same
table; a rule making the file machine-owned would refuse every one of those pull
requests. There is a negative control for exactly that.

**Permitting the path asserts nothing about the contents.** The generator's own
`--check` runs in CI over the same diff. This guard answers *may these paths change*;
that check answers *is the derived file derived*. A sync writing a fabricated table
passes here and fails there.

## The step warns rather than fails

The generator refuses when the registry and the ledger disagree — a ledger row for an
identifier the specification dropped, say. That disagreement belongs on the pull
request, where the content causing it is visible, not in a red sync run nobody opens.
The stale table then fails its check there: proposed, refused, legible.

## Verification

- [x] `python -m unittest discover -s scripts/tests -v` — 156 tests pass (153 before)
- [x] `python scripts/policy_guard.py --base origin/master` — passed over 4 files
- [x] `spec-sync.yml` parses as YAML
- [x] **Against the stuck branch itself.** In a worktree at `origin/spec-mirror`: the
      suite fails on `test_the_rendered_table_is_current`; after `python
      scripts/implementation_status.py` it passes (153/153), and `git status` shows
      exactly one extra file — the one this change permits.
- [x] **The guard, on the real path set.** #125's three changed paths pass; the same
      three plus the regenerated table pass; an ordinary branch writing that table
      passes.

## Evidence and uncertainty

- **Established:** the exact failing assertion on `origin/spec-mirror`; that it passes
  after regeneration; that `master`'s own table and registry agree, which is why the
  fix cannot live outside the mirror pull request.
- **Reasoned:** that this would recur on every status-moving sync. It follows from the
  generator being a pure function of the registry and the ledger, which its module
  contract states and which the `--check` mode relies on.
- **Not done:** #125 itself is not repaired by this. It carries a stale table and will
  keep failing until the next sync regenerates it — the sync replaces the branch
  wholesale, so one run after this merges is enough. Nothing needs doing by hand.
- **Scope not taken:** other derived files. `generated` is a tuple because this pattern
  will recur, but nothing else is derived from the mirror today, and adding speculative
  entries would widen what a machine branch may carry for no live reason.

## Review focus

Whether `generated` is drawn narrowly enough. It is a list of exact file paths, not
prefixes, and it is deliberately outside the exclusive-write rule — but it *is* a
widening of what a machine branch may carry, and that is the direction worth reading
carefully. The second negative control asserts the neighbouring file
`docs/spec/implementation_status.csv`, the ledger AUTHOR runs write, is still refused.

## Completion

- [x] Documentation synchronized — the class table gains the column and the reasoning.
- [x] No private data, credentials, or machine paths added.
- [x] No ADR — this closes a gap between existing controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
