### PR TITLE
Decode every control-plane subprocess as UTF-8, not by locale

### DIFF
--- a/scripts/mergeability.py
+++ b/scripts/mergeability.py
@@ -76,8 +76,14 @@ def classify(mergeable, mergeable_state):
 
 
 def _gh(args):
+    # UTF-8 explicitly, not by locale. Without it Python decodes with the platform's
+    # preferred encoding, which on a Windows console is cp1252: a comment or title
+    # holding an em dash then raises inside the reader thread, `stdout` comes back as
+    # None, and the caller fails several frames later on something that looks unrelated.
+    # The runner's UTF-8 locale hides this, so it only ever appears off the runner —
+    # where the control plane is developed. Same fix as machine_pr_guard.py carries.
     return subprocess.run(
-        ["gh", *args], check=True, capture_output=True, text=True
+        ["gh", *args], check=True, capture_output=True, text=True, encoding="utf-8"
     ).stdout
 
 

--- a/scripts/schedule_watchdog.py
+++ b/scripts/schedule_watchdog.py
@@ -39,7 +39,14 @@ def api(path: str, *, payload: dict | None = None):
         command += ["--method", "POST", "--input", "-"]
         data = json.dumps(payload)
     result = subprocess.run(
-        command, input=data, capture_output=True, text=True, timeout=30
+        command,
+        input=data,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        # See the note in machine_pr_guard.py: decoding by locale turns a non-ASCII
+        # byte in a forge response into a failure several frames away from its cause.
+        encoding="utf-8",
     )
     if result.returncode:
         # Never echo token-bearing command environments or arbitrary server output.

--- a/scripts/select_review_target.py
+++ b/scripts/select_review_target.py
@@ -192,8 +192,14 @@ def choose(candidates):
 
 
 def _gh(args):
+    # UTF-8 explicitly, not by locale. Without it Python decodes with the platform's
+    # preferred encoding, which on a Windows console is cp1252: a comment or title
+    # holding an em dash then raises inside the reader thread, `stdout` comes back as
+    # None, and the caller fails several frames later on something that looks unrelated.
+    # The runner's UTF-8 locale hides this, so it only ever appears off the runner —
+    # where the control plane is developed. Same fix as machine_pr_guard.py carries.
     return subprocess.run(
-        ["gh", *args], check=True, capture_output=True, text=True
+        ["gh", *args], check=True, capture_output=True, text=True, encoding="utf-8"
     ).stdout
 
 

--- a/scripts/status_lint.py
+++ b/scripts/status_lint.py
@@ -99,8 +99,14 @@ def lint(rows, merged_pull_numbers, requirements_claimed_by_merged, self_pull=No
 
 
 def _gh(args):
+    # UTF-8 explicitly, not by locale. Without it Python decodes with the platform's
+    # preferred encoding, which on a Windows console is cp1252: a comment or title
+    # holding an em dash then raises inside the reader thread, `stdout` comes back as
+    # None, and the caller fails several frames later on something that looks unrelated.
+    # The runner's UTF-8 locale hides this, so it only ever appears off the runner —
+    # where the control plane is developed. Same fix as machine_pr_guard.py carries.
     return subprocess.run(
-        ["gh", *args], check=True, capture_output=True, text=True
+        ["gh", *args], check=True, capture_output=True, text=True, encoding="utf-8"
     ).stdout
 
 

--- a/scripts/tests/test_subprocess_encoding.py
+++ b/scripts/tests/test_subprocess_encoding.py
@@ -1,0 +1,79 @@
+"""Every subprocess in the control plane decodes as UTF-8, not by locale.
+
+`subprocess.run(..., text=True)` without `encoding` decodes with the platform's
+preferred encoding. On the hosted runner that is UTF-8, so this is invisible there. On
+a Windows console it is cp1252, and a single non-ASCII byte — an em dash in a pull
+request title, a mirrored handoff filename — raises inside the reader thread. The
+exception does not propagate: `stdout` comes back as `None` and the caller fails
+several frames later on something that looks unrelated. `check=True` does not fire,
+because the process exited fine.
+
+This was found twice. `machine_pr_guard.py` learned it in #111 after the guard refused
+the first real mirror. Three other scripts had the same call shape and nobody looked,
+because the runner never showed it — and the runner is not where the control plane is
+developed or debugged.
+
+A rule enforced in one file is a habit. This makes it a property of the directory.
+"""
+
+import ast
+import pathlib
+import unittest
+
+SCRIPTS = pathlib.Path(__file__).resolve().parents[1]
+
+
+def subprocess_run_calls(tree):
+    """Every `subprocess.run(...)` call node in a parsed module."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "run"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "subprocess"
+        ):
+            yield node
+
+
+class SubprocessEncodingTests(unittest.TestCase):
+    def modules(self):
+        return sorted(SCRIPTS.glob("*.py"))
+
+    def test_every_subprocess_run_pins_the_encoding(self):
+        offenders = []
+        for path in self.modules():
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for call in subprocess_run_calls(tree):
+                keywords = {k.arg for k in call.keywords}
+                if "encoding" not in keywords:
+                    offenders.append(f"{path.name}:{call.lineno}")
+        self.assertEqual(
+            offenders,
+            [],
+            "subprocess.run without encoding= decodes by locale; "
+            f"pin encoding=\"utf-8\" at: {offenders}",
+        )
+
+    def test_the_scan_actually_finds_calls(self):
+        # Without this the test above passes on an empty set — the vacuous-pass shape
+        # this repository keeps rediscovering. Every module that shells out must be
+        # visible to the walker.
+        found = sum(
+            len(list(subprocess_run_calls(ast.parse(p.read_text(encoding="utf-8")))))
+            for p in self.modules()
+        )
+        self.assertGreaterEqual(found, 4, "the walker found almost no subprocess calls")
+
+    def test_a_call_without_encoding_is_detected(self):
+        # Negative control on the detector itself, not on the tree: prove it would
+        # object if a bare call appeared.
+        tree = ast.parse("import subprocess\nsubprocess.run(['gh'], text=True)\n")
+        call = next(subprocess_run_calls(tree))
+        self.assertNotIn("encoding", {k.arg for k in call.keywords})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Pull request

## Outcome

Four `subprocess.run` call sites pin `encoding="utf-8"`, and a test makes that a
property of `scripts/` rather than a habit in one file.

## The defect

`subprocess.run(..., text=True)` without `encoding` decodes with the platform's
preferred encoding. On the runner that is UTF-8, so this is invisible in CI. On a
Windows console it is cp1252, and one non-ASCII byte — an em dash in a pull request
title — raises **inside the reader thread**:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 2382
TypeError: the JSON object must be str, bytes or bytearray, not NoneType
```

The exception does not propagate. `stdout` comes back as `None`, `check=True` stays
quiet because the process exited fine, and the caller fails several frames later on
something that looks unrelated.

Found by running `select_review_target.py` locally: it died on a comment instead of
choosing a target.

## Why a test and not four edits

This is the second time. `machine_pr_guard.py` learned it in #111, after the guard
refused the first real mirror for being outside a directory it was inside. Three
sibling scripts had the identical call shape and nobody looked — because the runner
never shows it, and the runner is not where this control plane is developed or
debugged.

Four edits fix four call sites. The test fixes the fifth, which someone will write.

It walks each module's AST and refuses any `subprocess.run` without `encoding`, and it
carries two controls of its own:

- **the walker finds calls at all**, so it cannot pass vacuously over an empty set —
  the failure shape this repository keeps rediscovering;
- **the detector objects to a bare call**, proved against a synthetic one.

## Scope

- `scripts/mergeability.py`, `scripts/select_review_target.py`,
  `scripts/status_lint.py`, `scripts/schedule_watchdog.py` — one keyword each.
- `scripts/tests/test_subprocess_encoding.py` — the directory-wide rule.

No behaviour changes on the runner, where the locale was already UTF-8.

## Verification

- [x] `python -m unittest discover -s scripts/tests -v` — 161 tests pass (158 before)
- [x] `python scripts/policy_guard.py --base origin/master` — passed over 5 files
- [x] **The selector runs on Windows again**, correctly skipping both open pull
      requests (`#125` machine-generated, `#126` already judged) and reporting
      `target=none`. It crashed before this change.
- [x] **Negative control observed firing:** removing the keyword from one file fails
      the suite with `pin encoding="utf-8" at: ['mergeability.py:85']`.

## Evidence and uncertainty

- **Established:** the crash and its two-stage shape; that the runner's locale is UTF-8,
  which is why CI is green either way; that #111 fixed the same class in one file.
- **Reasoned:** that no other locale-dependent decoding lurks in these scripts. The
  test covers `subprocess.run` only — `open()` calls already pass `encoding`, but
  nothing enforces that, and a future `pathlib.read_text()` without one would slip
  through. Worth extending if it happens; not worth guessing at now.
- **Not done:** `subprocess.Popen` and `check_output` are not matched by the walker.
  Neither appears in this directory, and adding unused patterns would make the test
  look broader than its evidence.

## Review focus

Whether the AST walker is too narrow. It matches `subprocess.run` written exactly that
way — an aliased import (`from subprocess import run`) would evade it. That is a real
gap, and the argument for leaving it is that the alias does not appear here and a rule
matching every plausible spelling is a rule nobody can read. Say if you would rather
have breadth.

## Completion

- [x] Fixes the four live call sites and the class.
- [x] Documentation synchronized — the test module states the reasoning.
- [x] No private data, credentials, or machine paths added.
- [x] No ADR — a defect fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
