### PR TITLE
Give a late mergeability answer a second chance in the same run

### DIFF
--- a/scripts/mergeability.py
+++ b/scripts/mergeability.py
@@ -140,11 +140,16 @@ def main() -> int:
     )
     parser.add_argument("--attempts", type=int, default=8)
     parser.add_argument("--delay", type=float, default=4.0)
+    # A second, more patient pass over whatever is still unknown after the first. See
+    # the note on `pending` below.
+    parser.add_argument("--recheck-attempts", type=int, default=15)
+    parser.add_argument("--recheck-delay", type=float, default=8.0)
     args = parser.parse_args()
 
     numbers = [args.pull] if args.pull else open_pull_numbers(args.repo)
 
     conflicted = []
+    unknown = []
     for number in numbers:
         head_sha, mergeable, state = resolve(
             args.repo, number, args.attempts, args.delay
@@ -152,6 +157,28 @@ def main() -> int:
         status, description = classify(mergeable, state)
         post_status(args.repo, head_sha, status, description)
         print(f"{CONTEXT}: #{number} {head_sha[:8]} -> {status} ({description})")
+        if status == "failure":
+            conflicted.append(number)
+        elif status == "pending":
+            unknown.append(number)
+
+    # `pending` is honest and it blocks, which was the right call while this status was
+    # advisory. Now that it is a required check, a `pending` that nobody clears is a
+    # merge freeze — and the moment it is most likely is exactly after a merge, when
+    # GitHub invalidates mergeability for every open pull request and recomputes it
+    # lazily, sometimes past the first pass's patience.
+    #
+    # So whatever is still unknown gets one more, slower pass in the same run. Bounded
+    # on purpose: this is a nudge for a value that arrives late, not a wait loop for one
+    # that never arrives. Anything still unknown afterwards stays `pending` and clears
+    # on the next push, which is the behaviour this had before.
+    for number in unknown:
+        head_sha, mergeable, state = resolve(
+            args.repo, number, args.recheck_attempts, args.recheck_delay
+        )
+        status, description = classify(mergeable, state)
+        post_status(args.repo, head_sha, status, description)
+        print(f"{CONTEXT}: #{number} {head_sha[:8]} -> {status} (recheck)")
         if status == "failure":
             conflicted.append(number)
 

--- a/scripts/tests/test_mergeability.py
+++ b/scripts/tests/test_mergeability.py
@@ -97,5 +97,55 @@ class ResolveTests(unittest.TestCase):
         self.assertEqual(mergeability.classify(mergeable, "unknown")[0], "pending")
 
 
+class RecheckTests(unittest.TestCase):
+    """The second pass exists because this status is now a required check.
+
+    `pending` blocks, which was the right call while the status was advisory. As a
+    required check, a `pending` nobody clears is a merge freeze — and the moment it is
+    most likely is right after a merge, when GitHub invalidates mergeability for every
+    open pull request and recomputes it lazily.
+    """
+
+    def test_resolve_is_more_patient_when_asked(self):
+        calls = []
+
+        def counting(repo, number):
+            calls.append(number)
+            return ("sha", None, "unknown")
+
+        original = mergeability.read_pull
+        mergeability.read_pull = counting
+        try:
+            mergeability.resolve("o/r", 7, attempts=3, delay=0)
+            first_pass = len(calls)
+            mergeability.resolve("o/r", 7, attempts=15, delay=0)
+        finally:
+            mergeability.read_pull = original
+
+        self.assertEqual(first_pass, 3)
+        self.assertEqual(len(calls) - first_pass, 15)
+
+    def test_a_late_answer_is_still_an_answer(self):
+        # The case the recheck is for: unknown throughout the first pass, resolved
+        # during the second. Without it the pull request keeps a blocking `pending`
+        # until something unrelated pushes.
+        answers = [("sha", None, "unknown")] * 4 + [("sha", False, "dirty")]
+        seen = []
+
+        def late(repo, number):
+            seen.append(number)
+            return answers[min(len(seen) - 1, len(answers) - 1)]
+
+        original = mergeability.read_pull
+        mergeability.read_pull = late
+        try:
+            _, mergeable, state = mergeability.resolve("o/r", 7, attempts=10, delay=0)
+        finally:
+            mergeability.read_pull = original
+
+        self.assertIs(mergeable, False)
+        self.assertEqual(mergeability.classify(mergeable, state)[0], "failure")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Pull request

## Outcome

Whatever mergeability is still unknown after the first pass gets one more, slower pass
in the same run.

## Why now

`pending` blocks, and that was the right call while this status was advisory: unknown
is not green, and the next push re-evaluates. As of an hour ago it is a **required
check** with `enforce_admins` on — so a `pending` nobody clears is a merge freeze with
no override.

And the moment it is most likely is exactly after a merge, when GitHub invalidates
mergeability for every open pull request and recomputes it lazily.

Observed on #126 at 11:02:43, minutes after two merges:

```
mergeable: true, mergeable_state: "blocked"
contexts: ["mergeability=pending @2026-09-05T11:02:43Z"]
```

The fan-out found `null` through all eight attempts, wrote `pending`, and that status
is still sitting there. Nothing was lost — #126 was refused on its merits and owes a
fix — but on a pull request that was otherwise ready it would have stopped the loop
merging until something unrelated happened to push.

## The change

A second pass over the unknowns only, with `--recheck-attempts 15 --recheck-delay 8`.
Bounded on purpose: a nudge for an answer that arrives late, not a wait loop for one
that never arrives. Anything still unknown stays `pending` and clears on the next push,
exactly as before.

**The classification is untouched.** Unknown is still never `success`. The second pass
buys time for an answer; it does not invent one. That distinction is the whole reason
this is safe to add.

## Verification

- [x] `python -m unittest discover -s scripts/tests -v` — 163 tests pass (161 before)
- [x] `python scripts/policy_guard.py --base origin/master` — passed over 2 files
- [x] Two new controls: that `resolve` is actually more patient when asked (3 reads vs
      15), and that an answer arriving on the fifth read is returned rather than
      discarded — confirmed directly, resolving after 5 reads

## Evidence and uncertainty

- **Established:** #126's blocking `pending`, its timestamp relative to the merges, and
  that the status is required as of this morning.
- **Reasoned:** that eight attempts over ~32 seconds is simply too short after a merge.
  I did not measure how long GitHub actually takes — the recheck is sized to be
  comfortably longer rather than to a measured distribution, which is why it stays a
  bounded nudge instead of a guarantee.
- **Not fixed:** the worst case is unchanged. If GitHub is slow past both passes, the
  status stays `pending` and the pull request waits for the next push. The loop pushes
  every half hour, so the practical ceiling is that — but on a quiet repository it
  could be longer, and the honest answer there is a scheduled re-evaluation, which this
  deployment cannot rely on for the reasons in `docs/zendev/SCHEDULING.md`.

## A separate wart, not fixed here

The workflow **job** and the commit **status** are both named `mergeability`, so both
appear in the checks rollup and a reader cannot tell which one branch protection is
satisfied by. Right now #126 shows `mergeability=pass` (the job) beside
`mergeability=pending` (the status). It has not caused a wrong outcome, but two things
with one name in a required-check list is a trap, and renaming the job is a one-line
change I would rather make deliberately than fold in here.

## Review focus

Whether a second pass belongs in the run at all, rather than accepting that `pending`
clears on the next push. The argument for it is that a required check changed the cost
of being wrong; the argument against is that it makes a fan-out over many pull requests
slower in the exact case where several are unknown at once.

## Completion

- [x] Documentation synchronized — the reasoning is inline where the pass runs.
- [x] No private data, credentials, or machine paths added.
- [x] No ADR — tuning an existing check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
