### PR TITLE
Stop the job and the status answering to one name

### DIFF
--- a/.github/workflows/mergeability.yml
+++ b/.github/workflows/mergeability.yml
@@ -34,8 +34,18 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  mergeability:
-    name: mergeability
+  # Named apart from the commit status this job writes, deliberately.
+  #
+  # Both used to be called `mergeability`, so both appeared in the checks rollup under
+  # one name and no reader could tell which of them branch protection was satisfied by.
+  # On #126 the job showed `pass` beside the status showing `pending` — the same word
+  # reporting two different things about the same revision.
+  #
+  # `mergeability` is now exactly one thing: the commit status, and the required check.
+  # This job is the machinery that writes it, and its own success says only that the
+  # machinery ran.
+  write-mergeability-status:
+    name: write-mergeability-status
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/scripts/tests/test_check_names_are_unambiguous.py
+++ b/scripts/tests/test_check_names_are_unambiguous.py
@@ -1,0 +1,72 @@
+"""No workflow job may share a name with a commit status the repository writes.
+
+A required check is matched by name. When two different things answer to one name,
+the checks rollup shows both and no reader — person or run — can tell which one the
+protected branch is satisfied by. On #126 the job reported `pass` beside the status
+reporting `pending`: the same word, the same revision, two different claims.
+
+The two are not the same claim and must not look alike. A commit status says whether
+the branch merges. The job that writes it succeeding says only that the machinery ran.
+"""
+
+import pathlib
+import re
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github" / "workflows"
+SCRIPTS = ROOT / "scripts"
+
+# `CONTEXT = "..."` at module level: how a script declares the status name it posts.
+CONTEXT_ASSIGNMENT = re.compile(r'^CONTEXT\s*=\s*"([^"]+)"', re.MULTILINE)
+
+# `  name: value` two levels in, which is how a job's display name is written here.
+JOB_NAME = re.compile(r"^    name:\s*(\S+)\s*$", re.MULTILINE)
+
+
+def status_contexts():
+    """Every commit-status name a script in scripts/ posts."""
+    found = {}
+    for path in sorted(SCRIPTS.glob("*.py")):
+        for context in CONTEXT_ASSIGNMENT.findall(path.read_text(encoding="utf-8")):
+            found[context] = path.name
+    return found
+
+
+def job_names():
+    """Every workflow job display name, with the file it comes from."""
+    found = {}
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        for name in JOB_NAME.findall(path.read_text(encoding="utf-8")):
+            found.setdefault(name, []).append(path.name)
+    return found
+
+
+class CheckNameTests(unittest.TestCase):
+    def test_no_job_shares_a_name_with_a_commit_status(self):
+        contexts = status_contexts()
+        jobs = job_names()
+        collisions = sorted(set(contexts) & set(jobs))
+        self.assertEqual(
+            collisions,
+            [],
+            "a job and a commit status answer to the same name, so the rollup shows "
+            f"two different claims under one label: {collisions}",
+        )
+
+    def test_the_scan_finds_both_kinds_of_name(self):
+        # Without this, the assertion above passes whenever a pattern stops matching —
+        # the vacuous pass this repository keeps rediscovering. Both sides must be
+        # non-empty for the intersection to mean anything.
+        self.assertIn("mergeability", status_contexts())
+        self.assertGreaterEqual(len(job_names()), 4)
+
+    def test_the_status_name_is_the_one_branch_protection_requires(self):
+        # Renaming the context would silently un-require the check: branch protection
+        # holds the old name, nothing would ever post it, and the gate would sit
+        # pending forever. Changing this string is a repository-settings change too.
+        self.assertEqual(status_contexts().get("mergeability"), "mergeability.py")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Pull request

## Outcome

The workflow job is `write-mergeability-status`. `mergeability` is now exactly one
thing: the commit status, which is the required check.

## The confusion

Both were called `mergeability`, so both appeared in the checks rollup under one label
and no reader could tell which one branch protection was satisfied by. On #126:

```
mergeability = pass      (the job)
mergeability = pending   (the commit status)
```

Same word, same revision, two different claims — and they *should* differ. The status
says whether the branch merges. The job succeeding says only that the machinery ran; it
is green when the status it wrote is red, which is correct behaviour and completely
unreadable while both share a name.

## What is required, and what is not

`mergeability` — the commit status — stays the required check. Branch protection holds
that string, and this pull request does not touch it. The renamed job is no longer a
candidate for satisfying it, which is the point: one name, one claim.

A consequence worth stating: if the job fails outright, no status is written, so the
required check is *absent* rather than red — and an absent required check blocks. That
is the correct direction, and it is the same "unmeasured is not clean" rule the
selector already applies.

## The control

A test refuses any workflow job that shares a name with a commit status a script posts.
It carries two of its own:

- **both sides of the comparison find names** — otherwise the intersection is empty for
  the wrong reason, which is the vacuous pass this repository keeps rediscovering;
- **the context string is still the one branch protection holds.** Renaming it would
  un-require the check silently: protection would wait for a name nothing posts, and
  the gate would sit pending forever.

## Verification

- [x] `python -m unittest discover -s scripts/tests -v` — 166 tests pass (163 before)
- [x] `python scripts/policy_guard.py --base origin/master` — passed over 2 files
- [x] `mergeability.yml` parses; its only job is `write-mergeability-status`
- [x] **Negative control observed firing:** restoring the old job name fails the suite
      with `two different claims under one label: ['mergeability']`
- [x] No stale references to the old job name anywhere in `docs/`, `.github/` or
      `scripts/`

## Evidence and uncertainty

- **Established:** the two entries under one name on #126; that the status is the
  string branch protection holds.
- **Reasoned:** that the rollup ambiguity has not yet produced a wrong outcome. I could
  not find one, but "I looked and did not find it" is weaker than a measurement, and
  GitHub's matching rules when two things share a required name are not documented in a
  way I would rely on.
- **Watch on the first run:** this pull request's own checks are the first under the new
  name. If `mergeability` does not appear as a required check on it, the rename took the
  wrong one and the fix is to revert this file — nothing else depends on it.
- **Not done:** the job-name pattern is a regex over two-space-indented `name:` lines,
  not a YAML parse. It matches how every workflow here is written; a differently
  indented job would be invisible to it, and the second control would not catch that
  because other jobs still match. Worth a real parse if the workflows ever grow varied.

## Review focus

Whether making the status the only bearer of the required name is right, versus making
the *job* the required check and dropping the status. The status wins because it can be
written from any event — including for a conflicting pull request, where no
`pull_request` workflow can run at all and a job-based check would never appear.

## Completion

- [x] Documentation synchronized — the reasoning is inline in the workflow.
- [x] No private data, credentials, or machine paths added.
- [x] No ADR — a naming fix with a control attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
