### PR TITLE
Keep policy-class Issues out of the autonomous author queue

### DIFF
--- a/docs/zendev/AUTHOR_RUNBOOK.md
+++ b/docs/zendev/AUTHOR_RUNBOOK.md
@@ -50,6 +50,15 @@ Take the first applicable item and stop searching:
 Closing work outranks opening work. If another run already holds the item — an open
 pull request, a `status:in-progress` label, or a branch for that Issue — do not take it.
 
+**An Issue labelled `policy` is never yours**, whatever its `status:*` label says. It
+changes the control plane — the workflows, `scripts/`, these runbooks, `AGENTS.md` — and
+the operator session owns that class: your token cannot write a workflow, the ACCEPTOR may
+not merge a policy change that widens automated authority, and a run spent on one cannot
+close it. On 2026-09-05 every AUTHOR run of an afternoon went to two such Issues while
+the only product Issue waited (#139). Skip a `policy` Issue in items 3–5. A control-plane
+defect you discover is filed as a new Issue carrying `policy`, `type:process` and
+`status:needs-triage`, and then left alone.
+
 Evaluating 1–6 and finding nothing to mutate is never a silent success. Item 6 exists
 precisely so this cannot happen: whenever 1–5 yield no eligible item, item 6 always
 produces a durable record (a new ready Issue) before the run stops. A run must not


### PR DESCRIPTION
Closes #139

## Achieved outcome

The AUTHOR runbook now states that an Issue labelled `policy` is never the autonomous AUTHOR's, whatever its `status:*` label: it changes the control plane, the operator session owns that class, and a run spent on one cannot close it. A control-plane defect the AUTHOR discovers is filed with `policy` and `status:needs-triage` and left alone. Outside this diff, the `policy` label was created on the repository and applied to the open process Issues #121 and #122 and to every M0 Issue.

## Tested revision

`818480b`

## Changed artifacts

- `docs/zendev/AUTHOR_RUNBOOK.md` — section 2 gains the rule, with the label name and the afternoon that proved it.

## Acceptance criteria

- [x] `AUTHOR_RUNBOOK.md` section 2 states the rule and names the label — the new paragraph after the selection ladder.
- [x] The label exists with a description that says who owns such Issues — created by the operator; `gh label list` shows `policy`.
- [x] #121 and #122 carry `policy` — applied by the operator on 2026-09-05.
- [x] `python -m unittest discover -s scripts/tests` passes — 166 tests at `818480b`.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest discover -s scripts/tests` | passed | 166 tests, OK, at `818480b` |
| `python scripts/policy_guard.py --base origin/master` | passed | 1 changed file, no violation |
| `dotnet build --configuration Release` | not_run | no product code changed; the required check runs it on this pull request. Risk left open: none for a runbook-only diff |
| `dotnet test --configuration Release` | not_run | same |
| `npm run typecheck && npm test && npm run build` | not_run | same |

## Not checked

Whether the Haiku AUTHOR actually honours the paragraph. That is procedural until a mechanical author selector exists (M2); the `status:in-progress` label on every M0 Issue is what structurally keeps the AUTHOR off them today.

## Assumptions and unknowns

- Assumed: a runbook rule is read on every run, because the workflow prompt says to follow the runbook in order. Inference, not measurement.
- Unknown: whether the AUTHOR will still create `policy` Issues for discovered control-plane defects rather than fixing them inline. The paragraph tells it to; nothing enforces it yet.

## Highest-risk area for review

The paragraph itself: it must not read as permission to skip item 1 or 2 (the AUTHOR's own pull requests), only items 3–5.

## Remaining gate

None mandatory. The mechanical author selector that would enforce this is M2 work and is named as a non-goal in the Issue.
