### PR TITLE
Refuse a pull request whose diff carries a path its handoff does not name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   pull_request:
+    # `edited` as well: the handoff guard below reads the pull request body, and a
+    # corrected body must be able to turn that check green without an empty commit.
+    types: [opened, synchronize, reopened, edited]
   push:
     branches: [master]
 
@@ -84,6 +87,25 @@ jobs:
             --base "origin/${BASE_REF}" \
             --head-ref "${HEAD_REF}" \
             --head-sha "${HEAD_SHA}"
+
+      # The handoff must name every path the diff touches. Half of the runbook's
+      # "declared scope" gate is a predicate over the diff and the body, and a review
+      # run was spent on it in #130; this step decides that half, and the reviewer keeps
+      # the other — whether the declared set is what the Issue allows. The body arrives
+      # through the environment, never through an expression: it is attacker-
+      # controllable text on a public repository.
+      - name: Guard the handoff against undeclared changes
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          printf '%s' "${PR_BODY}" > "${RUNNER_TEMP}/pull-request-body.md"
+          python scripts/scope_guard.py \
+            --base "origin/${BASE_REF}" \
+            --head-ref "${HEAD_REF}" \
+            --body-file "${RUNNER_TEMP}/pull-request-body.md"
 
       # Offline and unconditional. The rendered table is a function of the ledger and
       # the mirrored registry, so regenerating and comparing catches both a hand-edited

--- a/docs/zendev/ACCEPTOR_RUNBOOK.md
+++ b/docs/zendev/ACCEPTOR_RUNBOOK.md
@@ -87,28 +87,30 @@ Post REQUEST_CHANGES and stop if any of these is true:
 
 ### Who decides each of these
 
-Two of them are already decided before you see the pull request, and six are yours. A
-gate belonging to neither would be the worst outcome — the contract would make it look
-enforced while nothing enforced it — so each is named here.
+Three of them are already decided before you see the pull request, and five are yours;
+one gate is split down the middle, and both halves are named. A gate belonging to
+neither would be the worst outcome — the contract would make it look enforced while
+nothing enforced it — so each is named here.
 
 | Gate | Decided by |
 | --- | --- |
 | Policy paths mixed with product paths | `scripts/policy_guard.py`, required |
 | Credentials, tokens, and local machine paths | `scripts/policy_guard.py`, required |
+| Every changed path is named in the handoff | `scripts/scope_guard.py`, required |
 | No linked Issue, or the Issue lacks a required section | you |
 | Label axes on the Issue | you |
 | The handoff record is incomplete | you |
-| The diff touches files outside the Issue's declared scope | you |
+| The declared set is what the Issue's scope allows, and no more | you |
 | Tests deleted, disabled, or weakened | you |
 | An invariant test relaxed without a Decision record | you |
 
-**For the two a check decides: read the check, do not re-derive it.** `policy-guard` runs
-on every pull request and its result is on the checks tab. Restating its finding costs a
-run and invites you to disagree with a control you cannot overrule. This does not excuse
-you from reading the diff — you read it for everything else in this section, and a guard
-that refused nothing is not a statement that there was nothing to find.
+**For the three a check decides: read the check, do not re-derive it.** `policy-guard`
+runs on every pull request and its result is on the checks tab. Restating its finding
+costs a run and invites you to disagree with a control you cannot overrule. This does not
+excuse you from reading the diff — you read it for everything else in this section, and a
+guard that refused nothing is not a statement that there was nothing to find.
 
-**For the six that are yours, the reason no check decides them** — each is a property of
+**For the five that are yours, the reason no check decides them** — each is a property of
 the gate, not a gap someone has yet to fill:
 
 - *Issue completeness and label axes* could be checked, and no run has yet failed them.
@@ -118,9 +120,11 @@ the gate, not a gap someone has yet to fill:
   the evidence honestly separates what was measured from what was assumed is the thing
   you exist to judge. Checking the first half alone would report a complete handoff for a
   record that says nothing.
-- *Declared scope* cannot be checked while `Scope` is prose. Making it checkable means
-  every Issue carrying a machine-readable path set — a tax on every future task for a
-  gate you close by reading the diff.
+- *Declared scope* splits the way handoff completeness does. Whether every changed path
+  is named in the body at all is a string search, and `scope_guard` performs it inside
+  `policy-guard` — the first revision of #130 changed ten files and declared two, and a
+  run was spent finding that. Whether the named set is what the Issue's `Scope` allows
+  cannot be checked while `Scope` is prose, and that half is yours.
 - *Tests deleted or disabled* is mechanically visible in its crudest forms — a removed
   file, `it.skip`, a fall in the discovered count — but a falling count is also what a
   legitimate consolidation looks like, and *weakened* is invisible to any count. A
@@ -131,7 +135,7 @@ the gate, not a gap someone has yet to fill:
   record nearby, but reporting is not refusing, and a control that never refuses teaches
   its reader to scroll past it.
 
-If you find a defect in one of the six, say so in your verdict and open an Issue for the
+If you find a defect in one of the five, say so in your verdict and open an Issue for the
 check. An observed failure is what moves a gate; symmetry is not.
 
 ## 2a. Machine-generated pull requests are not yours

--- a/docs/zendev/AUTHOR_RUNBOOK.md
+++ b/docs/zendev/AUTHOR_RUNBOOK.md
@@ -199,7 +199,12 @@ regenerates it and fails on the difference.
 
 Push the branch and open a pull request whose body follows
 [the pull request template](../../.github/PULL_REQUEST_TEMPLATE.md) completely, with
-`Closes #<issue>`. Set `status:needs-review` on the Issue, replacing
+`Closes #<issue>`. *Changed artifacts* names **every** path the diff touches, spelled
+exactly as `git diff --name-only origin/master...HEAD` spells it. The `scope-guard` step
+of the required `policy-guard` check refuses a pull request whose diff carries a path
+the body does not mention; when it does, either the body is incomplete — fix it, and
+the edit re-runs the check without a new commit — or the change does not belong to this
+Issue and comes out of the branch. Set `status:needs-review` on the Issue, replacing
 `status:in-progress`. Post a handoff comment naming the branch, the tested revision,
 checks, decisions, and what remains.
 

--- a/scripts/scope_guard.py
+++ b/scripts/scope_guard.py
@@ -1,0 +1,89 @@
+"""Every path a pull request changes must be named in its handoff.
+
+The handoff record has a *Changed artifacts* section, and the ACCEPTOR runbook refuses a
+diff that reaches outside the Issue's declared scope. Half of that gate is judgement —
+whether the declared set is the *right* set for the Issue — and it stays with the
+reviewer. The other half is a predicate: does every changed path appear in the body at
+all? The first revision of #130 changed more than ten files and declared two, and a
+review run was spent discovering what a string search would have found.
+
+So this is that string search, run inside the required ``policy-guard`` check. A changed
+path the body does not mention refuses the pull request, and the author — whose own
+ladder puts a failing required check second — corrects the handoff. The reviewer never
+sees the undeclared version.
+
+Deliberately literal. A path counts as declared when it appears verbatim in the body,
+inside backticks or not, exactly as ``git diff --name-only`` spells it. There is no
+parsing of sections: the template's shape can change, and a guard coupled to prose
+drifts with it. Machine-generated pull requests are exempt — they have no author and
+no handoff by construction, and their own class guard decides what they may touch.
+
+Exit code 0 means every changed path is declared, 1 means at least one is not.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+import machine_pr_guard
+
+
+def undeclared(paths, body):
+    """The changed paths the body does not mention. Pure."""
+    text = body or ""
+    return [path for path in paths if path not in text]
+
+
+def check(paths, body, head_ref):
+    """Pure decision. Returns a list of human-readable violations."""
+    if machine_pr_guard.classify(head_ref or "") is not None:
+        return []
+    missing = undeclared(paths, body)
+    if not missing:
+        return []
+    if not (body or "").strip():
+        return [
+            "the pull request body is empty; a handoff names every changed file, and "
+            "this diff changes %d" % len(paths)
+        ]
+    return [
+        "%d changed path(s) are not named anywhere in the pull request body:\n  %s\n"
+        "  A handoff lists every changed file under *Changed artifacts*, spelled as git "
+        "spells it. Add the missing ones, or drop the change if it does not belong to "
+        "this pull request's Issue." % (len(missing), "\n  ".join(missing))
+    ]
+
+
+def read_body(path):
+    if not path:
+        return ""
+    file = pathlib.Path(path)
+    if not file.is_file():
+        return ""
+    return file.read_text(encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", required=True, help="base ref to compare against")
+    parser.add_argument("--head-ref", required=True, help="head branch name")
+    parser.add_argument(
+        "--body-file", required=True, help="file holding the pull request body"
+    )
+    args = parser.parse_args()
+
+    paths = machine_pr_guard.changed_paths(args.base)
+    violations = check(paths, read_body(args.body_file), args.head_ref)
+
+    if not violations:
+        print("scope-guard: every one of %d changed path(s) is named in the handoff" % len(paths))
+        return 0
+    for violation in violations:
+        print("::error::scope-guard: %s" % violation)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_scope_guard.py
+++ b/scripts/tests/test_scope_guard.py
@@ -1,0 +1,84 @@
+"""Negative controls for the handoff guard: prove it refuses, not merely that it runs."""
+
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import scope_guard as guard  # noqa: E402
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+CI = ROOT / ".github" / "workflows" / "ci.yml"
+
+BODY = """Closes #140
+
+## Changed artifacts
+
+- `scripts/scope_guard.py` — the guard
+- scripts/tests/test_scope_guard.py — its negative controls
+"""
+
+
+class CheckTests(unittest.TestCase):
+    def test_an_undeclared_path_is_a_violation_naming_the_path(self):
+        # #130, exactly: files changed that the handoff never mentioned.
+        violations = guard.check(
+            ["scripts/scope_guard.py", "scripts/mergeability.py"], BODY, "claude/issue-140-x"
+        )
+        self.assertEqual(len(violations), 1)
+        self.assertIn("scripts/mergeability.py", violations[0])
+        self.assertNotIn("scripts/scope_guard.py\n", violations[0])
+
+    def test_a_declared_path_passes_with_or_without_backticks(self):
+        paths = ["scripts/scope_guard.py", "scripts/tests/test_scope_guard.py"]
+        self.assertEqual(guard.check(paths, BODY, "claude/issue-140-x"), [])
+
+    def test_an_empty_body_with_changes_is_refused(self):
+        violations = guard.check(["src/index.ts"], "", "claude/issue-1-x")
+        self.assertEqual(len(violations), 1)
+        self.assertIn("empty", violations[0])
+        self.assertEqual(guard.check(["src/index.ts"], None, "claude/issue-1-x")[0], violations[0])
+
+    def test_an_empty_diff_has_nothing_to_declare(self):
+        self.assertEqual(guard.check([], "", "claude/issue-1-x"), [])
+
+    def test_a_machine_class_branch_is_exempt_without_reading_the_body(self):
+        # A mirror snapshot has no author and no handoff; its own guard decides its paths.
+        self.assertEqual(
+            guard.check(["docs/spec/mirror/SPEC_INDEX.md"], "", "spec-mirror"), []
+        )
+
+    def test_matching_is_literal(self):
+        # A path spelled differently from git is not declared: the guard must not guess.
+        violations = guard.check(["docs/zendev/AUTHOR_RUNBOOK.md"], "docs\\zendev\\AUTHOR_RUNBOOK.md", "claude/x")
+        self.assertEqual(len(violations), 1)
+
+
+class WorkflowTests(unittest.TestCase):
+    def text(self):
+        return CI.read_text(encoding="utf-8")
+
+    def test_the_guard_runs_inside_policy_guard_on_pull_requests(self):
+        text = self.text()
+        self.assertIn("scripts/scope_guard.py", text)
+        # Inside the policy-guard job, after its declaration and before the next job or EOF.
+        job = text.index("policy-guard:")
+        self.assertGreater(text.index("scripts/scope_guard.py"), job)
+
+    def test_a_corrected_body_re_runs_the_check(self):
+        # `edited` in the pull_request event types: without it a fixed handoff could
+        # only be re-measured by pushing an empty commit.
+        self.assertIn("edited", self.text())
+        self.assertRegex(self.text(), r"types:\s*\[[^\]]*edited[^\]]*\]")
+
+    def test_the_body_arrives_through_the_environment_not_an_expression(self):
+        # Attacker-controllable text on a public repository must never be interpolated
+        # into a shell line.
+        text = self.text()
+        self.assertIn("PR_BODY: ${{ github.event.pull_request.body }}", text)
+        self.assertNotIn('"${{ github.event.pull_request.body }}"', text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #140

## Achieved outcome

A pull request whose diff carries a path its body does not name is refused by the required `policy-guard` check before any review run is spent on it. The check runs on `edited` pull request events as well, so a corrected handoff turns it green without an empty commit. Machine-class branches are exempt. The runbooks now name the split: the string search is the check's, whether the declared set is what the Issue allows is the reviewer's.

## Tested revision

`a3df1e7`

## Changed artifacts

- `scripts/scope_guard.py` — new: pure `check(paths, body, head_ref)` and a CLI over `machine_pr_guard.changed_paths`.
- `scripts/tests/test_scope_guard.py` — new: negative controls (undeclared path, empty body, machine branch, literal matching) and text assertions on `ci.yml`.
- `.github/workflows/ci.yml` — `pull_request` types include `edited`; a new step in `policy-guard` passes the body through the environment and runs the guard.
- `docs/zendev/AUTHOR_RUNBOOK.md` — section 7: *Changed artifacts* names every path as git spells it; what to do when the guard refuses.
- `docs/zendev/ACCEPTOR_RUNBOOK.md` — section 2 table and the paragraph on declared scope: the gate is split into its mechanical and its judged half.

## Acceptance criteria

- [x] An undeclared changed path is a violation naming the path; a declared one is not — `test_an_undeclared_path_is_a_violation_naming_the_path`, `test_a_declared_path_passes_with_or_without_backticks`.
- [x] A machine-class head branch passes without reading the body — `test_a_machine_class_branch_is_exempt_without_reading_the_body`.
- [x] An empty body with a non-empty diff is refused — `test_an_empty_body_with_changes_is_refused`.
- [x] `ci.yml` runs the guard inside `policy-guard` on `opened`, `synchronize`, `reopened` and `edited` — `WorkflowTests`, and the `on:` block.
- [x] Both runbooks describe the split — AUTHOR section 7, ACCEPTOR section 2.
- [x] `python -m unittest discover -s scripts/tests` passes and includes the new negative controls — 175 tests at `a3df1e7`.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest discover -s scripts/tests` | passed | 175 tests, OK, at `a3df1e7` |
| `python scripts/policy_guard.py --base origin/master` | passed | 5 changed files, no violation |
| `dotnet build --configuration Release` | not_run | no product code changed; the required check runs it on this pull request. Risk left open: none for this diff |
| `dotnet test --configuration Release` | not_run | same |
| `npm run typecheck && npm test && npm run build` | not_run | same |

## Not checked

The guard against a real pull request event: `pull_request` workflows run from the merge ref, so this very pull request is the first live run — its body names all five changed paths on purpose. The `edited` trigger was not exercised; it will be the first time a body is corrected after a refusal.

## Assumptions and unknowns

- Assumed: `github.event.pull_request.body` is null-safe through `printf '%s'` when the body is empty. The guard treats an empty file as an empty body and refuses.
- Assumed: paths in handoffs are spelled with forward slashes, as git spells them. `test_matching_is_literal` makes the alternative a refusal, deliberately.
- Cost: `edited` re-runs all three CI jobs on every body edit. Actions minutes are free on a public repository; the concurrency group cancels superseded runs.

## Highest-risk area for review

`ci.yml`: the body reaches the shell only through an environment variable and `printf '%s'`. A future edit that interpolates the expression directly would be an injection path on a public repository; `test_the_body_arrives_through_the_environment_not_an_expression` refuses the obvious form.

## Remaining gate

None mandatory. Watch the first AUTHOR pull request after merge for a false refusal on a renamed or deleted file; both appear in `git diff --name-only` and must be named too.
