### PR TITLE
Update a loop branch that is merely behind, without a model run

### DIFF
--- a/.github/workflows/mergeability.yml
+++ b/.github/workflows/mergeability.yml
@@ -69,3 +69,28 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: python scripts/mergeability.py --repo "${{ github.repository }}" --all-open
+
+      # `behind` is a red required check (#127), and its repair is a merge of the base
+      # into the branch — a computation. Until now that computation cost a model run:
+      # the AUTHOR's ladder picks up its own failing check and does the merge by hand.
+      # The forge does it here instead, for the loop's own branches only; a conflict
+      # (`dirty`) is still the author's.
+      #
+      # From `master` only. On a push to any other branch this workflow's definition
+      # and its scripts come from that branch, unreviewed, and this step carries a
+      # credential that can push. `master` is the reviewed definition — and `master`
+      # moving is exactly when branches fall behind.
+      #
+      # The loop's token, not `github.token`: a push made with the workflow token starts
+      # no workflows, so the updated branch would sit with the stale checks it had
+      # before, measured on a revision that no longer exists.
+      - name: Update loop branches that are merely behind
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+        env:
+          GH_TOKEN: ${{ secrets.ZENDEV_PAT }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::warning::ZENDEV_PAT is not available; branches that are behind stay with the author"
+            exit 0
+          fi
+          python scripts/update_branches.py --repo "${{ github.repository }}" --all-open

--- a/docs/zendev/AUTHOR_RUNBOOK.md
+++ b/docs/zendev/AUTHOR_RUNBOOK.md
@@ -34,7 +34,11 @@ Section 7 says how to write your row.
 Take the first applicable item and stop searching:
 
 1. an open pull request of yours with **changes requested** — address the feedback;
-2. an open pull request of yours with a **failing required check** — fix it;
+2. an open pull request of yours with a **failing required check** — fix it. One
+   exception: a `mergeability` failure that reads *the base has moved* is not yours.
+   The forge merges `master` into loop branches itself on the next push to `master`
+   and the branch is re-measured; a genuine conflict (*conflicts with the base branch*)
+   still is yours;
 3. an Issue labelled `status:blocked` whose blocking condition is now demonstrably
    resolved — unblock it;
 4. an Issue labelled `status:ready`, highest `priority:*` first, respecting

--- a/scripts/tests/test_update_branches.py
+++ b/scripts/tests/test_update_branches.py
@@ -1,0 +1,104 @@
+"""Negative controls: the sweep touches exactly the branches it may, and no other."""
+
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import update_branches as ub  # noqa: E402
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "mergeability.yml"
+
+REPO = "drevendev/trade_simulation"
+
+
+def pull(ref="claude/issue-9-example", head_repo=REPO, mergeable=True, state="behind", draft=False, pr_state="open"):
+    return {
+        "state": pr_state,
+        "draft": draft,
+        "mergeable": mergeable,
+        "mergeable_state": state,
+        "head": {"ref": ref, "sha": "abc", "repo": {"full_name": head_repo} if head_repo else None},
+        "base": {"ref": "master", "repo": {"full_name": REPO}},
+    }
+
+
+class ShouldUpdateTests(unittest.TestCase):
+    def test_a_loop_branch_that_is_behind_is_updated(self):
+        ok, reason = ub.should_update(pull())
+        self.assertTrue(ok)
+        self.assertEqual(reason, "behind")
+
+    def test_a_conflict_is_left_to_the_author(self):
+        ok, reason = ub.should_update(pull(mergeable=False, state="dirty"))
+        self.assertFalse(ok)
+        self.assertIn("dirty", reason)
+
+    def test_a_clean_or_blocked_branch_is_not_touched(self):
+        for state in ("clean", "blocked", "unstable", "has_hooks"):
+            with self.subTest(state=state):
+                self.assertFalse(ub.should_update(pull(state=state))[0])
+
+    def test_an_uncomputed_answer_is_not_a_reason_to_act(self):
+        ok, reason = ub.should_update(pull(mergeable=None, state="unknown"))
+        self.assertFalse(ok)
+        self.assertIn("not yet computed", reason)
+
+    def test_a_machine_branch_is_never_updated(self):
+        # A merge commit committed by the loop identity would fail the committer gate
+        # that class is accepted on.
+        ok, reason = ub.should_update(pull(ref="spec-mirror"))
+        self.assertFalse(ok)
+        self.assertIn("machine class", reason)
+
+    def test_an_operator_branch_is_left_alone(self):
+        ok, reason = ub.should_update(pull(ref="policy/142-update-behind-branches"))
+        self.assertFalse(ok)
+        self.assertIn("not a loop branch", reason)
+
+    def test_a_fork_head_is_not_ours_to_move(self):
+        for head_repo in ("someone/trade_simulation", None):
+            with self.subTest(head_repo=head_repo):
+                ok, reason = ub.should_update(pull(head_repo=head_repo))
+                self.assertFalse(ok)
+                self.assertIn("not in this repository", reason)
+
+    def test_drafts_and_closed_pull_requests_are_skipped(self):
+        self.assertFalse(ub.should_update(pull(draft=True))[0])
+        self.assertFalse(ub.should_update(pull(pr_state="closed"))[0])
+
+
+class FailureDetailTests(unittest.TestCase):
+    def test_the_http_status_line_is_kept_and_nothing_else(self):
+        stderr = "gh: Validation Failed (HTTP 422)\nHTTP 422: Validation Failed (https://api.github.com/...)\n{\"message\": \"...\"}"
+        detail = ub.failure_detail(stderr, 1)
+        self.assertTrue(detail.startswith("gh: ") or detail.startswith("HTTP "))
+        self.assertNotIn("message", detail)
+
+    def test_no_recognisable_line_falls_back_to_the_exit_code(self):
+        self.assertEqual(ub.failure_detail("", 7), "gh exit 7")
+
+
+class WorkflowTests(unittest.TestCase):
+    def text(self):
+        return WORKFLOW.read_text(encoding="utf-8")
+
+    def test_the_sweep_runs_after_the_fan_out_and_from_master_only(self):
+        text = self.text()
+        sweep = text.index("scripts/update_branches.py")
+        fan_out = text.index("scripts/mergeability.py --repo")
+        self.assertGreater(sweep, fan_out, "statuses must be written before branches are updated")
+        step = text[text.rfind("- name:", 0, sweep):sweep]
+        self.assertIn("refs/heads/master", step)
+        self.assertIn("github.event_name != 'pull_request'", step)
+
+    def test_the_sweep_uses_the_loop_token_so_the_push_triggers_checks(self):
+        sweep = self.text().index("scripts/update_branches.py")
+        step = self.text()[self.text().rfind("- name:", 0, sweep):sweep]
+        self.assertIn("secrets.ZENDEV_PAT", step)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/update_branches.py
+++ b/scripts/update_branches.py
@@ -1,0 +1,156 @@
+"""Bring a loop branch that is merely behind its base up to date, without a model run.
+
+`mergeability` reports two red conditions. `dirty` is a conflict and needs a person or
+a model to resolve. `behind` is not: the branch merges cleanly, its checks were simply
+measured against a base that has since moved, and the repair is one merge commit of the
+base into the branch. Until now that merge cost a full AUTHOR run — the role's own
+ladder picks up its failing check and performs the merge by hand — twice on #130 in one
+afternoon.
+
+This performs the merge through the forge's own endpoint, for the loop's branches only:
+
+* the head must live in this repository — a fork's branch is not ours to move;
+* the branch must be the loop's (``claude/**``); an operator's branch is left alone;
+* it must not be a machine class: a merge commit committed by anyone but the producing
+  workflow fails that class's committer gate, so updating one would refuse it;
+* GitHub must already report ``behind``. ``dirty``, ``clean``, ``blocked`` and an
+  uncomputed answer are all left exactly as they are.
+
+The credential matters. A push made with the workflow's own token starts no workflows,
+so the updated branch would carry the stale checks it had before, and the pull request
+would read as measured on a revision nothing ever measured. The step that runs this
+uses the loop's token instead, and runs only from the reviewed definition on ``master``.
+
+Exit code is 0 whatever happened to individual branches. The outcome for a pull request
+is the update the forge did or did not perform, printed per branch; this run's own
+status says only that the sweep ran.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+import machine_pr_guard
+
+LOOP_PREFIX = "claude/"
+BEHIND = "behind"
+
+
+def should_update(pull):
+    """(bool, reason). Pure: decides from one pull request object as the API returns it."""
+    head = pull.get("head") or {}
+    base = pull.get("base") or {}
+    ref = head.get("ref") or ""
+    head_repo = (head.get("repo") or {}).get("full_name")
+    base_repo = (base.get("repo") or {}).get("full_name")
+
+    if pull.get("state", "open") != "open":
+        return False, "not open"
+    if pull.get("draft"):
+        return False, "draft"
+    if not head_repo or head_repo != base_repo:
+        return False, "head is not in this repository"
+    if machine_pr_guard.classify(ref) is not None:
+        return False, "machine class: a merge commit from anyone else fails its committer gate"
+    if not ref.startswith(LOOP_PREFIX):
+        return False, f"not a loop branch ({LOOP_PREFIX}**)"
+    if pull.get("mergeable") is None:
+        return False, "mergeability not yet computed"
+    state = pull.get("mergeable_state")
+    if state != BEHIND:
+        return False, f"mergeable_state is {state!r}, not {BEHIND!r}"
+    return True, BEHIND
+
+
+def failure_detail(stderr: str, returncode: int) -> str:
+    """The one line of a failed gh call worth printing: the HTTP status, if any."""
+    for line in (stderr or "").splitlines():
+        if line.startswith("HTTP ") or line.startswith("gh: "):
+            return line.strip()
+    return f"gh exit {returncode}"
+
+
+def _gh(args):
+    # UTF-8 explicitly, not by locale: see the note in machine_pr_guard.py.
+    return subprocess.run(
+        ["gh", *args], capture_output=True, text=True, encoding="utf-8"
+    )
+
+
+def read_pull(repo: str, number: int):
+    result = _gh(["api", f"repos/{repo}/pulls/{number}"])
+    if result.returncode:
+        raise RuntimeError(f"could not read #{number}: {failure_detail(result.stderr, result.returncode)}")
+    return json.loads(result.stdout)
+
+
+def open_pull_numbers(repo: str):
+    result = _gh(["api", f"repos/{repo}/pulls?state=open&per_page=100"])
+    if result.returncode:
+        raise RuntimeError(f"could not list pull requests: {failure_detail(result.stderr, result.returncode)}")
+    return [int(pull["number"]) for pull in json.loads(result.stdout)]
+
+
+def update(repo: str, number: int, head_sha: str):
+    """Ask the forge to merge the base into the branch. Returns (ok, detail).
+
+    `expected_head_sha` makes the request refuse if the branch moved since it was
+    read, so a push landing in the same second is never merged over.
+    """
+    result = _gh(
+        [
+            "api",
+            "-X",
+            "PUT",
+            f"repos/{repo}/pulls/{number}/update-branch",
+            "-f",
+            f"expected_head_sha={head_sha}",
+        ]
+    )
+    if result.returncode == 0:
+        return True, "update requested"
+    return False, failure_detail(result.stderr, result.returncode)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="owner/name")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--pull", type=int, help="one pull request number")
+    group.add_argument("--all-open", action="store_true", help="every open pull request")
+    parser.add_argument("--dry-run", action="store_true", help="decide, but update nothing")
+    args = parser.parse_args()
+
+    try:
+        numbers = [args.pull] if args.pull else open_pull_numbers(args.repo)
+    except (RuntimeError, ValueError, KeyError, json.JSONDecodeError) as error:
+        print(f"::warning::update-branches: {error}")
+        return 0
+
+    for number in numbers:
+        try:
+            pull = read_pull(args.repo, number)
+        except (RuntimeError, ValueError, KeyError, json.JSONDecodeError) as error:
+            print(f"::warning::update-branches: {error}")
+            continue
+        ref = (pull.get("head") or {}).get("ref") or "?"
+        ok, reason = should_update(pull)
+        if not ok:
+            print(f"update-branches: #{number} {ref} left alone: {reason}")
+            continue
+        if args.dry_run:
+            print(f"update-branches: #{number} {ref} would be updated ({reason})")
+            continue
+        done, detail = update(args.repo, number, pull["head"]["sha"])
+        verb = "updated" if done else "not updated"
+        print(f"update-branches: #{number} {ref} {verb}: {detail}")
+        if not done:
+            print(f"::notice::update-branches: #{number} not updated: {detail}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #142

## Achieved outcome

When the mergeability fan-out runs on a push to `master`, it now asks the forge to merge `master` into every open loop branch that GitHub reports as `behind`, using the loop's token so the resulting push triggers checks. Real conflicts, machine-class branches, operator branches, forks and drafts are left exactly as they are. The AUTHOR runbook says a *behind* failure is not the author's any more.

## Tested revision

`88cfe67`

## Changed artifacts

- `scripts/update_branches.py` — new: pure `should_update(pull)`, `failure_detail`, and a sweep over open pull requests calling `PUT /pulls/{n}/update-branch` with `expected_head_sha`.
- `scripts/tests/test_update_branches.py` — new: every skip reason as a negative control, the failure-detail parser, and text assertions on the workflow step.
- `.github/workflows/mergeability.yml` — a step after the fan-out, on non-`pull_request` events from `refs/heads/master` only, with `ZENDEV_PAT`; warns and exits when the secret is absent.
- `docs/zendev/AUTHOR_RUNBOOK.md` — ladder item 2: *the base has moved* is the forge's to repair; a conflict is still the author's.

## Acceptance criteria

- [x] `should_update` says yes for `behind` on a same-repository `claude/**` branch and no for `dirty`, `clean`, unknown, a machine branch, a fork head and another prefix — `ShouldUpdateTests`, one test per reason.
- [x] The workflow step runs after the fan-out statuses and not on `pull_request` events, using the PAT — `WorkflowTests`.
- [x] A 422 from the API is reported, not raised — `update()` returns `(False, detail)`; `FailureDetailTests`.
- [x] `python -m unittest discover -s scripts/tests` passes — 178 tests at `88cfe67`.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest discover -s scripts/tests` | passed | 178 tests, OK, at `88cfe67` |
| `python scripts/policy_guard.py --base origin/master` | passed | 4 changed files, no violation |
| `dotnet build --configuration Release` | not_run | no product code changed; the required check runs it on this pull request. Risk left open: none for this diff |
| `dotnet test --configuration Release` | not_run | same |
| `npm run typecheck && npm test && npm run build` | not_run | same |

## Not checked

A live `update-branch` call. Nothing is `behind` right now, and the step runs from `master` only, so the first live exercise is the next push to `master` while a loop branch is open. `--dry-run` exists for a manual check afterwards.

## Assumptions and unknowns

- Assumed: a push made by the PAT identity triggers `pull_request: synchronize` on the updated branch, as the AUTHOR's own pushes do today. This is the documented reason the AUTHOR uses the PAT.
- Assumed: `GET /pulls/{n}` returns `mergeable_state` freshly enough right after the fan-out, which already waited for GitHub to compute it. An uncomputed answer is a skip, never an update.
- Unknown: whether `expected_head_sha` ever refuses because an AUTHOR run pushed in the same second. That is the intended refusal; the branch is re-measured on that push anyway.

## Highest-risk area for review

The credential. `ZENDEV_PAT` now reaches a workflow that runs on pushes, which is why the step is gated to `refs/heads/master` (reviewed definition and scripts) and to non-`pull_request` events. A branch cannot make this step run its own copy of the script.

## Remaining gate

This widens a workflow's authority (a PAT in `mergeability.yml`), so a person accepts it, per the ACCEPTOR hard limits.
