### PR TITLE
Let the spec sync close its own stale refused proposal

### DIFF
--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -151,6 +151,17 @@ jobs:
             fi
           done
 
+      # A refused proposal releases nothing on its own: nobody may push to its branch,
+      # and re-running replays the definition that refused it. #109 and #112 each waited
+      # for a person for half an hour after their cause was already fixed on master. The
+      # producer now closes a proposal that has been red for a bound and proposes afresh
+      # below, under the current checks. A cause that is real stays a person's — see
+      # docs/zendev/MACHINE_PULL_REQUESTS.md, "Recovering one".
+      - name: Close a stale refused proposal
+        env:
+          GH_TOKEN: ${{ secrets.ZENDEV_PAT || github.token }}
+        run: python scripts/stale_mirror_pr.py --repo "${{ github.repository }}"
+
       - name: Propose the mirror as a pull request
         id: mirror_pr
         uses: peter-evans/create-pull-request@v8

--- a/docs/zendev/MACHINE_PULL_REQUESTS.md
+++ b/docs/zendev/MACHINE_PULL_REQUESTS.md
@@ -118,19 +118,27 @@ The procedure is:
 
 1. **Fix the cause and merge the fix**, as an ordinary policy change through the ordinary
    path. A guard defect is a defect like any other.
-2. **Close the refused pull request**, with a comment recording why it was refused, what
-   fixed it, and the evidence that the fix accepts its head — running the repaired guard
-   against `refs/pull/<n>/head` locally is enough and takes a moment.
-3. **Let the producer propose again.** The branch still holds the content, so the next
-   sync opens a fresh pull request whose checks resolve the current definition. Dispatch
-   the sync rather than waiting, if the pipeline is stalled behind it.
+2. **The producer closes the refused pull request itself.** Every sync runs
+   `scripts/stale_mirror_pr.py` before proposing: when the open proposal has carried a
+   *concluded* red check for longer than a bound (90 minutes by default), the sync closes
+   it with a comment saying so, deletes the branch, and proposes the current mirror afresh
+   in the same run, under the current workflow definitions. A pending or green proposal,
+   or a red one younger than the bound, is left alone.
+3. **Nothing else is needed for a cause that is already fixed.** Dispatch the sync rather
+   than waiting for the hour, if the pipeline is stalled behind it.
+
+A cause that is *not* fixed produces churn instead of a stall: the proposal is closed and
+re-proposed each time the bound elapses, and is red again each time. That churn is visible
+in the pull request list and harmless, and it is still a person's to end — by fixing the
+cause. The producer never touches the branch's content, never pushes to it, and never
+merges it; it only closes what it produced and produces again.
 
 Do not force-push the branch, do not push a commit to unstick it, and do not merge it by
 hand. Each of those defeats a different one of the four conditions above, and the guard is
 built to refuse the result.
 
 This was worked out twice from first principles, under a stalled specification pipeline
-both times — #109 and #112 — which is why it is written here.
+both times — #109 and #112 — which is why it was written here, and then automated.
 
 ## Cost, and why this exists
 

--- a/scripts/stale_mirror_pr.py
+++ b/scripts/stale_mirror_pr.py
@@ -1,0 +1,184 @@
+"""Close a refused mirror proposal that nothing else can release, so the producer can
+propose again.
+
+A machine-generated pull request is accepted by mechanical gates and merged by branch
+protection; no agent reviews it and no agent may push to its branch. That is the
+class's whole point, and it has one consequence the class cannot recover from on its
+own: when a gate refuses the proposal, nothing releases it. Re-running the checks
+replays the workflow definition their run started with, so even a fix to the gate,
+merged on ``master``, leaves the proposal red. #109 and #112 each sat that way until a
+person closed them by hand, and the specification pipeline stalled for about half an
+hour both times.
+
+The producer can do that closing itself. Every sync, before proposing, it asks one
+question about the open proposal on its branch: has it carried a *concluded* red check
+for longer than a bound? If so, the proposal is closed with a comment saying why, its
+branch is deleted, and the proposal step that follows opens a fresh one from the
+current mirror under the current checks. A pending or green proposal is left alone, and
+so is a red one younger than the bound — checks take minutes to settle, and a young red
+is more likely a check still running than a refusal.
+
+The bound is what keeps this honest. A proposal red for a real reason — content outside
+the allowlist, say — will be closed and re-proposed every time the bound elapses, and
+be red again. That churn is visible, harmless, and still an operator matter: the cause
+has to be fixed by a person, exactly as before. What changes is that a cause already
+fixed no longer needs a person to notice.
+
+Exit code is 0 whatever the decision. The decision itself is printed, and the
+proposal's own state is the record.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import subprocess
+import sys
+
+import machine_pr_guard
+
+MIN_AGE = dt.timedelta(minutes=90)
+
+# Concluded and red. `CANCELLED` is not here — a cancelled run says a newer one
+# superseded it, not that the proposal failed — and neither is `ACTION_REQUIRED`, which
+# asks a person to approve a run, not to repair a proposal.
+RED = frozenset({"FAILURE", "ERROR", "TIMED_OUT", "STARTUP_FAILURE"})
+
+
+def default_branch() -> str:
+    """The mirror class's branch, taken from the one definition of the class."""
+    for cls in machine_pr_guard.MACHINE_CLASSES:
+        if cls.producer.endswith("spec-sync.yml"):
+            return cls.branch
+    return machine_pr_guard.MACHINE_CLASSES[0].branch
+
+
+def red_checks(pull):
+    """Names of the checks that have concluded red on the proposal's head."""
+    names = []
+    for check in pull.get("statusCheckRollup") or []:
+        outcome = (check.get("conclusion") or check.get("state") or "").upper()
+        if outcome in RED:
+            names.append(check.get("name") or check.get("context") or "?")
+    return names
+
+
+def decide(pull, head_committed_at, now, min_age=MIN_AGE):
+    """(close, reason). Pure: no network, no clock of its own."""
+    if pull is None:
+        return False, "no open proposal"
+    red = red_checks(pull)
+    if not red:
+        return False, "no concluded red check; a pending or green proposal is left alone"
+    age = now - head_committed_at
+    minutes = int(age.total_seconds() // 60)
+    if age < min_age:
+        return False, (
+            "red (%s) but the head is only %d min old; letting the checks settle"
+            % (", ".join(red), minutes)
+        )
+    return True, "red for %d min: %s" % (minutes, ", ".join(red))
+
+
+def closing_comment(reason: str) -> str:
+    return (
+        "Closed by the producer, not by a reviewer.\n\n"
+        "This proposal has been %s. Nothing may push to its branch, and re-running its "
+        "checks would replay the definition that refused it, so it cannot be released "
+        "from here. The next sync proposes the current mirror afresh under the current "
+        "checks.\n\n"
+        "If the new proposal is red as well, the cause is real and a person owns it — "
+        "see docs/zendev/MACHINE_PULL_REQUESTS.md, *Recovering one*." % reason
+    )
+
+
+def timestamp(value: str) -> dt.datetime:
+    parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("GitHub timestamp must include a timezone")
+    return parsed
+
+
+def _gh(args):
+    # UTF-8 explicitly, not by locale: see the note in machine_pr_guard.py.
+    return subprocess.run(
+        ["gh", *args], check=True, capture_output=True, text=True, encoding="utf-8"
+    ).stdout
+
+
+def load_open_proposal(repo: str, branch: str):
+    raw = _gh(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--head",
+            branch,
+            "--state",
+            "open",
+            "--json",
+            "number,headRefOid,statusCheckRollup,url",
+        ]
+    )
+    pulls = json.loads(raw)
+    return pulls[0] if pulls else None
+
+
+def head_committed_at(repo: str, sha: str) -> dt.datetime:
+    raw = _gh(["api", f"repos/{repo}/commits/{sha}"])
+    return timestamp(json.loads(raw)["commit"]["committer"]["date"])
+
+
+def close(repo: str, number: int, comment: str) -> None:
+    _gh(
+        [
+            "pr",
+            "close",
+            str(number),
+            "--repo",
+            repo,
+            "--comment",
+            comment,
+            "--delete-branch",
+        ]
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="owner/name")
+    parser.add_argument("--branch", default=default_branch(), help="the machine branch")
+    parser.add_argument("--min-age-minutes", type=int, default=int(MIN_AGE.total_seconds() // 60))
+    parser.add_argument("--dry-run", action="store_true", help="decide, but close nothing")
+    args = parser.parse_args()
+
+    try:
+        pull = load_open_proposal(args.repo, args.branch)
+        committed = head_committed_at(args.repo, pull["headRefOid"]) if pull else None
+    except (subprocess.CalledProcessError, ValueError, KeyError, json.JSONDecodeError) as error:
+        print(f"::warning::stale-mirror-pr: could not read the proposal: {type(error).__name__}")
+        return 0
+
+    close_it, reason = decide(
+        pull, committed, dt.datetime.now(dt.timezone.utc), dt.timedelta(minutes=args.min_age_minutes)
+    )
+    number = pull["number"] if pull else None
+    if not close_it:
+        print(f"stale-mirror-pr: leaving #{number} alone: {reason}" if pull else f"stale-mirror-pr: {reason}")
+        return 0
+    if args.dry_run:
+        print(f"stale-mirror-pr: would close #{number}: {reason}")
+        return 0
+    try:
+        close(args.repo, number, closing_comment(reason))
+    except subprocess.CalledProcessError as error:
+        print(f"::warning::stale-mirror-pr: could not close #{number} (gh exit {error.returncode})")
+        return 0
+    print(f"stale-mirror-pr: closed #{number}: {reason}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_stale_mirror_pr.py
+++ b/scripts/tests/test_stale_mirror_pr.py
@@ -1,0 +1,102 @@
+"""The producer closes only what is red, concluded and old — and nothing else."""
+
+import datetime as dt
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import stale_mirror_pr as stale  # noqa: E402
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "spec-sync.yml"
+
+NOW = dt.datetime(2026, 9, 5, 12, 0, tzinfo=dt.timezone.utc)
+
+
+def check(name, conclusion=None, state=None):
+    entry = {"name": name}
+    if conclusion is not None:
+        entry["conclusion"] = conclusion
+    if state is not None:
+        entry["context"] = name
+        entry["state"] = state
+    return entry
+
+
+def proposal(*checks):
+    return {"number": 112, "headRefOid": "abc", "statusCheckRollup": list(checks)}
+
+
+class DecideTests(unittest.TestCase):
+    def test_red_and_old_is_closed(self):
+        pull = proposal(check("policy-guard", "FAILURE"), check("typescript", "SUCCESS"))
+        close, reason = stale.decide(pull, NOW - dt.timedelta(hours=2), NOW)
+        self.assertTrue(close)
+        self.assertIn("policy-guard", reason)
+        self.assertNotIn("typescript", reason)
+
+    def test_red_but_young_is_left_to_settle(self):
+        pull = proposal(check("policy-guard", "FAILURE"))
+        close, reason = stale.decide(pull, NOW - dt.timedelta(minutes=10), NOW)
+        self.assertFalse(close)
+        self.assertIn("10 min old", reason)
+
+    def test_the_bound_is_inclusive_of_exactly_the_bound(self):
+        pull = proposal(check("policy-guard", "FAILURE"))
+        self.assertTrue(stale.decide(pull, NOW - stale.MIN_AGE, NOW)[0])
+
+    def test_green_or_pending_is_never_closed_however_old(self):
+        for entry in (
+            check("policy-guard", "SUCCESS"),
+            check("mergeability", state="PENDING"),
+            check("build-and-test", None),
+            check("ci", "CANCELLED"),
+            check("ci", "ACTION_REQUIRED"),
+        ):
+            with self.subTest(entry=entry):
+                close, _ = stale.decide(proposal(entry), NOW - dt.timedelta(days=3), NOW)
+                self.assertFalse(close)
+
+    def test_a_red_commit_status_counts_like_a_red_check_run(self):
+        pull = proposal(check("mergeability", state="FAILURE"))
+        self.assertTrue(stale.decide(pull, NOW - dt.timedelta(hours=2), NOW)[0])
+
+    def test_no_open_proposal_is_nothing_to_do(self):
+        close, reason = stale.decide(None, None, NOW)
+        self.assertFalse(close)
+        self.assertEqual(reason, "no open proposal")
+
+    def test_a_shorter_bound_can_be_passed(self):
+        pull = proposal(check("policy-guard", "FAILURE"))
+        close, _ = stale.decide(pull, NOW - dt.timedelta(minutes=10), NOW, dt.timedelta(minutes=5))
+        self.assertTrue(close)
+
+
+class ClassTests(unittest.TestCase):
+    def test_the_branch_comes_from_the_machine_class_definition(self):
+        self.assertEqual(stale.default_branch(), "spec-mirror")
+
+    def test_the_closing_comment_points_at_the_recovery_document(self):
+        text = stale.closing_comment("red for 120 min: policy-guard")
+        self.assertIn("MACHINE_PULL_REQUESTS.md", text)
+        self.assertIn("red for 120 min", text)
+
+
+class WorkflowTests(unittest.TestCase):
+    def test_the_producer_closes_before_it_proposes(self):
+        text = WORKFLOW.read_text(encoding="utf-8")
+        closing = text.index("scripts/stale_mirror_pr.py")
+        proposing = text.index("peter-evans/create-pull-request")
+        self.assertLess(closing, proposing)
+
+    def test_closing_uses_the_same_token_as_proposing(self):
+        text = WORKFLOW.read_text(encoding="utf-8")
+        closing = text.index("scripts/stale_mirror_pr.py")
+        step = text[text.rfind("- name:", 0, closing):closing]
+        self.assertIn("secrets.ZENDEV_PAT || github.token", step)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #143

## Achieved outcome

Every sync now runs `stale_mirror_pr.py` before proposing. When the open `spec-mirror` proposal has carried a concluded red check for longer than 90 minutes, the sync closes it with a comment saying why, deletes the branch, and the proposal step that follows opens a fresh one under the current workflow definitions. A pending or green proposal, or a red one younger than the bound, is left alone. `MACHINE_PULL_REQUESTS.md` describes the automated recovery and the churn a real cause produces.

## Tested revision

`bddfb11`

## Changed artifacts

- `scripts/stale_mirror_pr.py` — new: pure `decide(pull, head_committed_at, now, min_age)`, the closing comment, and a CLI with `--dry-run`.
- `scripts/tests/test_stale_mirror_pr.py` — new: red-and-old closes; red-and-young, green, pending, cancelled, action-required never close; the bound is inclusive; the step precedes the proposal and uses its token.
- `.github/workflows/spec-sync.yml` — a step before *Propose the mirror as a pull request*, with the same token the proposal uses.
- `docs/zendev/MACHINE_PULL_REQUESTS.md` — *Recovering one*: steps 2 and 3 are the producer's now; what churn means and who still owns a real cause.

## Acceptance criteria

- [x] Red and older than the bound: close. Red but younger: keep. Green or pending: keep. No open proposal: nothing — `DecideTests`.
- [x] The step runs before the proposal step and uses the same token the proposal uses — `WorkflowTests`.
- [x] The document describes the new behaviour and the churn it can produce when a gate is red for a real reason — the rewritten *Recovering one*.
- [x] `python -m unittest discover -s scripts/tests` passes — 177 tests at `bddfb11`.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest discover -s scripts/tests` | passed | 177 tests, OK, at `bddfb11` |
| `python scripts/policy_guard.py --base origin/master` | passed | 4 changed files, no violation |
| `dotnet build --configuration Release` | not_run | no product code changed; the required check runs it on this pull request. Risk left open: none for this diff |
| `dotnet test --configuration Release` | not_run | same |
| `npm run typecheck && npm test && npm run build` | not_run | same |

## Not checked

A live close. No refused proposal is open right now. After merge, `python scripts/stale_mirror_pr.py --repo drevendev/trade_simulation --dry-run` prints the decision without acting; the next real refusal is the live test.

## Assumptions and unknowns

- Assumed: `gh pr list --head spec-mirror` returns the one open proposal; the class permits only one branch, so there is at most one.
- Assumed: after `--delete-branch`, `peter-evans/create-pull-request` recreates the branch from the fresh checkout in the same run. This is the action's documented behaviour for a missing branch.
- Known cost: a proposal red for a real reason is closed and re-proposed every time the bound elapses. Visible churn, no stall, still a person's to end.

## Highest-risk area for review

`RED`: the set of conclusions treated as refusals. `CANCELLED` and `ACTION_REQUIRED` are deliberately excluded; including them would close a proposal whose checks were merely superseded or awaiting approval.

## Remaining gate

None mandatory. The step uses the token the proposal step already uses; no new credential reaches the workflow.
