### PR TITLE
Record the subscription windows and the kind of run, not only the tokens

### DIFF
--- a/.github/workflows/zendev-acceptor.yml
+++ b/.github/workflows/zendev-acceptor.yml
@@ -48,7 +48,9 @@ jobs:
       # request that edited that script would have had its version executed by the
       # reviewing workflow, with the ledger credential in the environment.
       - name: Stage the usage recorder outside the working tree
-        run: cp scripts/record_usage.py "${RUNNER_TEMP}/record_usage.py"
+        run: |
+          cp scripts/record_usage.py "${RUNNER_TEMP}/record_usage.py"
+          cp scripts/subscription_usage.py "${RUNNER_TEMP}/subscription_usage.py"
 
       # Section 1 of the runbook is a computation, and running it in the model cost
       # two consecutive runs on one ineligible pull request while three others went
@@ -60,6 +62,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.ZENDEV_PAT || github.token }}
         run: python scripts/select_review_target.py --repo "${{ github.repository }}"
+
+      # The subscription is metered in rolling windows, not dollars. One reading before
+      # the model and one after; the recorder writes the difference to the private
+      # ledger. Only when a model run is about to happen: a run with no work spends
+      # nothing and needs no reading. The token reaches this step and the model step
+      # only, and the reading never prints what it read.
+      - name: Read the subscription windows before the model runs
+        if: steps.select.outputs.target != 'none'
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: python "${RUNNER_TEMP}/subscription_usage.py" --out "${RUNNER_TEMP}/usage-before.json"
 
       - name: Review one pull request
         id: claude
@@ -121,6 +134,12 @@ jobs:
             - If you cannot decide, name the exact gate in a comment and leave the
               pull request open. Never merge to clear a queue.
 
+      - name: Read the subscription windows after the model ran
+        if: always() && steps.select.outputs.target != 'none'
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: python "${RUNNER_TEMP}/subscription_usage.py" --out "${RUNNER_TEMP}/usage-after.json"
+
       # Telemetry only. See the note in zendev-author.yml: this never fails the run.
       - name: Record what this run consumed
         if: always()
@@ -134,4 +153,6 @@ jobs:
             --ledger-repo drevendev/zen-telemetry \
             --run-id "${{ github.run_id }}" \
             --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --commit "${{ github.sha }}"
+            --commit "${{ github.sha }}" \
+            --usage-before "${RUNNER_TEMP}/usage-before.json" \
+            --usage-after "${RUNNER_TEMP}/usage-after.json"

--- a/.github/workflows/zendev-author.yml
+++ b/.github/workflows/zendev-author.yml
@@ -48,7 +48,18 @@ jobs:
       # request that edited that script would have had its version executed by the
       # reviewing workflow, with the ledger credential in the environment.
       - name: Stage the usage recorder outside the working tree
-        run: cp scripts/record_usage.py "${RUNNER_TEMP}/record_usage.py"
+        run: |
+          cp scripts/record_usage.py "${RUNNER_TEMP}/record_usage.py"
+          cp scripts/subscription_usage.py "${RUNNER_TEMP}/subscription_usage.py"
+
+      # The subscription is metered in rolling windows, not dollars. One reading before
+      # the model and one after; the recorder writes the difference to the private
+      # ledger. The token reaches this step and the model step only, and the reading
+      # never prints what it read.
+      - name: Read the subscription windows before the model runs
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: python "${RUNNER_TEMP}/subscription_usage.py" --out "${RUNNER_TEMP}/usage-before.json"
 
       - name: Run one AUTHOR unit of work
         id: claude
@@ -102,6 +113,12 @@ jobs:
             - If you are blocked, say so on the Issue with the exact gate and stop.
               A blocked run that reports honestly is a successful run.
 
+      - name: Read the subscription windows after the model ran
+        if: always()
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: python "${RUNNER_TEMP}/subscription_usage.py" --out "${RUNNER_TEMP}/usage-after.json"
+
       # Telemetry only. This repository is public, so the numbers go to a private
       # ledger. It never fails the run: a missing token or an unreachable ledger is a
       # warning, because a loop that stops over bookkeeping is worse than a gap in the
@@ -118,4 +135,6 @@ jobs:
             --ledger-repo drevendev/zen-telemetry \
             --run-id "${{ github.run_id }}" \
             --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --commit "${{ github.sha }}"
+            --commit "${{ github.sha }}" \
+            --usage-before "${RUNNER_TEMP}/usage-before.json" \
+            --usage-after "${RUNNER_TEMP}/usage-after.json"

--- a/scripts/record_usage.py
+++ b/scripts/record_usage.py
@@ -12,6 +12,21 @@ Two rules shape this script:
 - **Unknown is not zero.** A field that could not be determined is written as null and
   the record is marked so the rollup can exclude it, rather than quietly reporting a
   run that cost nothing.
+
+Beyond tokens, a record now says three more things, because three days of records
+could not answer the questions that matter for the budget:
+
+- **What share of the subscription the run consumed.** The loop runs on a subscription
+  metered in rolling windows, not dollars. ``subscription_usage.py`` reads the windows
+  before and after the model; the difference is recorded here. Those figures go to the
+  private ledger only — the public log prints the record without them.
+- **What kind of run it was.** ``completed``, ``no_work``, ``blocked``, ``failed`` or
+  ``unknown``. The workflow decides ``no_work`` and ``failed``; the rest is read from
+  what the model wrote and is marked as a heuristic, because a transcript that discusses
+  a blocker it does not have looks blocked to a string search.
+- **Which work it touched.** Issue and pull request numbers and requirement identifiers
+  mentioned in the transcript, and whether an author run was reworking a refusal. These
+  are what let cost be read per merged requirement instead of per run.
 """
 
 from __future__ import annotations
@@ -22,6 +37,7 @@ import datetime as dt
 import json
 import os
 import pathlib
+import re
 import sys
 import urllib.error
 import urllib.request
@@ -34,6 +50,31 @@ TOKEN_FIELDS = (
 )
 
 API = "https://api.github.com"
+
+# The two windows whose difference is a run's share of the subscription.
+GATING_WINDOWS = ("five_hour", "seven_day")
+
+OUTCOMES = ("completed", "no_work", "blocked", "failed", "unknown")
+
+REQUIREMENT = re.compile(r"\bREQ-[A-Z]+-\d{3}\b")
+# `#123` not glued to a word, a slash or another hash: a forge reference, not a URL
+# fragment, a colour code or a markdown heading.
+REFERENCE = re.compile(r"(?<![\w/#])#(\d{1,6})\b")
+
+# The shapes a run uses when it stops on a gate: the label it sets, the phrase the
+# runbook prescribes, or a heading that names a blocker. Prose that merely mentions the
+# word — "no known blockers" in a claim comment — is not a heading and does not match.
+BLOCKED = re.compile(
+    r"status:blocked|\bblocked on\b|^#{1,6}[^\n]*\bblock(?:ed|er)\b", re.I | re.M
+)
+NO_WORK = re.compile(
+    r"\bno[_ ]work\b|\bno eligible\b|\bnothing (?:is )?eligible\b|\bno executable work\b",
+    re.I,
+)
+REWORK = re.compile(
+    r"REQUEST_CHANGES|CHANGES_REQUESTED|\bchanges requested\b|\bACCEPTOR (?:verdict|feedback)\b",
+    re.I,
+)
 
 
 def warn(message: str) -> None:
@@ -112,6 +153,106 @@ def extract_usage(messages):
     return totals, {}, "summed"
 
 
+def transcript(messages) -> str:
+    """Everything the model said: the final result text and every assistant text block."""
+    parts = []
+    for message in messages or []:
+        if not isinstance(message, dict):
+            continue
+        if message.get("type") == "result" and isinstance(message.get("result"), str):
+            parts.append(message["result"])
+        content = (message.get("message") or {}).get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if (
+                isinstance(block, dict)
+                and block.get("type") == "text"
+                and isinstance(block.get("text"), str)
+            ):
+                parts.append(block["text"])
+    return "\n".join(parts)
+
+
+def classify_outcome(conclusion, text):
+    """(outcome, source). Pure.
+
+    The workflow's own conclusion is trusted where it is specific: `no_work` means the
+    model was never started, and anything that is not success or unknown is a failure.
+    Everything else is read from the transcript, and the source says so.
+    """
+    if conclusion == "no_work":
+        return "no_work", "workflow"
+    if conclusion not in (None, "", "unknown", "success"):
+        return "failed", "workflow"
+    if BLOCKED.search(text or ""):
+        return "blocked", "heuristic"
+    if NO_WORK.search(text or ""):
+        return "no_work", "heuristic"
+    if conclusion == "success":
+        return "completed", "heuristic"
+    return "unknown", "heuristic"
+
+
+def mentions(text):
+    """Forge references and requirement identifiers the transcript names. Pure."""
+    return {
+        "references": sorted({int(number) for number in REFERENCE.findall(text or "")}),
+        "requirements": sorted(set(REQUIREMENT.findall(text or ""))),
+    }
+
+
+def is_rework(role, text):
+    """Whether an author run was answering a refusal. None for any other role."""
+    if role != "author":
+        return None
+    return bool(REWORK.search(text or ""))
+
+
+def load_reading(path):
+    """A subscription reading written by subscription_usage.py, or None."""
+    if not path:
+        return None
+    try:
+        data = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _utilization(reading, window):
+    if not isinstance(reading, dict) or not reading.get("available"):
+        return None
+    block = reading.get(window)
+    if not isinstance(block, dict):
+        return None
+    value = block.get("utilization")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return value
+
+
+def subscription_block(before, after):
+    """Before, after and the difference per gating window. Pure.
+
+    The delta is null unless both readings are available: a missing side is a gap in
+    the bookkeeping, and a gap must never be read as a run that consumed nothing.
+    """
+    delta = {}
+    for window in GATING_WINDOWS:
+        first, second = _utilization(before, window), _utilization(after, window)
+        if first is None or second is None:
+            delta[window] = None
+        else:
+            delta[window] = round(second - first, 3)
+    return {"before": before, "after": after, "delta": delta}
+
+
+def public_view(record):
+    """The record as printed in the public run log: everything but the subscription."""
+    return {key: value for key, value in record.items() if key != "subscription"}
+
+
 def put_record(repo: str, path: str, payload: str, token: str) -> None:
     body = json.dumps(
         {
@@ -144,24 +285,37 @@ def main() -> int:
     parser.add_argument("--run-id", default="")
     parser.add_argument("--run-url", default="")
     parser.add_argument("--commit", default="")
+    parser.add_argument("--usage-before", default="", help="subscription reading before the model")
+    parser.add_argument("--usage-after", default="", help="subscription reading after the model")
     args = parser.parse_args()
 
     messages, problem = read_messages(args.execution_file)
     if problem:
         warn(problem)
         tokens = {field: None for field in TOKEN_FIELDS}
-        extra, source, model = {}, "unavailable", None
+        extra, source, model, text = {}, "unavailable", None, ""
     else:
         tokens, extra, source = extract_usage(messages)
         model = extract_model(messages)
+        text = transcript(messages)
         if model is None:
             warn("the execution file names no model; recording null")
+
+    outcome, outcome_source = classify_outcome(args.conclusion, text)
+    before = load_reading(args.usage_before)
+    after = load_reading(args.usage_after)
+    if before is None or after is None:
+        warn("a subscription reading is missing; the subscription block carries nulls")
 
     now = dt.datetime.now(dt.timezone.utc)
     record = {
         "recorded_at": now.isoformat(timespec="seconds"),
         "role": args.role,
         "conclusion": args.conclusion,
+        "outcome": outcome,
+        "outcome_source": outcome_source,
+        "rework": is_rework(args.role, text),
+        "mentions": mentions(text),
         "model": model,
         "usage_source": source,
         **tokens,
@@ -169,6 +323,7 @@ def main() -> int:
         "duration_ms": extra.get("duration_ms"),
         "num_turns": extra.get("num_turns"),
         "session_id": extra.get("session_id"),
+        "subscription": subscription_block(before, after),
         "run_id": args.run_id,
         "run_url": args.run_url,
         "commit": args.commit,
@@ -176,8 +331,10 @@ def main() -> int:
     payload = json.dumps(record, indent=2, ensure_ascii=False) + "\n"
 
     # Visible in the public run log on purpose: token counts are not sensitive, and
-    # seeing them here is what makes a broken ledger obvious.
-    print(json.dumps(record, ensure_ascii=False))
+    # seeing them here is what makes a broken ledger obvious. The subscription figures
+    # are the one exception — they describe the account, not the run — and stay in the
+    # private ledger.
+    print(json.dumps(public_view(record), ensure_ascii=False))
 
     token = os.environ.get("TELEMETRY_TOKEN", "")
     if not token:

--- a/scripts/subscription_usage.py
+++ b/scripts/subscription_usage.py
@@ -1,0 +1,140 @@
+"""Read how much of the subscription's rate-limit windows is in use, so a run's share
+can be recorded.
+
+The loop authenticates with a Claude subscription token, and a subscription is not
+metered in dollars. It is metered in rolling windows — five hours and seven days — each
+reported as a utilization percentage, the same figures Claude Code shows on its own
+usage screen. The ledger's ``total_cost_usd`` is what the same tokens would cost at API
+list prices; it says nothing about how close the loop is to the ceiling that actually
+stops it. This reads that ceiling once before the model runs and once after, and the
+difference is the run's share of the subscription.
+
+Three rules, the same ones ``record_usage.py`` lives by:
+
+- **It never fails the run.** No token, a 429, a timeout, a body that is not JSON: each
+  writes a file saying the reading is unavailable, and exits 0.
+- **Unknown is not zero.** An unavailable reading is ``available: false`` with a reason,
+  and the recorder turns that into nulls — never into a zero delta.
+- **It prints nothing it read.** Neither the token nor the response body appears in the
+  log, only whether the reading succeeded. The figures themselves reach the private
+  ledger through the recorder and stay out of the public run log.
+
+The endpoint is the one Claude Code itself uses. It is not a documented public API, so
+this reads defensively: only the two fields per window that the ledger needs are kept,
+and any surprise in the shape becomes "unavailable" rather than a crash or a guess.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import pathlib
+import sys
+import urllib.error
+import urllib.request
+
+ENDPOINT = "https://api.anthropic.com/api/oauth/usage"
+TOKEN_VARIABLE = "CLAUDE_CODE_OAUTH_TOKEN"
+
+# Both headers are load-bearing. Without the beta header the endpoint does not accept
+# an OAuth token at all; without a Claude Code user agent it rate-limits aggressively
+# and answers 429 to everything.
+BETA_HEADER = "oauth-2025-04-20"
+USER_AGENT = "claude-code/2.1.0"
+
+# The windows the ledger records. `five_hour` and `seven_day` are the two that gate the
+# loop; the per-model weekly windows exist on some plans and are kept when present.
+WINDOWS = ("five_hour", "seven_day", "seven_day_opus", "seven_day_sonnet")
+KEPT_FIELDS = ("utilization", "resets_at")
+
+
+def now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds")
+
+
+def summarize(payload):
+    """Keep only utilization and reset time per window. Pure.
+
+    Everything else the endpoint returns — credits, limits, flags — is dropped here, so
+    the ledger never accumulates fields nobody asked for, and a shape change upstream
+    can at worst turn one window into null.
+    """
+    windows = {}
+    for name in WINDOWS:
+        block = payload.get(name) if isinstance(payload, dict) else None
+        if not isinstance(block, dict):
+            windows[name] = None
+            continue
+        utilization = block.get("utilization")
+        if isinstance(utilization, bool) or not isinstance(utilization, (int, float)):
+            utilization = None
+        resets_at = block.get("resets_at")
+        if not isinstance(resets_at, str):
+            resets_at = None
+        windows[name] = {"utilization": utilization, "resets_at": resets_at}
+    return windows
+
+
+def unavailable(reason: str):
+    return {
+        "available": False,
+        "reason": reason,
+        "fetched_at": now_iso(),
+        **{name: None for name in WINDOWS},
+    }
+
+
+def fetch(token: str, timeout: float = 20.0):
+    request = urllib.request.Request(
+        ENDPOINT,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "anthropic-beta": BETA_HEADER,
+            "User-Agent": USER_AGENT,
+            "Accept": "application/json",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def read(token: str, fetcher=fetch):
+    """One reading, or an unavailable record naming the class of failure. Never raises."""
+    if not token:
+        return unavailable("no token in the environment")
+    try:
+        payload = fetcher(token)
+    except urllib.error.HTTPError as exc:
+        # The status code and nothing else: the body of a refusal is not ours to log.
+        return unavailable(f"HTTP {exc.code}")
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return unavailable(type(exc).__name__)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return unavailable("malformed body")
+    if not isinstance(payload, dict):
+        return unavailable("malformed body")
+    return {"available": True, "reason": None, "fetched_at": now_iso(), **summarize(payload)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", required=True, help="where to write the reading as JSON")
+    args = parser.parse_args()
+
+    reading = read(os.environ.get(TOKEN_VARIABLE, ""))
+    path = pathlib.Path(args.out)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(reading, indent=2) + "\n", encoding="utf-8")
+
+    # The figures stay out of the public log on purpose; only the fact of a reading.
+    if reading["available"]:
+        print("subscription_usage: reading recorded")
+    else:
+        print(f"::warning::subscription_usage: reading unavailable ({reading['reason']})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_record_usage.py
+++ b/scripts/tests/test_record_usage.py
@@ -116,5 +116,142 @@ class ReadMessagesTests(unittest.TestCase):
         self.assertEqual(len(messages), 1)
 
 
+class TranscriptTests(unittest.TestCase):
+    def test_result_text_and_assistant_text_blocks_are_joined(self):
+        messages = [
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "first"}]}},
+            {"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "Bash"}]}},
+            {"type": "result", "result": "done"},
+        ]
+        self.assertEqual(rec.transcript(messages), "first\ndone")
+
+    def test_a_malformed_message_list_yields_an_empty_transcript(self):
+        self.assertEqual(rec.transcript([None, "text", {"type": "result"}]), "")
+
+
+class OutcomeTests(unittest.TestCase):
+    def test_no_work_from_the_workflow_is_trusted(self):
+        self.assertEqual(rec.classify_outcome("no_work", "anything"), ("no_work", "workflow"))
+
+    def test_a_failed_action_is_failed_whatever_the_transcript_says(self):
+        self.assertEqual(rec.classify_outcome("failure", "all good"), ("failed", "workflow"))
+
+    def test_a_blocked_run_is_read_from_its_own_markers(self):
+        for text in (
+            "Set status:blocked and stopped.",
+            "## AUTHOR blocker\n\nGate: token scope",
+            "**Blocked on**: the mirror is missing",
+        ):
+            with self.subTest(text=text):
+                self.assertEqual(rec.classify_outcome("success", text), ("blocked", "heuristic"))
+
+    def test_prose_mentioning_blockers_is_not_a_blocked_run(self):
+        # The claim comment every run posts says "Known blockers: none".
+        text = "**AUTHOR claim**\n\nKnown blockers: none. Proceeding."
+        self.assertEqual(rec.classify_outcome("success", text), ("completed", "heuristic"))
+
+    def test_a_run_that_found_nothing_is_no_work(self):
+        text = "Evaluated items 1-5: no eligible item. Nothing to do."
+        self.assertEqual(rec.classify_outcome("success", text), ("no_work", "heuristic"))
+
+    def test_an_unknown_conclusion_with_no_markers_is_unknown(self):
+        self.assertEqual(rec.classify_outcome("unknown", ""), ("unknown", "heuristic"))
+        self.assertEqual(rec.classify_outcome("", ""), ("unknown", "heuristic"))
+
+    def test_every_outcome_is_one_of_the_declared_values(self):
+        for conclusion, text in (("success", ""), ("failure", ""), ("no_work", ""), ("", "x")):
+            outcome, _ = rec.classify_outcome(conclusion, text)
+            self.assertIn(outcome, rec.OUTCOMES)
+
+
+class MentionTests(unittest.TestCase):
+    def test_references_and_requirements_are_collected_once_each_and_sorted(self):
+        text = "Closes #135. See #48 and #135; REQ-CONFIG-004 depends on REQ-CONFIG-003."
+        self.assertEqual(
+            rec.mentions(text),
+            {"references": [48, 135], "requirements": ["REQ-CONFIG-003", "REQ-CONFIG-004"]},
+        )
+
+    def test_url_fragments_headings_and_colours_are_not_references(self):
+        text = "https://x/pull/130#issuecomment-5 ## Heading #ffffff #123abc"
+        self.assertEqual(rec.mentions(text)["references"], [])
+
+    def test_empty_text_yields_empty_lists(self):
+        self.assertEqual(rec.mentions(""), {"references": [], "requirements": []})
+
+
+class ReworkTests(unittest.TestCase):
+    def test_an_author_answering_a_refusal_is_rework(self):
+        self.assertTrue(rec.is_rework("author", "Addressed REQUEST_CHANGES feedback"))
+        self.assertTrue(rec.is_rework("author", "## Handoff\n\nchanges requested were fixed"))
+
+    def test_an_author_implementing_fresh_work_is_not(self):
+        self.assertFalse(rec.is_rework("author", "Implemented REQ-CONFIG-004 and opened #150"))
+
+    def test_other_roles_are_null_not_false(self):
+        self.assertIsNone(rec.is_rework("acceptor", "REQUEST_CHANGES"))
+
+
+def reading(**windows):
+    return {"available": True, "reason": None, **windows}
+
+
+class SubscriptionBlockTests(unittest.TestCase):
+    def test_the_delta_is_the_difference_per_gating_window(self):
+        before = reading(five_hour={"utilization": 10.0}, seven_day={"utilization": 40})
+        after = reading(five_hour={"utilization": 12.5}, seven_day={"utilization": 41})
+        block = rec.subscription_block(before, after)
+        self.assertEqual(block["delta"], {"five_hour": 2.5, "seven_day": 1})
+        self.assertIs(block["before"], before)
+        self.assertIs(block["after"], after)
+
+    def test_a_missing_side_makes_the_delta_null_not_zero(self):
+        after = reading(five_hour={"utilization": 12.5}, seven_day={"utilization": 41})
+        block = rec.subscription_block(None, after)
+        self.assertEqual(block["delta"], {"five_hour": None, "seven_day": None})
+        self.assertIsNone(block["before"])
+
+    def test_an_unavailable_reading_counts_as_missing(self):
+        before = reading(five_hour={"utilization": 10.0}, seven_day={"utilization": 40})
+        after = {"available": False, "reason": "HTTP 429", "five_hour": None, "seven_day": None}
+        self.assertEqual(
+            rec.subscription_block(before, after)["delta"],
+            {"five_hour": None, "seven_day": None},
+        )
+
+    def test_one_null_window_does_not_poison_the_other(self):
+        before = reading(five_hour={"utilization": 10.0}, seven_day=None)
+        after = reading(five_hour={"utilization": 11.0}, seven_day={"utilization": 41})
+        self.assertEqual(
+            rec.subscription_block(before, after)["delta"], {"five_hour": 1.0, "seven_day": None}
+        )
+
+
+class PublicViewTests(unittest.TestCase):
+    def test_the_public_log_never_carries_the_subscription_block(self):
+        record = {"role": "author", "subscription": {"delta": {"five_hour": 2}}, "num_turns": 3}
+        public = rec.public_view(record)
+        self.assertNotIn("subscription", public)
+        self.assertEqual(public["num_turns"], 3)
+        # And the original is untouched: the ledger gets everything.
+        self.assertIn("subscription", record)
+
+
+class LoadReadingTests(unittest.TestCase):
+    def test_missing_or_malformed_files_are_none(self):
+        self.assertIsNone(rec.load_reading(""))
+        self.assertIsNone(rec.load_reading("no-such-file.json"))
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "bad.json"
+            path.write_text("[1]", encoding="utf-8")
+            self.assertIsNone(rec.load_reading(str(path)))
+
+    def test_a_reading_round_trips(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "ok.json"
+            path.write_text(json.dumps({"available": False, "reason": "HTTP 429"}), encoding="utf-8")
+            self.assertEqual(rec.load_reading(str(path))["reason"], "HTTP 429")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_subscription_usage.py
+++ b/scripts/tests/test_subscription_usage.py
@@ -1,0 +1,114 @@
+"""A reading that cannot be taken must say so, and a reading that can must say only
+what the ledger asked for."""
+
+import json
+import pathlib
+import sys
+import unittest
+import urllib.error
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import subscription_usage as usage  # noqa: E402
+
+PAYLOAD = {
+    "five_hour": {"utilization": 12.5, "resets_at": "2026-09-05T18:00:00Z"},
+    "seven_day": {"utilization": 41, "resets_at": "2026-09-08T04:50:00Z"},
+    "seven_day_opus": None,
+    "seven_day_sonnet": {"utilization": 3, "resets_at": "2026-09-08T04:50:00Z"},
+    "extra_usage": {"is_enabled": False, "monthly_limit": None, "used_credits": None},
+}
+
+
+class SummarizeTests(unittest.TestCase):
+    def test_only_the_two_fields_per_window_survive(self):
+        windows = usage.summarize(PAYLOAD)
+        self.assertEqual(set(windows), set(usage.WINDOWS))
+        self.assertEqual(
+            windows["five_hour"],
+            {"utilization": 12.5, "resets_at": "2026-09-05T18:00:00Z"},
+        )
+        self.assertNotIn("extra_usage", windows)
+
+    def test_an_absent_window_is_null_not_zero(self):
+        self.assertIsNone(usage.summarize(PAYLOAD)["seven_day_opus"])
+
+    def test_a_non_numeric_utilization_is_dropped(self):
+        payload = {"five_hour": {"utilization": "12", "resets_at": 5}}
+        self.assertEqual(
+            usage.summarize(payload)["five_hour"], {"utilization": None, "resets_at": None}
+        )
+
+    def test_a_boolean_is_not_a_percentage(self):
+        payload = {"five_hour": {"utilization": True, "resets_at": "x"}}
+        self.assertIsNone(usage.summarize(payload)["five_hour"]["utilization"])
+
+    def test_a_payload_that_is_not_an_object_yields_all_nulls(self):
+        self.assertTrue(all(v is None for v in usage.summarize(["nope"]).values()))
+
+
+class ReadTests(unittest.TestCase):
+    def test_no_token_is_unavailable_with_a_reason(self):
+        reading = usage.read("", fetcher=lambda token: PAYLOAD)
+        self.assertFalse(reading["available"])
+        self.assertIn("no token", reading["reason"])
+        self.assertIsNone(reading["five_hour"])
+
+    def test_a_rate_limit_is_recorded_by_status_code_only(self):
+        def refuse(token):
+            raise urllib.error.HTTPError("u", 429, "Too Many Requests", {}, None)
+
+        reading = usage.read("t", fetcher=refuse)
+        self.assertFalse(reading["available"])
+        self.assertEqual(reading["reason"], "HTTP 429")
+
+    def test_a_network_failure_is_recorded_by_class(self):
+        def drop(token):
+            raise urllib.error.URLError("unreachable")
+
+        reading = usage.read("t", fetcher=drop)
+        self.assertFalse(reading["available"])
+        self.assertEqual(reading["reason"], "URLError")
+
+    def test_a_timeout_is_recorded_by_class(self):
+        def hang(token):
+            raise TimeoutError()
+
+        self.assertEqual(usage.read("t", fetcher=hang)["reason"], "TimeoutError")
+
+    def test_a_malformed_body_is_unavailable(self):
+        def garbage(token):
+            raise json.JSONDecodeError("bad", "", 0)
+
+        self.assertEqual(usage.read("t", fetcher=garbage)["reason"], "malformed body")
+        self.assertEqual(usage.read("t", fetcher=lambda t: [1, 2])["reason"], "malformed body")
+
+    def test_a_successful_reading_is_available_and_summarized(self):
+        reading = usage.read("t", fetcher=lambda token: PAYLOAD)
+        self.assertTrue(reading["available"])
+        self.assertIsNone(reading["reason"])
+        self.assertEqual(reading["seven_day"]["utilization"], 41)
+        self.assertNotIn("extra_usage", reading)
+
+    def test_the_fetcher_receives_the_token_and_nothing_is_printed_from_it(self):
+        seen = {}
+
+        def capture(token):
+            seen["token"] = token
+            return PAYLOAD
+
+        reading = usage.read("secret-token", fetcher=capture)
+        self.assertEqual(seen["token"], "secret-token")
+        self.assertNotIn("secret-token", json.dumps(reading))
+
+
+class HeaderTests(unittest.TestCase):
+    def test_the_two_headers_the_endpoint_requires_are_declared(self):
+        # Losing either one turns every reading into "HTTP 429" or "HTTP 401", which the
+        # ledger would faithfully record as a gap forever. Pin them.
+        self.assertEqual(usage.BETA_HEADER, "oauth-2025-04-20")
+        self.assertTrue(usage.USER_AGENT.startswith("claude-code/"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_workflow_bookkeeping.py
+++ b/scripts/tests/test_workflow_bookkeeping.py
@@ -10,6 +10,10 @@ The recording step carries the ledger credential, so this is also the shape of a
 credential-handling defect: a pull request that edited the recorder would have had its
 version executed by the reviewing workflow with that token in the environment.
 
+The subscription reader is held to the same rule, and to one more: it carries the
+Claude OAuth token, so that token must reach exactly the steps that need it — the model
+and the two readings — and no other.
+
 These are text assertions rather than a YAML parse, deliberately — the check must run
 in the policy-guard job with nothing installed but the standard library.
 """
@@ -25,6 +29,11 @@ STAGED_CALL = 'python "${RUNNER_TEMP}/record_usage.py"'
 WORKING_TREE_CALL = "python scripts/record_usage.py"
 MODEL_STEP = "uses: anthropics/claude-code-action"
 
+USAGE_STAGE_LINE = 'cp scripts/subscription_usage.py "${RUNNER_TEMP}/subscription_usage.py"'
+USAGE_STAGED_CALL = 'python "${RUNNER_TEMP}/subscription_usage.py"'
+USAGE_WORKING_TREE_CALL = "python scripts/subscription_usage.py"
+OAUTH_TOKEN = "secrets.CLAUDE_CODE_OAUTH_TOKEN"
+
 
 def lines(name):
     return (WORKFLOWS / name).read_text(encoding="utf-8").splitlines()
@@ -35,6 +44,10 @@ def index_of(rows, needle, name):
         if needle in row:
             return i
     raise AssertionError(f"{name}: {needle!r} not found")
+
+
+def indexes_of(rows, needle):
+    return [i for i, row in enumerate(rows) if needle in row]
 
 
 class BookkeeperIsolationTests(unittest.TestCase):
@@ -74,6 +87,46 @@ class BookkeeperIsolationTests(unittest.TestCase):
             with self.subTest(workflow=name):
                 self.assertTrue((WORKFLOWS / name).is_file(), f"{name} is missing")
                 self.assertIn(MODEL_STEP, "\n".join(lines(name)))
+
+
+class SubscriptionReaderTests(unittest.TestCase):
+    def test_the_reader_is_staged_before_the_model_runs(self):
+        for name in MODEL_RUNNERS:
+            with self.subTest(workflow=name):
+                rows = lines(name)
+                self.assertLess(index_of(rows, USAGE_STAGE_LINE, name), index_of(rows, MODEL_STEP, name))
+
+    def test_one_reading_precedes_the_model_and_one_follows_it(self):
+        for name in MODEL_RUNNERS:
+            with self.subTest(workflow=name):
+                rows = lines(name)
+                calls = indexes_of(rows, USAGE_STAGED_CALL)
+                model = index_of(rows, MODEL_STEP, name)
+                self.assertEqual(len(calls), 2, f"{name}: expected exactly two readings, found {len(calls)}")
+                self.assertLess(calls[0], model, f"{name}: the first reading must precede the model")
+                self.assertGreater(calls[1], model, f"{name}: the second reading must follow the model")
+
+    def test_the_reader_never_runs_from_the_working_tree(self):
+        for name in MODEL_RUNNERS:
+            with self.subTest(workflow=name):
+                self.assertEqual([r for r in lines(name) if USAGE_WORKING_TREE_CALL in r], [])
+
+    def test_the_oauth_token_reaches_exactly_the_model_and_the_two_readings(self):
+        for name in MODEL_RUNNERS:
+            with self.subTest(workflow=name):
+                self.assertEqual(
+                    len(indexes_of(lines(name), OAUTH_TOKEN)),
+                    3,
+                    f"{name}: the OAuth token must appear in the model step and the two "
+                    "reading steps, nowhere else",
+                )
+
+    def test_the_recorder_receives_both_readings(self):
+        for name in MODEL_RUNNERS:
+            with self.subTest(workflow=name):
+                text = "\n".join(lines(name))
+                self.assertIn("--usage-before", text)
+                self.assertIn("--usage-after", text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #144

## Achieved outcome

Every ledger record now carries a `subscription` block — the five-hour and seven-day window utilization before and after the model, and the difference — plus `outcome` (`completed`, `no_work`, `blocked`, `failed`, `unknown`) with its source, a `rework` flag for author runs, and `mentions` of Issue numbers and requirement identifiers named in the transcript. The subscription figures reach only the private ledger; the public run log prints the record without them. Cost can now be read per merged requirement, in the unit the subscription actually meters.

## Tested revision

`597af90`

## Changed artifacts

- `scripts/subscription_usage.py` — new: one reading of the windows written as JSON; only `utilization` and `resets_at` per window are kept; any failure is `available: false` with a reason; nothing it read is printed.
- `scripts/record_usage.py` — `--usage-before` / `--usage-after`; `subscription` block with before, after and per-window delta; `transcript`, `classify_outcome`, `mentions`, `is_rework`; `public_view` strips the subscription from the printed record.
- `scripts/tests/test_subscription_usage.py` — new: summarize keeps two fields, drops the rest; every failure class is unavailable, never zero; the token is never in the reading.
- `scripts/tests/test_record_usage.py` — transcript, outcome per class, mentions, rework, subscription block including a missing side and an unavailable side, public view, reading loader.
- `scripts/tests/test_workflow_bookkeeping.py` — the reader is staged before the model; exactly one reading before and one after; the OAuth token appears exactly three times per workflow; the recorder receives both readings.
- `.github/workflows/zendev-author.yml` — stages the reader, reads before and after the model, passes both files to the recorder.
- `.github/workflows/zendev-acceptor.yml` — the same, gated on a selected target so a no-work run makes no reading.

## Acceptance criteria

- [x] `summarize()` keeps only `utilization` and `resets_at` for each window and drops everything else — `SummarizeTests`.
- [x] An HTTP error, a timeout, a malformed body or a missing token yield `available: false` and a null block in the record, never zero — `ReadTests`, `SubscriptionBlockTests`.
- [x] The delta is computed only when both readings are available — `test_a_missing_side_makes_the_delta_null_not_zero`, `test_an_unavailable_reading_counts_as_missing`.
- [x] Outcome classification and mention extraction have tests for each class — `OutcomeTests`, `MentionTests`, `ReworkTests`.
- [x] Both model-running workflows stage the usage script before the model and call the staged copy; the token appears only in the two usage steps and the model step — `SubscriptionReaderTests`.
- [x] The printed record carries no `subscription` key; the ledger record does — `PublicViewTests`; `main()` prints `public_view(record)` and uploads `record`.
- [x] `python -m unittest discover -s scripts/tests` passes — 206 tests at `597af90`.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest discover -s scripts/tests` | passed | 206 tests, OK, at `597af90` |
| `python scripts/policy_guard.py --base origin/master` | passed | 7 changed files, no violation |
| `dotnet build --configuration Release` | not_run | no product code changed; the required check runs it on this pull request. Risk left open: none for this diff |
| `dotnet test --configuration Release` | not_run | same |
| `npm run typecheck && npm test && npm run build` | not_run | same |

## Not checked

The endpoint was not called from this session: the token lives in the workflow's secrets, not here. The first scheduled run after merge is the live check. A 429 or a changed shape appears as `available: false` with a reason in the ledger — never as a zero delta — and the rest of the record is unaffected.

## Assumptions and unknowns

- The endpoint, its two headers and its response shape are the ones Claude Code's own usage screen uses, as documented by third-party tooling. It is not a public API; if it changes, the block goes null and nothing else breaks.
- The `User-Agent` names a Claude Code version that may not match the action's. The endpoint is known to key on the `claude-code/` prefix; if it turns out to key on the exact version, every reading is `HTTP 429` and the ledger says so.
- `outcome` and `rework` are heuristics over the transcript and are marked `heuristic` in the record; only `no_work` and `failed` come from the workflow.
- The window figures describe the account, not the run, which is why they are kept out of the public log even though token counts are printed.

## Highest-risk area for review

The two workflow files. The OAuth token now reaches two more steps. `test_the_oauth_token_reaches_exactly_the_model_and_the_two_readings` pins the count to three per workflow, and the reader runs from a copy staged before the model, for the same reason the recorder does.

## Remaining gate

Widening: the OAuth token is exposed to two additional steps, so a person accepts this change per the ACCEPTOR hard limits. Follow-up outside this repository: the rollup in `zen-telemetry` does not yet read `subscription`, `outcome` or `mentions`.
