### PR TITLE
Close a pull request at its third refusal and return the Issue to the queue

### DIFF
--- a/.github/workflows/zendev-acceptor.yml
+++ b/.github/workflows/zendev-acceptor.yml
@@ -51,6 +51,8 @@ jobs:
         run: |
           cp scripts/record_usage.py "${RUNNER_TEMP}/record_usage.py"
           cp scripts/subscription_usage.py "${RUNNER_TEMP}/subscription_usage.py"
+          # The whole control plane too: the rework bound below imports its neighbours.
+          cp -r scripts "${RUNNER_TEMP}/control-plane"
 
       # Section 1 of the runbook is a computation, and running it in the model cost
       # two consecutive runs on one ineligible pull request while three others went
@@ -139,6 +141,22 @@ jobs:
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: python "${RUNNER_TEMP}/subscription_usage.py" --out "${RUNNER_TEMP}/usage-after.json"
+
+      # The third refusal is the last. Rework on one pull request is bounded (#141):
+      # once the reviewed pull request carries three REQUEST_CHANGES verdicts, the forge
+      # closes it with the record of every verdict, deletes the loop's branch and returns
+      # the Issue to status:ready, so the next AUTHOR starts from master with the history
+      # instead of a fourth round on a branch that has failed review three times. Runs
+      # from the staged copy, for the same reason the recorder does; with the workflow
+      # token, which may close, comment, label and delete a branch, and nothing more.
+      - name: Enforce the rework bound on the reviewed pull request
+        if: always() && steps.select.outputs.target != 'none'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python "${RUNNER_TEMP}/control-plane/rework_limit.py" \
+            --repo "${{ github.repository }}" \
+            --pull "${{ steps.select.outputs.target }}"
 
       # Telemetry only. See the note in zendev-author.yml: this never fails the run.
       - name: Record what this run consumed

--- a/docs/zendev/ACCEPTOR_RUNBOOK.md
+++ b/docs/zendev/ACCEPTOR_RUNBOOK.md
@@ -223,6 +223,14 @@ Exactly one of the following.
 matters, and what would satisfy it. Set the Issue back to `status:in-progress`.
 Vague dissatisfaction is not a verdict.
 
+The third refusal on one pull request is the last. After your run, the forge counts the
+`REQUEST_CHANGES` verdicts on the pull request (`scripts/rework_limit.py`); at three it
+closes the pull request with the record of every verdict, deletes the loop's branch, and
+returns the Issue to `status:ready` with the same record. You do nothing differently —
+post the verdict as always — but know that a third refusal ends this branch, so it must
+name everything that is still wrong: the next AUTHOR starts from `master` with your
+verdicts as its work packet.
+
 Exactly one verdict per head revision, and it is the last thing the run does. Do not
 post a verdict and then continue checking; if a later check changes the answer, the
 first verdict is already standing and the AUTHOR — which has no memory and reads

--- a/docs/zendev/AUTHOR_RUNBOOK.md
+++ b/docs/zendev/AUTHOR_RUNBOOK.md
@@ -105,6 +105,16 @@ identical fallback when consuming one, not just the formal-review path — other
 real change request goes unaddressed while later runs report green with nothing
 actually fixed.
 
+### The rework bound (items 1 and 2)
+
+Rework on one pull request is bounded at three `REQUEST_CHANGES` verdicts. At the third,
+the forge closes the pull request with the record of every verdict, deletes its branch,
+and returns the Issue to `status:ready` with the same record (`scripts/rework_limit.py`).
+A pull request closed this way is not yours to reopen, and its branch is gone: take the
+Issue through item 4, start from `master`, and read every verdict on the closed pull
+request before claiming — they are the work packet now. Its commits stay reachable from
+the closed pull request if you need them.
+
 ## 3. Claim before mutating
 
 Comment on the Issue with: role, intended scope, the branch name you will use, and

--- a/scripts/rework_limit.py
+++ b/scripts/rework_limit.py
@@ -1,0 +1,233 @@
+"""Bound the rework on one pull request.
+
+The AUTHOR's ladder puts "an open pull request of yours with changes requested" first,
+which is right: closing work outranks opening it. It also has no bound, and #130 showed
+what an unbounded first rung costs. Three `REQUEST_CHANGES` verdicts on three heads, five
+AUTHOR runs and four ACCEPTOR runs in one afternoon, the only product Issue waiting the
+whole time — and the pull request still open.
+
+This bounds it. After the ACCEPTOR has posted its verdict, the forge counts the refusals
+on the pull request. At the bound (three by default) it closes the pull request with a
+comment listing every refusal, deletes the loop's own branch, and returns the Issue to
+`status:ready` with the same record, so the next AUTHOR run starts from `master` with
+the history in hand instead of opening a fourth round on a branch that has failed
+review three times.
+
+What counts as a refusal is what the selector already counts as a verdict, narrowed to
+the refusing kind: a comment whose first marked line says `REQUEST_CHANGES` in one of
+the shapes the runbook prescribes, or a formal review in the `CHANGES_REQUESTED` state.
+An `ACCEPT`, a correction handoff, prose that mentions an earlier refusal — none of
+those count. Neither does an operator's QA comment: the bound is on the automated loop's
+own rounds.
+
+Two things it never does. It never deletes a branch that is not the loop's (`claude/**`);
+an operator's branch stays. And it never fails the acceptor run: the outcome for the
+pull request is the state the forge leaves it in, printed here, and a bookkeeping error
+is a warning.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+LIMIT = 3
+LOOP_PREFIX = "claude/"
+STATUS_READY = "status:ready"
+
+# A refusal announces itself the way a verdict does: at the start of a line, behind at
+# most a heading or bold marker, optionally the role and the word "verdict", then the
+# refusing word. Anchored so that a sentence *about* an earlier refusal stays prose, and
+# so that an operator's QA marker — which the AUTHOR runbook counts as evidence, not as
+# a verdict — is not a round of the loop.
+REFUSAL_LINE = re.compile(
+    r"^\s*(?:#{1,4}\s*|\*\*)?\s*(?:ACCEPTOR\s+)?(?:VERDICT\s*[:\-—]\s*)?REQUEST_CHANGES\b",
+    re.MULTILINE | re.IGNORECASE,
+)
+REFUSING_REVIEW = "CHANGES_REQUESTED"
+
+CLOSES = re.compile(r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)", re.IGNORECASE)
+BRANCH_ISSUE = re.compile(r"^claude/issue-(\d+)-")
+
+
+def is_refusal(entry) -> bool:
+    """A comment in the refusing verdict shape, or a formal review in the refusing state."""
+    if (entry.get("state") or "").upper() == REFUSING_REVIEW:
+        return True
+    return bool(REFUSAL_LINE.search(entry.get("body") or ""))
+
+
+def decide(entries, limit=LIMIT):
+    """(bound reached, the refusals). Pure."""
+    refusals = [entry for entry in entries if is_refusal(entry)]
+    return len(refusals) >= limit, refusals
+
+
+def linked_issue(body, head_ref):
+    """The Issue a pull request belongs to: `Closes #N` in the body, else the branch name."""
+    match = CLOSES.search(body or "")
+    if match:
+        return int(match.group(1))
+    match = BRANCH_ISSUE.match(head_ref or "")
+    return int(match.group(1)) if match else None
+
+
+def entries_of(pull):
+    """Comments and formal reviews as one timeline. Reviews without a time are not events."""
+    entries = [
+        {
+            "body": comment.get("body") or "",
+            "createdAt": comment.get("createdAt") or "",
+            "state": None,
+            "url": comment.get("url"),
+        }
+        for comment in pull.get("comments") or []
+    ]
+    entries += [
+        {
+            "body": review.get("body") or "",
+            "createdAt": review.get("submittedAt") or "",
+            "state": review.get("state"),
+            "url": None,
+        }
+        for review in pull.get("reviews") or []
+        if review.get("submittedAt")
+    ]
+    return sorted(entries, key=lambda entry: entry["createdAt"])
+
+
+def first_line(text: str) -> str:
+    for line in (text or "").splitlines():
+        if line.strip():
+            return line.strip()[:120]
+    return ""
+
+
+def summary(pull, refusals, limit, issue):
+    head = (pull.get("headRefOid") or "")[:8]
+    lines = [
+        f"## Rework bound reached: {len(refusals)} refusals on one pull request",
+        "",
+        f"Closed by the forge at head `{head}`, not by a reviewer. The bound is {limit} "
+        "`REQUEST_CHANGES` verdicts: a further round on a branch that has failed review "
+        "this often costs more than a fresh start from `master` with the record in hand.",
+        "",
+        "Refusals:",
+    ]
+    for refusal in refusals:
+        label = first_line(refusal["body"]) or (refusal.get("state") or "review")
+        where = f" ({refusal['url']})" if refusal.get("url") else ""
+        lines.append(f"- {refusal['createdAt']} — {label}{where}")
+    lines.append("")
+    if issue is not None:
+        lines.append(
+            f"The commits stay reachable from this pull request. Issue #{issue} returns to "
+            f"`{STATUS_READY}` with this record; the next AUTHOR run starts from `master` and "
+            "reads every verdict above before claiming it."
+        )
+    else:
+        lines.append(
+            "The commits stay reachable from this pull request. No linked Issue could be "
+            "read from the body or the branch name, so a person decides what returns to "
+            "the queue."
+        )
+    return "\n".join(lines)
+
+
+def issue_note(pull, refusals, limit):
+    return (
+        f"## Returned to the queue by the forge\n\n"
+        f"Pull request {pull.get('url')} was closed after {len(refusals)} `REQUEST_CHANGES` "
+        f"verdicts (the bound is {limit}). Its commits remain reachable from the pull request; "
+        f"its branch is gone. Start from `master`, and read every verdict on that pull request "
+        f"before claiming this Issue: the record of what was refused is the work packet now."
+    )
+
+
+def _gh(args):
+    # UTF-8 explicitly, not by locale: see the note in machine_pr_guard.py.
+    return subprocess.run(
+        ["gh", *args], check=True, capture_output=True, text=True, encoding="utf-8"
+    ).stdout
+
+
+def load_pull(repo: str, number: int):
+    raw = _gh(
+        [
+            "pr",
+            "view",
+            str(number),
+            "--repo",
+            repo,
+            "--json",
+            "number,state,url,body,headRefName,headRefOid,comments,reviews",
+        ]
+    )
+    return json.loads(raw)
+
+
+def issue_status_labels(repo: str, issue: int):
+    raw = _gh(["issue", "view", str(issue), "--repo", repo, "--json", "labels"])
+    return [label["name"] for label in json.loads(raw).get("labels", []) if label["name"].startswith("status:")]
+
+
+def close_out(repo: str, pull, refusals, limit: int) -> None:
+    number = pull["number"]
+    head_ref = pull.get("headRefName") or ""
+    issue = linked_issue(pull.get("body"), head_ref)
+
+    _gh(["pr", "comment", str(number), "--repo", repo, "--body", summary(pull, refusals, limit, issue)])
+    close = ["pr", "close", str(number), "--repo", repo]
+    if head_ref.startswith(LOOP_PREFIX):
+        close.append("--delete-branch")
+    _gh(close)
+
+    if issue is None:
+        return
+    args = ["issue", "edit", str(issue), "--repo", repo, "--add-label", STATUS_READY]
+    for label in issue_status_labels(repo, issue):
+        if label != STATUS_READY:
+            args += ["--remove-label", label]
+    _gh(args)
+    _gh(["issue", "comment", str(issue), "--repo", repo, "--body", issue_note(pull, refusals, limit)])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="owner/name")
+    parser.add_argument("--pull", type=int, required=True, help="the pull request just reviewed")
+    parser.add_argument("--limit", type=int, default=LIMIT, help="refusals that end the rework")
+    parser.add_argument("--dry-run", action="store_true", help="decide, but change nothing")
+    args = parser.parse_args()
+
+    try:
+        pull = load_pull(args.repo, args.pull)
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as error:
+        print(f"::warning::rework-limit: could not read #{args.pull}: {type(error).__name__}")
+        return 0
+
+    if (pull.get("state") or "").upper() != "OPEN":
+        print(f"rework-limit: #{args.pull} is {pull.get('state')}; nothing to bound")
+        return 0
+
+    reached, refusals = decide(entries_of(pull), args.limit)
+    print(f"rework-limit: #{args.pull} has {len(refusals)} refusal(s); bound is {args.limit}")
+    if not reached:
+        return 0
+    if args.dry_run:
+        print(f"rework-limit: would close #{args.pull} and return its Issue to {STATUS_READY}")
+        return 0
+    try:
+        close_out(args.repo, pull, refusals, args.limit)
+    except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError) as error:
+        print(f"::warning::rework-limit: closing #{args.pull} did not complete: {type(error).__name__}")
+        return 0
+    print(f"rework-limit: closed #{args.pull} at the bound")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_rework_limit.py
+++ b/scripts/tests/test_rework_limit.py
@@ -1,0 +1,151 @@
+"""The bound fires on the third refusal and on nothing that is not a refusal."""
+
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import rework_limit as rl  # noqa: E402
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "zendev-acceptor.yml"
+
+
+def comment(body, created, url="https://example/c"):
+    return {"body": body, "createdAt": created, "state": None, "url": url}
+
+
+def review(state, created, body=""):
+    return {"body": body, "createdAt": created, "state": state, "url": None}
+
+
+# The three shapes the ACCEPTOR actually used on #130 in one afternoon.
+REFUSALS_ON_130 = [
+    comment("## VERDICT: REQUEST_CHANGES\n\n**Reviewed head revision**: 909f03d", "2026-09-05T11:13:00Z"),
+    comment("REQUEST_CHANGES at revision 9e14cdb\n\n**Handoff record is incomplete**", "2026-09-05T12:14:00Z"),
+    comment("## ACCEPTOR VERDICT: REQUEST_CHANGES\n\n**Head revision**: 0bcc816", "2026-09-05T13:12:00Z"),
+]
+
+
+class RefusalShapeTests(unittest.TestCase):
+    def test_every_shape_the_acceptor_used_is_a_refusal(self):
+        for entry in REFUSALS_ON_130:
+            with self.subTest(body=entry["body"].splitlines()[0]):
+                self.assertTrue(rl.is_refusal(entry))
+
+    def test_bold_and_lowercase_markers_count_too(self):
+        self.assertTrue(rl.is_refusal(comment("**REQUEST_CHANGES**\n\nfix it", "t")))
+        self.assertTrue(rl.is_refusal(comment("## ACCEPTOR verdict: request_changes", "t")))
+
+    def test_a_formal_review_requesting_changes_needs_no_words(self):
+        self.assertTrue(rl.is_refusal(review("CHANGES_REQUESTED", "t")))
+        self.assertFalse(rl.is_refusal(review("APPROVED", "t")))
+        self.assertFalse(rl.is_refusal(review("COMMENTED", "t", "A note that mentions REQUEST_CHANGES mid-sentence.")))
+
+    def test_an_acceptance_is_not_a_refusal(self):
+        self.assertFalse(rl.is_refusal(comment("## ACCEPTOR verdict: ACCEPT\n\nAll six hold.", "t")))
+        self.assertFalse(rl.is_refusal(comment("## ACCEPT", "t")))
+
+    def test_prose_about_an_earlier_refusal_is_not_one(self):
+        self.assertFalse(rl.is_refusal(comment("## AUTHOR correction\n\nThe previous REQUEST_CHANGES asked for a label fix.", "t")))
+        self.assertFalse(rl.is_refusal(comment("Addressed REQUEST_CHANGES feedback from ACCEPTOR.", "t")))
+
+    def test_an_operator_qa_marker_is_evidence_not_a_round_of_the_loop(self):
+        self.assertFalse(rl.is_refusal(comment("## Operator QA: REQUEST_CHANGES\n\nlooked wrong", "t")))
+
+
+class DecideTests(unittest.TestCase):
+    def test_two_refusals_keep_the_pull_request_open(self):
+        reached, refusals = rl.decide(REFUSALS_ON_130[:2])
+        self.assertFalse(reached)
+        self.assertEqual(len(refusals), 2)
+
+    def test_the_third_refusal_reaches_the_bound(self):
+        # #130, exactly.
+        reached, refusals = rl.decide(REFUSALS_ON_130)
+        self.assertTrue(reached)
+        self.assertEqual(len(refusals), 3)
+
+    def test_acceptances_and_handoffs_between_refusals_do_not_count(self):
+        timeline = [
+            REFUSALS_ON_130[0],
+            comment("## AUTHOR handoff\n\nfixed", "2026-09-05T11:35:00Z"),
+            REFUSALS_ON_130[1],
+            comment("## ACCEPTOR verdict: ACCEPT", "2026-09-05T12:40:00Z"),
+        ]
+        reached, refusals = rl.decide(timeline)
+        self.assertFalse(reached)
+        self.assertEqual(len(refusals), 2)
+
+    def test_the_bound_is_configurable(self):
+        self.assertTrue(rl.decide(REFUSALS_ON_130[:2], limit=2)[0])
+        self.assertFalse(rl.decide(REFUSALS_ON_130, limit=4)[0])
+
+
+class LinkedIssueTests(unittest.TestCase):
+    def test_closes_in_the_body_wins(self):
+        self.assertEqual(rl.linked_issue("Closes #121\n\n## Achieved outcome", "claude/issue-999-x"), 121)
+        self.assertEqual(rl.linked_issue("fixes #5", ""), 5)
+        self.assertEqual(rl.linked_issue("Resolved #77.", ""), 77)
+
+    def test_the_branch_name_is_the_fallback(self):
+        self.assertEqual(rl.linked_issue("no reference here", "claude/issue-121-label-cleanup-workflow"), 121)
+
+    def test_nothing_to_read_is_none_not_a_guess(self):
+        self.assertIsNone(rl.linked_issue("", "policy/142-update-behind-branches"))
+        self.assertIsNone(rl.linked_issue(None, None))
+
+
+class TimelineTests(unittest.TestCase):
+    def test_comments_and_reviews_are_one_ordered_timeline(self):
+        pull = {
+            "comments": [{"body": "b", "createdAt": "2026-09-05T12:00:00Z", "url": "u"}],
+            "reviews": [
+                {"body": "", "state": "CHANGES_REQUESTED", "submittedAt": "2026-09-05T11:00:00Z"},
+                {"body": "pending", "state": "PENDING"},
+            ],
+        }
+        entries = rl.entries_of(pull)
+        self.assertEqual([e["createdAt"] for e in entries], ["2026-09-05T11:00:00Z", "2026-09-05T12:00:00Z"])
+        self.assertEqual(entries[0]["state"], "CHANGES_REQUESTED")
+
+
+class SummaryTests(unittest.TestCase):
+    def test_the_summary_names_the_count_the_head_and_the_issue(self):
+        pull = {"headRefOid": "0bcc8161e5c66cd9", "url": "https://x/pull/130"}
+        text = rl.summary(pull, REFUSALS_ON_130, 3, 121)
+        self.assertIn("3 refusals", text)
+        self.assertIn("0bcc8161", text)
+        self.assertIn("Issue #121 returns to `status:ready`", text)
+        self.assertIn("## VERDICT: REQUEST_CHANGES", text)
+
+    def test_without_an_issue_a_person_is_named_instead(self):
+        text = rl.summary({"headRefOid": "abc", "url": "u"}, REFUSALS_ON_130, 3, None)
+        self.assertIn("a person decides", text)
+
+
+class WorkflowTests(unittest.TestCase):
+    def text(self):
+        return WORKFLOW.read_text(encoding="utf-8")
+
+    def test_the_control_plane_is_staged_before_the_model_and_the_bound_runs_from_it(self):
+        rows = self.text().splitlines()
+        staged = next(i for i, r in enumerate(rows) if 'cp -r scripts "${RUNNER_TEMP}/control-plane"' in r)
+        model = next(i for i, r in enumerate(rows) if "uses: anthropics/claude-code-action" in r)
+        bound = next(i for i, r in enumerate(rows) if '"${RUNNER_TEMP}/control-plane/rework_limit.py"' in r)
+        self.assertLess(staged, model)
+        self.assertGreater(bound, model)
+
+    def test_the_bound_runs_only_when_a_pull_request_was_reviewed(self):
+        text = self.text()
+        bound = text.index("control-plane/rework_limit.py")
+        step = text[text.rfind("- name:", 0, bound):bound]
+        self.assertIn("always() && steps.select.outputs.target != 'none'", step)
+
+    def test_the_bound_never_runs_from_the_working_tree(self):
+        self.assertNotIn("python scripts/rework_limit.py", self.text())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #141

Stacked on #151: both change the same staging step of `zendev-acceptor.yml`. GitHub retargets this pull request to `master` when #151 merges; review the diff against that base.

## Achieved outcome

Rework on one pull request is bounded. After the ACCEPTOR posts its verdict, the forge counts the `REQUEST_CHANGES` verdicts on the reviewed pull request; at the third it closes the pull request with a comment listing every refusal, deletes the loop's `claude/**` branch, and returns the Issue to `status:ready` with the same record, so the next AUTHOR run starts from `master` with the history in hand instead of a fourth round. Both runbooks name the bound.

## Tested revision

`ce0956b`

## Changed artifacts

- `scripts/rework_limit.py` — new: `is_refusal`, pure `decide(entries, limit)`, `linked_issue(body, head_ref)`, the timeline over comments and formal reviews, the closing summary and the Issue note, and a CLI with `--dry-run`.
- `scripts/tests/test_rework_limit.py` — new: the three verdict shapes used on #130 count; acceptances, handoffs, prose and operator QA do not; the bound at two, three and configured values; linked-Issue parsing; timeline ordering; text assertions on the workflow.
- `.github/workflows/zendev-acceptor.yml` — the staging step also copies the whole control plane; a post-model step runs the bound from the staged copy, only when a pull request was reviewed, with the workflow token.
- `docs/zendev/ACCEPTOR_RUNBOOK.md` — section 4: the third refusal is the last, and what that means for its content.
- `docs/zendev/AUTHOR_RUNBOOK.md` — new subsection under section 2: a pull request closed at the bound is not reopened; the Issue returns through item 4 with the verdicts as the work packet.

## Acceptance criteria

- [x] Two `REQUEST_CHANGES` verdicts keep the pull request open; three close it — `DecideTests`.
- [x] `ACCEPT` verdicts and non-verdict comments are not counted — `test_acceptances_and_handoffs_between_refusals_do_not_count`, `RefusalShapeTests`.
- [x] The linked Issue is found from `Closes #N` and, failing that, from the branch name — `LinkedIssueTests`.
- [x] The workflow stages the script before the model step and runs the staged copy afterwards — `WorkflowTests`.
- [x] Both runbooks state the bound and what happens at it — ACCEPTOR section 4, AUTHOR section 2.
- [x] `python -m unittest discover -s scripts/tests` passes — 225 tests at `ce0956b`.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest discover -s scripts/tests` | passed | 225 tests, OK, at `ce0956b` |
| `python scripts/policy_guard.py --base policy/144-subscription-telemetry` | passed | 5 changed files against the stacked base, no violation |
| `dotnet build --configuration Release` | not_run | no product code changed; the required check runs it on this pull request. Risk left open: none for this diff |
| `dotnet test --configuration Release` | not_run | same |
| `npm run typecheck && npm test && npm run build` | not_run | same |

## Not checked

A live close. `--dry-run` exists; after merge, `python scripts/rework_limit.py --repo drevendev/trade_simulation --pull 130 --dry-run` should report three refusals and the bound reached, which is the exact case this was built for. Whether #130 is still open by then depends on the loop.

## Assumptions and unknowns

- Assumed: `gh pr view --json comments,reviews` returns every comment; the pull requests in question have a few dozen at most.
- Assumed: the workflow token (`pull-requests: write`, `issues: write`, `contents: write`) may close, comment, relabel and delete a branch. It already deletes branches on merge.
- Known gap: the selector (`select_review_target.py`) does not recognise `## ACCEPTOR VERDICT: REQUEST_CHANGES`, the very shape the runbook prescribes, so this script carries its own pattern for now. Filed as #152; once fixed, the two patterns should become one.
- The bound counts refusals across heads, not per head, deliberately: a pull request refused on three different revisions has failed review three times.

## Highest-risk area for review

`close_out`: it closes and deletes on the strength of a comment count. The count is guarded by `REFUSAL_LINE`, which is anchored to a line start behind at most a heading or bold marker, so prose about an earlier refusal and an operator QA marker do not count; `RefusalShapeTests` are the negative controls. The branch is deleted only when it is `claude/**`.

## Remaining gate

Merge after #151 (the base). No widening beyond #151: the step uses the workflow token the acceptor job already holds.
