### PR TITLE
Act as three GitHub Apps instead of one person

### DIFF
--- a/.github/workflows/mergeability.yml
+++ b/.github/workflows/mergeability.yml
@@ -81,16 +81,30 @@ jobs:
       # credential that can push. `master` is the reviewed definition — and `master`
       # moving is exactly when branches fall behind.
       #
-      # The loop's token, not `github.token`: a push made with the workflow token starts
-      # no workflows, so the updated branch would sit with the stale checks it had
-      # before, measured on a revision that no longer exists.
+      # The MACHINE identity's token, not `github.token`: a push made with the workflow
+      # token starts no workflows, so the updated branch would sit with the stale checks
+      # it had before, measured on a revision that no longer exists. Minted for this
+      # repository alone and revoked with the job (docs/adr/0006-github-apps-as-loop-
+      # identities.md). A failed mint leaves the branch to the author and warns; it does
+      # not paint master red.
+      - name: Act as the MACHINE identity
+        id: identity
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.ZENDEV_MACHINE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ZENDEV_MACHINE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Update loop branches that are merely behind
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
         env:
-          GH_TOKEN: ${{ secrets.ZENDEV_PAT }}
+          GH_TOKEN: ${{ steps.identity.outputs.token }}
         run: |
           if [ -z "${GH_TOKEN}" ]; then
-            echo "::warning::ZENDEV_PAT is not available; branches that are behind stay with the author"
+            echo "::warning::no MACHINE identity token; branches that are behind stay with the author"
             exit 0
           fi
           python scripts/update_branches.py --repo "${{ github.repository }}" --all-open

--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -43,6 +43,27 @@ jobs:
         with:
           python-version: '3.12'
 
+      # The sync acts as the MACHINE identity (docs/adr/0006-github-apps-as-loop-
+      # identities.md): a token for this repository alone, minted here and revoked with
+      # the job. It closes, opens and arms the mirror proposal; it never runs a model.
+      # The proposal's author becomes zendev-machine[bot]; its commits stay *committed*
+      # by github-actions[bot], set explicitly on the proposing step below, so the
+      # committer gate in machine_pr_guard is unchanged.
+      - name: Act as the MACHINE identity
+        id: identity
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.ZENDEV_MACHINE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ZENDEV_MACHINE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Say who this run is
+        env:
+          APP_SLUG: ${{ steps.identity.outputs.app-slug }}
+          INSTALLATION: ${{ steps.identity.outputs.installation-id }}
+        run: echo "identity: ${APP_SLUG}[bot], installation ${INSTALLATION}"
+
       - name: Require configuration
         env:
           SA_JSON: ${{ secrets.GDRIVE_SA_JSON }}
@@ -159,16 +180,20 @@ jobs:
       # docs/zendev/MACHINE_PULL_REQUESTS.md, "Recovering one".
       - name: Close a stale refused proposal
         env:
-          GH_TOKEN: ${{ secrets.ZENDEV_PAT || github.token }}
+          GH_TOKEN: ${{ steps.identity.outputs.token }}
         run: python scripts/stale_mirror_pr.py --repo "${{ github.repository }}"
 
       - name: Propose the mirror as a pull request
         id: mirror_pr
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.ZENDEV_PAT || github.token }}
+          token: ${{ steps.identity.outputs.token }}
           branch: spec-mirror
           base: master
+          # Explicit, because machine_pr_guard accepts this class on the committer of
+          # its head commit. The action's default is the same identity; naming it here
+          # keeps the gate's expectation and the producer's behaviour in one place.
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           add-paths: |
             docs/spec/mirror
             docs/spec/IMPLEMENTATION_STATUS.md
@@ -220,7 +245,7 @@ jobs:
       # operator.
       - name: Arm auto-merge on the mirror
         env:
-          GH_TOKEN: ${{ secrets.ZENDEV_PAT || github.token }}
+          GH_TOKEN: ${{ steps.identity.outputs.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.mirror_pr.outputs.pull-request-number }}
         run: |

--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -62,7 +62,8 @@ jobs:
         env:
           APP_SLUG: ${{ steps.identity.outputs.app-slug }}
           INSTALLATION: ${{ steps.identity.outputs.installation-id }}
-        run: echo "identity: ${APP_SLUG}[bot], installation ${INSTALLATION}"
+        run: |
+          echo "identity: ${APP_SLUG}[bot], installation ${INSTALLATION}"
 
       - name: Require configuration
         env:

--- a/.github/workflows/zendev-acceptor.yml
+++ b/.github/workflows/zendev-acceptor.yml
@@ -6,6 +6,11 @@ name: ZenDev acceptor
 on:
   # Automatic hourly cadence is owned by zendev-watchdog.yml.
   workflow_dispatch:
+    inputs:
+      smoke:
+        description: "Prove the identity only: mint the token, say who this run is, start no model"
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -19,15 +24,72 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  acceptor:
+  # Who this run is, before it does anything. The role acts through its own GitHub App
+  # (docs/adr/0006-github-apps-as-loop-identities.md), a different one from the AUTHOR's,
+  # which is what lets the forge tell the two roles apart. An installation token minted
+  # for this repository alone and revoked when the job ends. With `smoke` set, this job
+  # is the whole run.
+  identity:
     if: vars.ZENDEV_ENABLED == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Act as the ACCEPTOR identity
+        id: identity
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.ZENDEV_ACCEPTOR_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ZENDEV_ACCEPTOR_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Say who this run is
+        env:
+          GH_TOKEN: ${{ steps.identity.outputs.token }}
+          APP_SLUG: ${{ steps.identity.outputs.app-slug }}
+          INSTALLATION: ${{ steps.identity.outputs.installation-id }}
+        run: |
+          echo "identity: ${APP_SLUG}[bot], installation ${INSTALLATION}"
+          gh api "repos/${GITHUB_REPOSITORY}" --jq '"reaches: " + .full_name'
+
+      - name: Act as the MACHINE identity towards the ledger
+        id: ledger
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.ZENDEV_MACHINE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ZENDEV_MACHINE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: zen-telemetry
+
+      - name: Say that the ledger is reachable
+        env:
+          GH_TOKEN: ${{ steps.ledger.outputs.token }}
+          APP_SLUG: ${{ steps.ledger.outputs.app-slug }}
+        run: |
+          echo "ledger identity: ${APP_SLUG}[bot]"
+          gh api "repos/${GITHUB_REPOSITORY_OWNER}/zen-telemetry" --jq '"ledger reaches: " + .full_name'
+
+  acceptor:
+    needs: identity
+    # Not when `smoke` is set: proving the identity was the whole point of that run.
+    if: ${{ !inputs.smoke }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      # Minted again: a token does not cross jobs, and the one above is already revoked.
+      - name: Act as the ACCEPTOR identity
+        id: identity
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.ZENDEV_ACCEPTOR_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ZENDEV_ACCEPTOR_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          token: ${{ secrets.ZENDEV_PAT || github.token }}
+          token: ${{ steps.identity.outputs.token }}
 
       - uses: actions/setup-dotnet@v6
         with:
@@ -62,7 +124,7 @@ jobs:
       - name: Choose the pull request to review
         id: select
         env:
-          GH_TOKEN: ${{ secrets.ZENDEV_PAT || github.token }}
+          GH_TOKEN: ${{ steps.identity.outputs.token }}
         run: python scripts/select_review_target.py --repo "${{ github.repository }}"
 
       # The subscription is metered in rolling windows, not dollars. One reading before
@@ -82,7 +144,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.ZENDEV_PAT }}
+          # The ACCEPTOR app's token: a different identity from the AUTHOR's, so a merge
+          # or a verdict is attributable to the role that made it, and the forge could
+          # one day require the two to differ. Expires with the job.
+          github_token: ${{ steps.identity.outputs.token }}
           # The dispatcher runs this workflow with the repository's own GITHUB_TOKEN,
           # so the triggering actor is github-actions[bot]. The action refuses a bot
           # actor unless it is named here, which is why every watchdog-dispatched run
@@ -158,11 +223,25 @@ jobs:
             --repo "${{ github.repository }}" \
             --pull "${{ steps.select.outputs.target }}"
 
+      # The ledger lives in a private repository and is written by the MACHINE identity.
+      # Its token is minted here, at the end, scoped to that repository alone: the model
+      # never holds it. A failed mint is a gap in the bookkeeping, not a failed run.
+      - name: Act as the MACHINE identity towards the ledger
+        id: ledger
+        if: always()
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.ZENDEV_MACHINE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ZENDEV_MACHINE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: zen-telemetry
+
       # Telemetry only. See the note in zendev-author.yml: this never fails the run.
       - name: Record what this run consumed
         if: always()
         env:
-          TELEMETRY_TOKEN: ${{ secrets.TELEMETRY_PAT }}
+          TELEMETRY_TOKEN: ${{ steps.ledger.outputs.token }}
         run: |
           python "${RUNNER_TEMP}/record_usage.py" \
             --execution-file "${{ steps.claude.outputs.execution_file }}" \

--- a/.github/workflows/zendev-acceptor.yml
+++ b/.github/workflows/zendev-acceptor.yml
@@ -52,8 +52,11 @@ jobs:
           echo "identity: ${APP_SLUG}[bot], installation ${INSTALLATION}"
           gh api "repos/${GITHUB_REPOSITORY}" --jq '"reaches: " + .full_name'
 
+      # Telemetry never stops the loop, so an unreachable ledger is a warning here, not a
+      # failed identity. See the note in zendev-author.yml.
       - name: Act as the MACHINE identity towards the ledger
         id: ledger
+        continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ vars.ZENDEV_MACHINE_APP_CLIENT_ID }}
@@ -61,11 +64,15 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: zen-telemetry
 
-      - name: Say that the ledger is reachable
+      - name: Say whether the ledger is reachable
         env:
           GH_TOKEN: ${{ steps.ledger.outputs.token }}
           APP_SLUG: ${{ steps.ledger.outputs.app-slug }}
         run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::warning::no MACHINE token for the ledger; telemetry records nothing until the app is installed on zen-telemetry"
+            exit 0
+          fi
           echo "ledger identity: ${APP_SLUG}[bot]"
           gh api "repos/${GITHUB_REPOSITORY_OWNER}/zen-telemetry" --jq '"ledger reaches: " + .full_name'
 

--- a/.github/workflows/zendev-author.yml
+++ b/.github/workflows/zendev-author.yml
@@ -6,6 +6,11 @@ name: ZenDev author
 on:
   # Automatic hourly cadence is owned by zendev-watchdog.yml.
   workflow_dispatch:
+    inputs:
+      smoke:
+        description: "Prove the identity only: mint the token, say who this run is, start no model"
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -17,17 +22,78 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  author:
+  # Who this run is, before it does anything. The role acts through its own GitHub App
+  # (docs/adr/0006-github-apps-as-loop-identities.md): an installation token minted for
+  # this repository alone and revoked when the job ends. Printing the identity on every
+  # run makes a swapped key or a mis-installed app visible in the log; with `smoke` set,
+  # this job is the whole run — how a fresh project proves its setup without spending a
+  # model.
+  identity:
     # The dispatcher respects ZENDEV_ENABLED. Direct operator dispatch remains
     # available for maintenance even while automatic scheduling is paused.
     if: vars.ZENDEV_ENABLED == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Act as the AUTHOR identity
+        id: identity
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.ZENDEV_AUTHOR_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ZENDEV_AUTHOR_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Say who this run is
+        env:
+          GH_TOKEN: ${{ steps.identity.outputs.token }}
+          APP_SLUG: ${{ steps.identity.outputs.app-slug }}
+          INSTALLATION: ${{ steps.identity.outputs.installation-id }}
+        run: |
+          echo "identity: ${APP_SLUG}[bot], installation ${INSTALLATION}"
+          gh api "repos/${GITHUB_REPOSITORY}" --jq '"reaches: " + .full_name'
+
+      # The ledger is written by the MACHINE identity into a private repository. Proved
+      # here too, so a smoke run answers for every credential the real run will need.
+      - name: Act as the MACHINE identity towards the ledger
+        id: ledger
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.ZENDEV_MACHINE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ZENDEV_MACHINE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: zen-telemetry
+
+      - name: Say that the ledger is reachable
+        env:
+          GH_TOKEN: ${{ steps.ledger.outputs.token }}
+          APP_SLUG: ${{ steps.ledger.outputs.app-slug }}
+        run: |
+          echo "ledger identity: ${APP_SLUG}[bot]"
+          gh api "repos/${GITHUB_REPOSITORY_OWNER}/zen-telemetry" --jq '"ledger reaches: " + .full_name'
+
+  author:
+    needs: identity
+    # Not when `smoke` is set: proving the identity was the whole point of that run.
+    if: ${{ !inputs.smoke }}
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      # Minted again: a token does not cross jobs, and the one above is already revoked.
+      # Scoped to this repository, gone with the job.
+      - name: Act as the AUTHOR identity
+        id: identity
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.ZENDEV_AUTHOR_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ZENDEV_AUTHOR_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          token: ${{ secrets.ZENDEV_PAT || github.token }}
+          token: ${{ steps.identity.outputs.token }}
 
       - uses: actions/setup-dotnet@v6
         with:
@@ -66,9 +132,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # A PAT rather than the default token, so that pull requests this run opens
-          # actually trigger the CI workflow. Events from GITHUB_TOKEN do not.
-          github_token: ${{ secrets.ZENDEV_PAT }}
+          # The AUTHOR app's token, not GITHUB_TOKEN: pushes and pull requests made with
+          # it trigger checks, which events from GITHUB_TOKEN do not. Unlike the personal
+          # token it replaced, it names the role, carries the Workflows permission the
+          # role needs to propose a control-plane change, and expires with the job.
+          github_token: ${{ steps.identity.outputs.token }}
           # The dispatcher runs this workflow with the repository's own GITHUB_TOKEN,
           # so the triggering actor is github-actions[bot]. The action refuses a bot
           # actor unless it is named here, which is why every watchdog-dispatched run
@@ -119,6 +187,21 @@ jobs:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: python "${RUNNER_TEMP}/subscription_usage.py" --out "${RUNNER_TEMP}/usage-after.json"
 
+      # The ledger lives in a private repository and is written by the MACHINE identity.
+      # Its token is minted here, at the end, scoped to that repository alone: the model
+      # never holds it. A failed mint is a gap in the bookkeeping, not a failed run —
+      # the recorder warns that no token was set and exits 0.
+      - name: Act as the MACHINE identity towards the ledger
+        id: ledger
+        if: always()
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.ZENDEV_MACHINE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ZENDEV_MACHINE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: zen-telemetry
+
       # Telemetry only. This repository is public, so the numbers go to a private
       # ledger. It never fails the run: a missing token or an unreachable ledger is a
       # warning, because a loop that stops over bookkeeping is worse than a gap in the
@@ -126,7 +209,7 @@ jobs:
       - name: Record what this run consumed
         if: always()
         env:
-          TELEMETRY_TOKEN: ${{ secrets.TELEMETRY_PAT }}
+          TELEMETRY_TOKEN: ${{ steps.ledger.outputs.token }}
         run: |
           python "${RUNNER_TEMP}/record_usage.py" \
             --execution-file "${{ steps.claude.outputs.execution_file }}" \

--- a/.github/workflows/zendev-author.yml
+++ b/.github/workflows/zendev-author.yml
@@ -54,9 +54,13 @@ jobs:
           gh api "repos/${GITHUB_REPOSITORY}" --jq '"reaches: " + .full_name'
 
       # The ledger is written by the MACHINE identity into a private repository. Proved
-      # here too, so a smoke run answers for every credential the real run will need.
+      # here too, so a smoke run answers for every credential the real run will need —
+      # but telemetry never stops the loop, so an unreachable ledger is a warning here,
+      # not a failed identity. The first smoke run found exactly this: the app was not
+      # yet installed on the ledger, and the whole run stopped over bookkeeping.
       - name: Act as the MACHINE identity towards the ledger
         id: ledger
+        continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ vars.ZENDEV_MACHINE_APP_CLIENT_ID }}
@@ -64,11 +68,15 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: zen-telemetry
 
-      - name: Say that the ledger is reachable
+      - name: Say whether the ledger is reachable
         env:
           GH_TOKEN: ${{ steps.ledger.outputs.token }}
           APP_SLUG: ${{ steps.ledger.outputs.app-slug }}
         run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::warning::no MACHINE token for the ledger; telemetry records nothing until the app is installed on zen-telemetry"
+            exit 0
+          fi
           echo "ledger identity: ${APP_SLUG}[bot]"
           gh api "repos/${GITHUB_REPOSITORY_OWNER}/zen-telemetry" --jq '"ledger reaches: " + .full_name'
 

--- a/docs/adr/0006-github-apps-as-loop-identities.md
+++ b/docs/adr/0006-github-apps-as-loop-identities.md
@@ -1,0 +1,99 @@
+# 6. The loop acts through three GitHub Apps, one per class of authority
+
+Date: 2026-09-05
+Status: Accepted
+
+## Context
+
+ADR 0001 accepted a weakness and named it: both roles authenticated as the same
+personal account through one fine-grained token, so the forge could not tell the
+AUTHOR from the ACCEPTOR, and the separation between them was a rule the acceptor was
+asked to follow rather than something that refused a violation. The same token expired
+on a date, lacked the *Workflows* permission — which blocked #126 the day a
+control-plane fix needed to touch a workflow (#145) — and, being a person's, made every
+action of the loop look like that person's.
+
+The authority model this repository follows says which alternative makes the
+separation structural: an application identity per role, with short-lived credentials
+minted per run and permissions scoped to the role. Issue #145 asked for the choice
+between widening the token and taking that path. The path was taken.
+
+## Decision
+
+Three GitHub Apps, registered on the owner's account, each installed on the
+repositories it serves and nowhere else:
+
+| App | Acts for | Repository permissions | Installed on |
+| --- | --- | --- | --- |
+| ZenDev Author (`zendev-author[bot]`) | `zendev-author.yml` | Contents, Issues, Pull requests, Workflows — read and write | `trade_simulation` |
+| ZenDev Acceptor (`zendev-acceptor[bot]`) | `zendev-acceptor.yml` | Contents, Issues, Pull requests — read and write; Checks, Commit statuses, Actions — read | `trade_simulation` |
+| ZenDev Machine (`zendev-machine[bot]`) | `spec-sync.yml`, the branch update in `mergeability.yml`, the telemetry ledger | Contents, Pull requests — read and write | `trade_simulation`, `zen-telemetry` |
+
+The apps are **account-level and shared across projects**, named for the system and the
+role, never for a project: a new project adds its repository to the three installations
+and stores the same six values. One private key per project is the intended practice,
+so a leaked project secret is revoked without touching the others.
+
+Inside a workflow, a token is minted by `actions/create-github-app-token` in the job
+that uses it, scoped at mint time to **one repository** — this one for the role, the
+ledger alone for telemetry — and revoked when the job ends. Nothing long-lived is
+stored but the private keys. The watchdog keeps the ephemeral `GITHUB_TOKEN`: it
+dispatches workflows and holds no app. The rework bound and the commit statuses keep
+it too: they act as the forge, not as a role.
+
+Every model-running workflow begins with an `identity` job that mints its role's token
+and the ledger's, and prints who the run is — app slug and installation — and what it
+reaches. With the `smoke` input set, that job is the whole run. This is how a freshly
+bootstrapped project proves its six values before a model is ever started.
+
+The client identifiers are repository variables (`ZENDEV_<ROLE>_APP_CLIENT_ID`), the
+private keys repository secrets (`ZENDEV_<ROLE>_APP_PRIVATE_KEY`). A test refuses any
+workflow that names a personal access token, any role workflow that holds another
+role's app, and any role token not scoped to this repository.
+
+## Consequences
+
+**The separation is structural now.** Authorship and acceptance are two actors the
+forge can distinguish, which is the precondition ADR 0001 said was unmet. It makes a
+required approving review possible as a branch-protection rule. It is **not enabled by
+this decision**: a pull request's author cannot approve it, the operator authors the
+policy pull requests, and `enforce_admins` binds the operator too — so requiring an
+approval would block the one path a widening change may take. How a person accepts
+such a change under that rule is decided before the rule is turned on, not by it.
+
+**The personal tokens go.** `ZENDEV_PAT` and `TELEMETRY_PAT` are referenced nowhere
+after this change and are revoked once the first scheduled runs have proved the apps.
+
+**Blast radius is per app, not per project.** A private key stored in one project can
+mint a token for any repository the app is installed on; only our own workflow code
+narrows it to one. That is accepted for a personal account with few projects. The
+escape, if it stops being acceptable, is a second set of apps for the project that
+needs isolation; the workflows change nothing but variable names.
+
+**Identities show in the history.** Pull requests, comments, merges and the mirror
+proposals are now made by `zendev-author[bot]`, `zendev-acceptor[bot]` and
+`zendev-machine[bot]`. The mirror's commits are still *committed* by
+`github-actions[bot]`, because the proposing action sets its committer explicitly, so
+`machine_pr_guard`'s committer gate is unchanged; only the proposal's author changed.
+Slugs are stable identifiers from here on: scripts will come to check them, so the apps
+are not renamed.
+
+**Nothing changes for the model's trigger.** The dispatcher still starts the roles with
+`GITHUB_TOKEN`, so the triggering actor remains `github-actions[bot]` and the
+`allowed_bots` gate on the action stays exactly as narrow as before.
+
+**A follow-up becomes possible.** With distinct identities the acceptor can post a
+formal review instead of a comment-shaped verdict; the runbooks and the selector still
+describe comments, and moving them is its own change.
+
+## Alternatives considered
+
+- **Add the Workflows scope to the personal token.** Minutes of work; keeps one
+  identity for every role, keeps the expiry, keeps every action of the loop attributed
+  to a person. Rejected because it repairs the symptom in #145 and none of the
+  weakness ADR 0001 recorded.
+- **One app for everything.** Simplest to install; the forge still could not tell the
+  roles apart, which was the point. Rejected.
+- **One set of apps per project.** Contains a leaked key to one project. Deferred:
+  three apps per project multiplies setup for a personal account with few projects, and
+  the workflows are indifferent to which set they read, so it stays available.

--- a/docs/adr/0006-github-apps-as-loop-identities.md
+++ b/docs/adr/0006-github-apps-as-loop-identities.md
@@ -44,7 +44,11 @@ it too: they act as the forge, not as a role.
 Every model-running workflow begins with an `identity` job that mints its role's token
 and the ledger's, and prints who the run is — app slug and installation — and what it
 reaches. With the `smoke` input set, that job is the whole run. This is how a freshly
-bootstrapped project proves its six values before a model is ever started.
+bootstrapped project proves its six values before a model is ever started. The role's
+token is load-bearing there; the ledger's is not: telemetry never stops the loop, so a
+ledger the MACHINE app cannot reach is a warning in that job, not a failed identity.
+The first smoke run proved the point by stopping the whole run over an app not yet
+installed on the ledger.
 
 The client identifiers are repository variables (`ZENDEV_<ROLE>_APP_CLIENT_ID`), the
 private keys repository secrets (`ZENDEV_<ROLE>_APP_PRIVATE_KEY`). A test refuses any

--- a/docs/zendev/SCHEDULING.md
+++ b/docs/zendev/SCHEDULING.md
@@ -111,11 +111,13 @@ missed schedule.
 ## Permissions and opt-out
 
 The watchdog uses the ephemeral repository `GITHUB_TOKEN` with `actions: write` and
-`contents: read`. It receives no model token, Drive credential or `ZENDEV_PAT`.
+`contents: read`. It receives no model token, Drive credential or GitHub App key.
 GitHub permits `workflow_dispatch` from `GITHUB_TOKEN` to create a new run:
 [Triggering workflows](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow).
-The existing model-job credentials and permissions are unchanged. In particular this
-does **not** resolve the workflow-file push permission problem tracked by Issue #33.
+The roles it dispatches act through their own GitHub Apps
+([ADR 0006](../adr/0006-github-apps-as-loop-identities.md)); the workflow-file push
+permission problem once tracked by Issue #33 is resolved by the AUTHOR app's Workflows
+permission, not by anything the watchdog holds.
 
 The Actions `vars` context supplies `ZENDEV_ENABLED` to the script; the default
 `GITHUB_TOKEN` is not given extra access to the repository Variables API. Local

--- a/scripts/tests/test_loop_identities.py
+++ b/scripts/tests/test_loop_identities.py
@@ -117,6 +117,11 @@ class SmokeTests(unittest.TestCase):
                 identity = next(j for j in jobs(name) if j.startswith("  identity:"))
                 self.assertNotIn("claude-code-action", identity)
                 self.assertIn("Say who this run is", identity)
+                # Telemetry never stops the loop: an unreachable ledger is a warning in
+                # the identity job, not a failed identity. The first smoke run stopped
+                # the whole run over exactly that, before the app reached the ledger.
+                ledger = identity.index("id: ledger")
+                self.assertIn("continue-on-error: true", identity[ledger:identity.index("uses:", ledger)])
                 work = next(j for j in jobs(name) if "claude-code-action" in j)
                 self.assertIn("needs: identity", work)
                 self.assertIn("if: ${{ !inputs.smoke }}", work)

--- a/scripts/tests/test_loop_identities.py
+++ b/scripts/tests/test_loop_identities.py
@@ -1,0 +1,126 @@
+"""Each role acts through its own GitHub App, and no personal token remains.
+
+ADR 0006. The AUTHOR and the ACCEPTOR authenticate as two different applications, so
+the forge can tell them apart; the roles that run no model act as a third. Every token
+is minted inside the job that uses it, for one repository, and dies with the job. A
+personal access token anywhere in the workflows would undo all of that at once — one
+identity for every role, one credential that expires on a date nobody watches — so its
+absence is asserted here, not assumed.
+
+Text assertions rather than a YAML parse, like the other workflow tests: this must run
+in the policy-guard job with nothing but the standard library.
+"""
+
+import pathlib
+import re
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+MINT = "uses: actions/create-github-app-token@v3"
+AUTHOR = ("vars.ZENDEV_AUTHOR_APP_CLIENT_ID", "secrets.ZENDEV_AUTHOR_APP_PRIVATE_KEY")
+ACCEPTOR = ("vars.ZENDEV_ACCEPTOR_APP_CLIENT_ID", "secrets.ZENDEV_ACCEPTOR_APP_PRIVATE_KEY")
+MACHINE = ("vars.ZENDEV_MACHINE_APP_CLIENT_ID", "secrets.ZENDEV_MACHINE_APP_PRIVATE_KEY")
+THIS_REPOSITORY = "repositories: ${{ github.event.repository.name }}"
+LEDGER = "repositories: zen-telemetry"
+PERSONAL_TOKENS = ("ZENDEV_PAT", "TELEMETRY_PAT")
+
+
+def text(name):
+    return (WORKFLOWS / name).read_text(encoding="utf-8")
+
+
+def jobs(name):
+    """Split a workflow into its jobs by the two-space-indented job keys."""
+    body = text(name)
+    starts = [m.start() for m in re.finditer(r"^  [a-z][\w-]*:\s*$", body, re.MULTILINE)]
+    starts.append(len(body))
+    return [body[a:b] for a, b in zip(starts, starts[1:])]
+
+
+class NoPersonalTokenTests(unittest.TestCase):
+    def test_no_workflow_names_a_personal_access_token(self):
+        for path in sorted(WORKFLOWS.glob("*.yml")):
+            for token in PERSONAL_TOKENS:
+                with self.subTest(workflow=path.name, token=token):
+                    self.assertNotIn(token, path.read_text(encoding="utf-8"))
+
+    def test_the_scan_sees_every_workflow(self):
+        # Without this the assertion above passes on an empty directory.
+        self.assertGreaterEqual(len(list(WORKFLOWS.glob("*.yml"))), 6)
+
+
+class RoleIdentityTests(unittest.TestCase):
+    def assert_role(self, name, mine, others):
+        body = text(name)
+        for needle in mine:
+            self.assertIn(needle, body, f"{name} must act as its own app")
+        for other in others:
+            for needle in other:
+                self.assertNotIn(needle, body, f"{name} must never hold another role's app")
+        self.assertIn(THIS_REPOSITORY, body, f"{name} must scope its token to this repository")
+
+    def test_the_author_acts_as_the_author_app_only(self):
+        self.assert_role("zendev-author.yml", AUTHOR, [ACCEPTOR])
+
+    def test_the_acceptor_acts_as_the_acceptor_app_only(self):
+        self.assert_role("zendev-acceptor.yml", ACCEPTOR, [AUTHOR])
+
+    def test_model_roles_mint_before_they_check_out_and_hand_the_model_the_same_token(self):
+        for name in ("zendev-author.yml", "zendev-acceptor.yml"):
+            with self.subTest(workflow=name):
+                work = [job for job in jobs(name) if "claude-code-action" in job]
+                self.assertEqual(len(work), 1, f"{name}: exactly one job runs the model")
+                job = work[0]
+                self.assertLess(job.index(MINT), job.index("uses: actions/checkout"))
+                self.assertIn("token: ${{ steps.identity.outputs.token }}", job)
+                self.assertIn("github_token: ${{ steps.identity.outputs.token }}", job)
+
+    def test_the_ledger_is_written_as_the_machine_app_scoped_to_the_ledger(self):
+        for name in ("zendev-author.yml", "zendev-acceptor.yml"):
+            with self.subTest(workflow=name):
+                job = next(j for j in jobs(name) if "claude-code-action" in j)
+                ledger = job.index("id: ledger")
+                self.assertIn(LEDGER, job[ledger:])
+                self.assertIn("continue-on-error: true", job[ledger:])
+                self.assertIn("TELEMETRY_TOKEN: ${{ steps.ledger.outputs.token }}", job)
+                for needle in MACHINE:
+                    self.assertIn(needle, job)
+
+    def test_the_machine_roles_act_as_the_machine_app_only(self):
+        for name in ("spec-sync.yml", "mergeability.yml"):
+            with self.subTest(workflow=name):
+                body = text(name)
+                for needle in MACHINE:
+                    self.assertIn(needle, body)
+                for other in (AUTHOR, ACCEPTOR):
+                    for needle in other:
+                        self.assertNotIn(needle, body)
+                self.assertIn(THIS_REPOSITORY, body)
+
+    def test_the_watchdog_holds_no_app_at_all(self):
+        body = text("zendev-watchdog.yml")
+        self.assertNotIn(MINT, body)
+        for role in (AUTHOR, ACCEPTOR, MACHINE):
+            for needle in role:
+                self.assertNotIn(needle, body)
+
+
+class SmokeTests(unittest.TestCase):
+    def test_model_roles_can_prove_their_identity_without_a_model(self):
+        for name in ("zendev-author.yml", "zendev-acceptor.yml"):
+            with self.subTest(workflow=name):
+                body = text(name)
+                self.assertIn("smoke:", body)
+                self.assertIn("type: boolean", body)
+                identity = next(j for j in jobs(name) if j.startswith("  identity:"))
+                self.assertNotIn("claude-code-action", identity)
+                self.assertIn("Say who this run is", identity)
+                work = next(j for j in jobs(name) if "claude-code-action" in j)
+                self.assertIn("needs: identity", work)
+                self.assertIn("if: ${{ !inputs.smoke }}", work)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_stale_mirror_pr.py
+++ b/scripts/tests/test_stale_mirror_pr.py
@@ -92,10 +92,14 @@ class WorkflowTests(unittest.TestCase):
         self.assertLess(closing, proposing)
 
     def test_closing_uses_the_same_token_as_proposing(self):
+        # Both act as the MACHINE identity: the token minted once at the top of the job.
         text = WORKFLOW.read_text(encoding="utf-8")
         closing = text.index("scripts/stale_mirror_pr.py")
         step = text[text.rfind("- name:", 0, closing):closing]
-        self.assertIn("secrets.ZENDEV_PAT || github.token", step)
+        self.assertIn("GH_TOKEN: ${{ steps.identity.outputs.token }}", step)
+        proposing = text.index("peter-evans/create-pull-request")
+        proposal = text[proposing:text.index("add-paths:", proposing)]
+        self.assertIn("token: ${{ steps.identity.outputs.token }}", proposal)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_update_branches.py
+++ b/scripts/tests/test_update_branches.py
@@ -94,10 +94,17 @@ class WorkflowTests(unittest.TestCase):
         self.assertIn("refs/heads/master", step)
         self.assertIn("github.event_name != 'pull_request'", step)
 
-    def test_the_sweep_uses_the_loop_token_so_the_push_triggers_checks(self):
-        sweep = self.text().index("scripts/update_branches.py")
-        step = self.text()[self.text().rfind("- name:", 0, sweep):sweep]
-        self.assertIn("secrets.ZENDEV_PAT", step)
+    def test_the_sweep_acts_as_the_machine_identity_so_the_push_triggers_checks(self):
+        text = self.text()
+        sweep = text.index("scripts/update_branches.py")
+        step = text[text.rfind("- name:", 0, sweep):sweep]
+        self.assertIn("GH_TOKEN: ${{ steps.identity.outputs.token }}", step)
+        # The identity is minted right before, under the same master-only condition,
+        # from the MACHINE app — a role that runs no model.
+        mint = text[text.rfind("- name: Act as the MACHINE identity", 0, sweep):sweep]
+        self.assertIn("vars.ZENDEV_MACHINE_APP_CLIENT_ID", mint)
+        self.assertIn("refs/heads/master", mint)
+        self.assertNotIn("ZENDEV_PAT", text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #145

Stacked on #150 (`policy/143-stale-mirror-proposal`): both change `spec-sync.yml`. GitHub retargets this pull request to `master` when #150 merges; I will rebase it then, as with #153.

## Achieved outcome

The loop no longer acts as a person. Each role authenticates as its own GitHub App — ZenDev Author, ZenDev Acceptor, ZenDev Machine — with an installation token minted inside the job that uses it, scoped to one repository, and revoked when the job ends. `ZENDEV_PAT` and `TELEMETRY_PAT` are referenced nowhere. The AUTHOR now carries the Workflows permission that blocked #126. Every model-running workflow starts with an `identity` job that prints who the run is and proves it reaches this repository and the ledger; with the new `smoke` input that job is the whole run, which is how a fresh project proves its setup without a model. ADR 0006 records the decision.

## Tested revision

`84ae776`

## Changed artifacts

- `.github/workflows/zendev-author.yml` — `smoke` input; `identity` job (AUTHOR token, ledger token, who-am-I); the `author` job mints its own AUTHOR token for checkout and `github_token`, and a MACHINE token scoped to `zen-telemetry` at the end for the recorder.
- `.github/workflows/zendev-acceptor.yml` — the same shape with the ACCEPTOR app; the selector uses the role token; the rework bound keeps `github.token`.
- `.github/workflows/spec-sync.yml` — MACHINE token for closing, proposing and arming the mirror; `committer` set explicitly to `github-actions[bot]` so the class gate is unchanged.
- `.github/workflows/mergeability.yml` — MACHINE token minted under the master-only condition for the branch update; a failed mint warns instead of failing the job.
- `scripts/tests/test_loop_identities.py` — new: no personal token anywhere; each role holds only its own app; token scoped to this repository; mint precedes checkout and feeds `github_token`; ledger written as MACHINE scoped to `zen-telemetry`; the watchdog holds no app; `smoke` proves identity without a model.
- `scripts/tests/test_update_branches.py` — the sweep is asserted to act as the MACHINE identity instead of the PAT.
- `scripts/tests/test_stale_mirror_pr.py` — closing and proposing are asserted to share the MACHINE token instead of the PAT.
- `docs/adr/0006-github-apps-as-loop-identities.md` — new: the decision, the three apps, what stays on `GITHUB_TOKEN`, consequences and alternatives.
- `docs/zendev/SCHEDULING.md` — the watchdog holds no app key; the Issue #33 sentence points at the AUTHOR app's permission.

## Acceptance criteria

- [x] A test pull request touching a workflow can be pushed and merged by the loop identity — the AUTHOR app carries Workflows: read and write. Live proof is the first AUTHOR run after merge that touches a workflow; see *Not checked*.
- [x] An ADR records which option was taken and why — `docs/adr/0006-github-apps-as-loop-identities.md`.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest discover -s scripts/tests` | passed | 266 tests, OK, at `84ae776` |
| `python scripts/policy_guard.py --base policy/143-stale-mirror-proposal` | passed | policy paths only, no violation |
| smoke: `zendev-author.yml` with `smoke=true` on this branch | passed | identity job output, run linked below |
| smoke: `zendev-acceptor.yml` with `smoke=true` on this branch | passed | identity job output, run linked below |
| smoke: `spec-sync.yml` on this branch | passed | identity step output, run linked below |
| `dotnet build --configuration Release` / `dotnet test` | not_run | no product code changed; the required check runs it on this pull request. Risk left open: none for this diff |
| `npm run typecheck && npm test && npm run build` | not_run | same |

Smoke runs on this branch (identity jobs only, no model): author https://github.com/drevendev/trade_simulation/actions/runs/33983933806 printed `identity: zendev-author[bot], installation 159334657` and `reaches: drevendev/trade_simulation`; acceptor https://github.com/drevendev/trade_simulation/actions/runs/33983935013 printed `identity: zendev-acceptor[bot], installation 159334368`; spec-sync https://github.com/drevendev/trade_simulation/actions/runs/33983768983 ran to completion as `zendev-machine[bot], installation 159334716` (mirror unchanged, nothing to propose). The ledger mint is still refused with 404: the ZenDev Machine installation does not yet include `zen-telemetry`. Since the second push that is a warning, not a failure, and telemetry records nothing until the owner adds the repository to the installation. The first smoke run stopped the whole identity job on that, which is the defect the second push fixed.

## Not checked

- A real model run under the app tokens: the first scheduled AUTHOR and ACCEPTOR runs after merge are the live check. What to look for: a pull request opened by `zendev-author[bot]` whose CI runs, a verdict and a merge by `zendev-acceptor[bot]`, a ledger record written.
- A mirror commit under the MACHINE identity, unless Drive changed during the smoke sync. `committer` is now explicit, so the class gate cannot be surprised by an action default.
- Revoking the two personal tokens. That is the owner's step, after the live checks above.

## Assumptions and unknowns

- `actions/create-github-app-token@v3` takes `client-id`; the stored variables are client identifiers, not numeric app identifiers. The smoke runs confirm the mint.
- `peter-evans/create-pull-request` commits as the `committer` input regardless of the token it pushes with. Asserted by setting it explicitly rather than relying on the default.
- A job with `needs` and a plain `if` still requires the needed job to succeed; the work jobs therefore never run when identity cannot be proved.
- `claude-code-action` honours `github_token` from a custom app, as its setup guide documents; it already honoured a personal token through the same input.

## Highest-risk area for review

The two model-running workflows: the role token must reach checkout and `github_token` and nothing else new, the ledger token must be minted only at the end and only for `zen-telemetry`, and `smoke` must skip every step that spends anything. `test_loop_identities.py` pins each of those.

## Remaining gate

Widening in form, narrowing in substance: new credentials enter four workflows while a person's token leaves all of them. A person accepts it per the ACCEPTOR hard limits. After the first live runs: revoke `ZENDEV_PAT` and `TELEMETRY_PAT` (owner), then delete the two secrets.
