### PR TITLE
Ignore local environment, Python and editor state the Visual Studio template misses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -360,6 +360,21 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
-# Node / canonical TypeScript engine
-node_modules/
+# Node / canonical TypeScript engine (node_modules/ is already ignored above)
 dist/
+coverage/
+*.tsbuildinfo
+
+# Python control plane under scripts/
+.venv/
+.pytest_cache/
+
+# Local environment, editors, operating system and coding-agent state
+.env
+.env.*
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/
+.claude/
+.codex/


### PR DESCRIPTION
Closes #165

## Achieved outcome

`.gitignore` now covers the local state this repository's own toolchain produces: environment files, the Python virtualenv and pytest cache, Vitest's coverage directory, editor, operating-system and coding-agent directories. It no longer lists `node_modules/` twice. Nothing tracked changes. The audit that motivated this (2026-09-05, tracked tree and the full history of every branch) found no junk and no credential in the repository; this closes the gap before it is used. The companion operator action, enabling secret scanning and push protection, is #164.

## Tested revision

124de328a54e1fc3edf50f7f6029c91052886097

## Changed artifacts

- `.gitignore`: replaces the trailing three-line Node block with a labelled block (`dist/`, `coverage/`, `*.tsbuildinfo`, `.venv/`, `.pytest_cache/`, `.env`, `.env.*`, `.DS_Store`, `Thumbs.db`, `.idea/`, `.vscode/`, `.claude/`, `.codex/`) and drops the duplicate `node_modules/` line; the original one under "Node.js Tools for Visual Studio" remains.

## Acceptance criteria

- [x] Every new pattern ignores what it should: `for p in .env .env.local .venv/x .pytest_cache/x coverage/x x.tsbuildinfo .DS_Store .idea/x .vscode/x .claude/x .codex/x node_modules/x dist/x; do git check-ignore -q "$p" || echo "not ignored: $p"; done` prints nothing on 124de32.
- [x] No tracked file becomes ignored: `git ls-files | git check-ignore --stdin --no-index` prints nothing on 124de32.
- [x] `grep -c '^node_modules/$' .gitignore` prints `1` on 124de32.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `dotnet build --configuration Release` | not_run | no C# source, project or solution file changed; the required `build-and-test` check runs it on this pull request. Residual risk: none, the change is one ignore file. |
| `dotnet test --configuration Release` | not_run | same |
| `npm run typecheck`, `npm test`, `npm run build` | not_run | no TypeScript, package or lockfile changed; the required `typescript` check runs them here. Residual risk: none. |
| `python -m unittest discover -s scripts/tests` | passed | local, on 124de32 |
| `python scripts/policy_guard.py --base origin/master` | passed | local, on 124de32 |
| `python scripts/machine_pr_guard.py --base origin/master --head-ref chore/issue-165-gitignore-hygiene --head-sha 124de328a54e1fc3edf50f7f6029c91052886097` | passed | local, on 124de32 |
| `python scripts/scope_guard.py --base origin/master --head-ref chore/issue-165-gitignore-hygiene --body-file <this body>` | passed | local, on 124de32 |
| `python scripts/implementation_status.py --check` | passed | local, on 124de32 |

Outcome words: `passed`, `failed`, `not_run`, `unavailable`.

## Not checked

`status_lint.py` was not run locally (it needs a token and the pull request number); it runs inside the required `policy-guard` check. The .NET and TypeScript suites were not run locally for the reason above.

## Assumptions and unknowns

- Fact: nothing tracked on `master` matches any new pattern (`git ls-files | git check-ignore --stdin --no-index` is empty).
- Assumption: nobody intends to commit a `coverage/` directory or an `.env` file in future; if a fixture ever needs one, add a negation rule then.
- Unknown: none.

## Highest-risk area for review

`coverage/` is unanchored, so a future source directory of that name anywhere in the tree would be ignored too. It matches the file's existing unanchored style; anchor it as `/coverage/` if that reads as a trap.

## Remaining gate

None for the change itself. The owner merges this by hand: the pull request carries `status:needs-decision` so an ACCEPTOR run leaves it alone, and it was opened from an owner session, not from an AUTHOR run.
