### PR TITLE
Record why a subscription reading was refused, and read the outcome from the last word

### DIFF
--- a/scripts/record_usage.py
+++ b/scripts/record_usage.py
@@ -61,6 +61,19 @@ REQUIREMENT = re.compile(r"\bREQ-[A-Z]+-\d{3}\b")
 # fragment, a colour code or a markdown heading.
 REFERENCE = re.compile(r"(?<![\w/#])#(\d{1,6})\b")
 
+# The shapes a run ends on when it delivered: a handoff or a verdict heading, or a pull
+# request it names. Checked first, on the final message only, because a run that opened
+# a pull request has completed whatever else its transcript discussed — the first live
+# record under this classifier called an author run "blocked" for mentioning an Issue
+# that was blocked, while the run itself ended in a handoff for #163.
+COMPLETED = re.compile(
+    r"^\s*#{1,6}\s*(?:AUTHOR\s+handoff|ACCEPTOR\s+verdict|ACCEPT\b|REQUEST_CHANGES\b)"
+    r"|\bpull request\b[^\n]{0,60}#\d+"
+    r"|\bPR:?\s*#\d+"
+    r"|\bopened (?:a )?(?:new )?pull request",
+    re.I | re.M,
+)
+
 # The shapes a run uses when it stops on a gate: the label it sets, the phrase the
 # runbook prescribes, or a heading that names a blocker. Prose that merely mentions the
 # word — "no known blockers" in a claim comment — is not a heading and does not match.
@@ -174,17 +187,46 @@ def transcript(messages) -> str:
     return "\n".join(parts)
 
 
+def final_text(messages) -> str:
+    """What the run said last: the result text, or failing that the last assistant text.
+
+    The outcome is read from this, not from the whole transcript. A run talks about many
+    things on the way — Issues that are blocked, work it decided not to take — and only
+    its last word says how it ended.
+    """
+    last = ""
+    for message in messages or []:
+        if not isinstance(message, dict):
+            continue
+        if message.get("type") == "result" and isinstance(message.get("result"), str):
+            return message["result"]
+        content = (message.get("message") or {}).get("content")
+        if not isinstance(content, list):
+            continue
+        texts = [
+            block["text"]
+            for block in content
+            if isinstance(block, dict) and block.get("type") == "text" and isinstance(block.get("text"), str)
+        ]
+        if texts:
+            last = "\n".join(texts)
+    return last
+
+
 def classify_outcome(conclusion, text):
     """(outcome, source). Pure.
 
     The workflow's own conclusion is trusted where it is specific: `no_work` means the
     model was never started, and anything that is not success or unknown is a failure.
-    Everything else is read from the transcript, and the source says so.
+    Everything else is read from the run's final message, and the source says so. A
+    handoff or a verdict there means completed, whatever else the message mentions.
     """
     if conclusion == "no_work":
         return "no_work", "workflow"
     if conclusion not in (None, "", "unknown", "success"):
         return "failed", "workflow"
+    if COMPLETED.search(text or ""):
+        return "completed", "heuristic"
     if BLOCKED.search(text or ""):
         return "blocked", "heuristic"
     if NO_WORK.search(text or ""):
@@ -301,7 +343,8 @@ def main() -> int:
         if model is None:
             warn("the execution file names no model; recording null")
 
-    outcome, outcome_source = classify_outcome(args.conclusion, text)
+    # The outcome is read from the run's last word; mentions and rework from everything.
+    outcome, outcome_source = classify_outcome(args.conclusion, final_text(messages))
     before = load_reading(args.usage_before)
     after = load_reading(args.usage_after)
     if before is None or after is None:

--- a/scripts/subscription_usage.py
+++ b/scripts/subscription_usage.py
@@ -77,13 +77,44 @@ def summarize(payload):
     return windows
 
 
-def unavailable(reason: str):
+def unavailable(reason: str, error_message=None):
     return {
         "available": False,
         "reason": reason,
+        "error_message": error_message,
         "fetched_at": now_iso(),
         **{name: None for name in WINDOWS},
     }
+
+
+def error_detail(exc):
+    """The API's own account of a refusal: its error type and message. Pure over the body.
+
+    Every reading since the first one came back `HTTP 403`, and a status code alone
+    cannot say whether the token lacks a scope, the endpoint moved, or a proxy refused
+    the runner. The error body can: it is JSON with an `error.type` and an
+    `error.message`, and neither carries the token. The type joins the reason, which is
+    printed; the message stays in the reading, which reaches the private ledger only.
+    """
+    try:
+        # Enough for any error document; the message itself is cut to 200 characters
+        # below, so what reaches the ledger is a line, never a page.
+        body = exc.read(65536)
+    except (OSError, AttributeError, ValueError):
+        return None, None
+    try:
+        data = json.loads(body.decode("utf-8", "replace"))
+    except (json.JSONDecodeError, AttributeError):
+        return None, None
+    error = data.get("error") if isinstance(data, dict) else None
+    if not isinstance(error, dict):
+        return None, None
+    kind = error.get("type")
+    message = error.get("message")
+    return (
+        kind if isinstance(kind, str) and kind else None,
+        message[:200] if isinstance(message, str) and message else None,
+    )
 
 
 def fetch(token: str, timeout: float = 20.0):
@@ -107,15 +138,23 @@ def read(token: str, fetcher=fetch):
     try:
         payload = fetcher(token)
     except urllib.error.HTTPError as exc:
-        # The status code and nothing else: the body of a refusal is not ours to log.
-        return unavailable(f"HTTP {exc.code}")
+        # The status code and the API's error type go into the reason; the error
+        # message goes into the reading only. Neither contains the token.
+        kind, message = error_detail(exc)
+        return unavailable(f"HTTP {exc.code}" + (f" {kind}" if kind else ""), message)
     except (urllib.error.URLError, TimeoutError, OSError) as exc:
         return unavailable(type(exc).__name__)
     except (json.JSONDecodeError, UnicodeDecodeError):
         return unavailable("malformed body")
     if not isinstance(payload, dict):
         return unavailable("malformed body")
-    return {"available": True, "reason": None, "fetched_at": now_iso(), **summarize(payload)}
+    return {
+        "available": True,
+        "reason": None,
+        "error_message": None,
+        "fetched_at": now_iso(),
+        **summarize(payload),
+    }
 
 
 def main() -> int:

--- a/scripts/tests/test_record_usage.py
+++ b/scripts/tests/test_record_usage.py
@@ -150,6 +150,45 @@ class OutcomeTests(unittest.TestCase):
         text = "**AUTHOR claim**\n\nKnown blockers: none. Proceeding."
         self.assertEqual(rec.classify_outcome("success", text), ("completed", "heuristic"))
 
+    def test_a_handoff_is_completed_whatever_else_it_mentions(self):
+        # Run 33986212612 opened #163 and was recorded as blocked, because its text
+        # also discussed Issue #138, which is blocked. The handoff decides.
+        text = (
+            "## AUTHOR handoff\n\nBranch: claude/issue-157-build-initial-world\n"
+            "Pull request: #163\n\n## Blocked elsewhere\n\nIssue #138 remains status:blocked."
+        )
+        self.assertEqual(rec.classify_outcome("success", text), ("completed", "heuristic"))
+
+    def test_a_verdict_is_completed_for_the_acceptor(self):
+        for text in ("## ACCEPTOR verdict: REQUEST_CHANGES\n\nHead abc", "## ACCEPT\n\nAll six hold."):
+            with self.subTest(text=text):
+                self.assertEqual(rec.classify_outcome("success", text), ("completed", "heuristic"))
+
+    def test_a_blocker_heading_without_a_handoff_is_still_blocked(self):
+        text = "## AUTHOR blocker\n\nGate: the registry names no READY row. status:blocked set."
+        self.assertEqual(rec.classify_outcome("success", text), ("blocked", "heuristic"))
+
+
+class FinalTextTests(unittest.TestCase):
+    def test_the_result_text_is_the_final_word(self):
+        messages = [
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "Issue #138 is blocked, skipping it"}]}},
+            {"type": "result", "result": "## AUTHOR handoff\n\nPull request: #163"},
+        ]
+        self.assertEqual(rec.final_text(messages), "## AUTHOR handoff\n\nPull request: #163")
+
+    def test_without_a_result_the_last_assistant_text_stands_in(self):
+        messages = [
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "first"}]}},
+            {"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "Bash"}]}},
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "last"}]}},
+        ]
+        self.assertEqual(rec.final_text(messages), "last")
+
+    def test_nothing_said_is_an_empty_final_text(self):
+        self.assertEqual(rec.final_text([{"type": "system"}, None]), "")
+        self.assertEqual(rec.final_text(None), "")
+
     def test_a_run_that_found_nothing_is_no_work(self):
         text = "Evaluated items 1-5: no eligible item. Nothing to do."
         self.assertEqual(rec.classify_outcome("success", text), ("no_work", "heuristic"))

--- a/scripts/tests/test_subscription_usage.py
+++ b/scripts/tests/test_subscription_usage.py
@@ -1,6 +1,7 @@
 """A reading that cannot be taken must say so, and a reading that can must say only
 what the ledger asked for."""
 
+import io
 import json
 import pathlib
 import sys
@@ -54,13 +55,45 @@ class ReadTests(unittest.TestCase):
         self.assertIn("no token", reading["reason"])
         self.assertIsNone(reading["five_hour"])
 
-    def test_a_rate_limit_is_recorded_by_status_code_only(self):
+    def test_a_refusal_records_the_status_and_the_error_type_and_keeps_the_message(self):
+        # Every live reading so far: 403, and a status code alone cannot say why.
+        body = io.BytesIO(
+            b'{"type":"error","error":{"type":"permission_error",'
+            b'"message":"This token does not have the required scope"}}'
+        )
+
         def refuse(token):
-            raise urllib.error.HTTPError("u", 429, "Too Many Requests", {}, None)
+            raise urllib.error.HTTPError("u", 403, "Forbidden", {}, body)
+
+        reading = usage.read("secret-token", fetcher=refuse)
+        self.assertFalse(reading["available"])
+        self.assertEqual(reading["reason"], "HTTP 403 permission_error")
+        self.assertEqual(reading["error_message"], "This token does not have the required scope")
+        self.assertNotIn("secret-token", json.dumps(reading))
+
+    def test_a_refusal_without_a_json_body_records_the_status_code_only(self):
+        def refuse(token):
+            raise urllib.error.HTTPError("u", 429, "Too Many Requests", {}, io.BytesIO(b"<html>rate limited</html>"))
 
         reading = usage.read("t", fetcher=refuse)
-        self.assertFalse(reading["available"])
         self.assertEqual(reading["reason"], "HTTP 429")
+        self.assertIsNone(reading["error_message"])
+
+    def test_a_refusal_with_no_body_at_all_is_still_recorded(self):
+        def refuse(token):
+            raise urllib.error.HTTPError("u", 403, "Forbidden", {}, None)
+
+        reading = usage.read("t", fetcher=refuse)
+        self.assertEqual(reading["reason"], "HTTP 403")
+        self.assertIsNone(reading["error_message"])
+
+    def test_a_long_message_is_cut_so_the_ledger_never_carries_a_page(self):
+        body = io.BytesIO(json.dumps({"error": {"type": "x", "message": "m" * 5000}}).encode())
+
+        def refuse(token):
+            raise urllib.error.HTTPError("u", 403, "Forbidden", {}, body)
+
+        self.assertEqual(len(usage.read("t", fetcher=refuse)["error_message"]), 200)
 
     def test_a_network_failure_is_recorded_by_class(self):
         def drop(token):


### PR DESCRIPTION
Closes #168

## Achieved outcome

A refused subscription reading now records the API's own error type in its reason (`HTTP 403 permission_error`) and keeps the error message in the reading, which reaches the private ledger only; the public warning prints the reason alone, and the token appears in neither. The outcome of a run is classified from its final message, and a handoff or a verdict marker there means `completed` whatever else the message mentions; blocker markers are consulted only after that.

## Tested revision

`d8a41a5`

## Changed artifacts

- `scripts/subscription_usage.py` — `error_detail()` reads at most 64 KB of a refusal body and returns `error.type` and a 200-character `error.message`; `unavailable()` and the success reading carry an `error_message` field; the HTTP branch of `read()` uses both.
- `scripts/record_usage.py` — `COMPLETED` markers (handoff, verdict, a named pull request); `final_text()` returns the result text or the last assistant text; `classify_outcome()` checks `COMPLETED` before `BLOCKED`; `main()` classifies from `final_text()` while mentions and rework still read the whole transcript.
- `scripts/tests/test_subscription_usage.py` — refusal with a JSON body, without a JSON body, with no body, and with an overlong message; the token never appears in a reading.
- `scripts/tests/test_record_usage.py` — the #163 case (handoff plus a blocked mention is `completed`), acceptor verdicts, a blocker heading without a handoff, and `final_text()` in three shapes.

## Acceptance criteria

- [x] A 403 whose body names `permission_error` is recorded with reason `HTTP 403 permission_error` and the message in the reading; a body that is not JSON leaves reason `HTTP 403` and no message; the token appears nowhere in either — `test_a_refusal_records_the_status_and_the_error_type_and_keeps_the_message`, `test_a_refusal_without_a_json_body_records_the_status_code_only`, `test_a_refusal_with_no_body_at_all_is_still_recorded`.
- [x] A final message carrying `## AUTHOR handoff` and a pull request number classifies as `completed` even if it also says something is blocked; a final message carrying `## AUTHOR blocker` classifies as `blocked` — `test_a_handoff_is_completed_whatever_else_it_mentions`, `test_a_blocker_heading_without_a_handoff_is_still_blocked`.
- [x] `python -m unittest discover -s scripts/tests` passes — 275 tests at `d8a41a5`.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest discover -s scripts/tests` | passed | 275 tests, OK, at `d8a41a5` |
| `python scripts/policy_guard.py --base origin/master` | passed | policy paths only, no violation |
| `dotnet build --configuration Release` / `dotnet test` | not_run | no product code changed; the required check runs it on this pull request. Risk left open: none for this diff |
| `npm run typecheck && npm test && npm run build` | not_run | same |

## Not checked

The live 403 body. The first run after merge records it; the reason then names the error type and the ledger holds the message, which is what decides the next step on the subscription figure.

## Assumptions and unknowns

- Anthropic error bodies are JSON of the shape `{"type": "error", "error": {"type": ..., "message": ...}}`. Any other shape degrades to the status code alone.
- The error message never contains the token. It is capped at 200 characters and stored in the private ledger only, so even a surprising message stays off the public log.
- `COMPLETED` is a heuristic like the rest of the classifier and is marked `heuristic` in the record. A run that opens a pull request and then reports a blocker in the same final message is recorded as `completed`; that is the intended reading — a pull request exists.

## Highest-risk area for review

`COMPLETED` in `record_usage.py`: too broad a pattern would hide genuinely blocked runs behind any mention of a pull request. It is anchored to headings for the role markers and requires a number for the pull request forms; `OutcomeTests` carries the negative controls.

## Remaining gate

None mandatory. Narrowing in substance: nothing new is printed except an error type, and no credential enters any workflow.
