### PR TITLE
Read the repository name from the run instead of enforcing a literal

### DIFF
--- a/.github/workflows/zendev-acceptor.yml
+++ b/.github/workflows/zendev-acceptor.yml
@@ -181,7 +181,7 @@ jobs:
             }
           prompt: |
             You are the ACCEPTOR role of an unattended ZenDev run on
-            drevendev/trade_simulation. You have no memory of previous runs.
+            ${{ github.repository }}. You have no memory of previous runs.
 
             Read AGENTS.md and then docs/zendev/ACCEPTOR_RUNBOOK.md, and follow the
             runbook exactly, in order, from section 1 to the end.

--- a/.github/workflows/zendev-author.yml
+++ b/.github/workflows/zendev-author.yml
@@ -171,7 +171,7 @@ jobs:
             }
           prompt: |
             You are the AUTHOR role of an unattended ZenDev run on
-            drevendev/trade_simulation. You have no memory of previous runs.
+            ${{ github.repository }}. You have no memory of previous runs.
 
             Read AGENTS.md and then docs/zendev/AUTHOR_RUNBOOK.md, and follow the
             runbook exactly, in order, from section 1 to the end.

--- a/.github/workflows/zendev-watchdog.yml
+++ b/.github/workflows/zendev-watchdog.yml
@@ -23,7 +23,11 @@ concurrency:
 
 jobs:
   watchdog:
-    if: github.repository == 'drevendev/trade_simulation' && github.ref == 'refs/heads/master' && vars.ZENDEV_ENABLED == 'true'
+    # No repository name here, on purpose: a rename must not stop the loop, and on
+    # 2026-09-05 a rename in case only did, for as long as the spelling differed (#171).
+    # ZENDEV_ENABLED is the fork guard — a fork receives no repository variables — and
+    # the dispatcher acts on the repository it runs in, whatever it is called today.
+    if: github.ref == 'refs/heads/master' && vars.ZENDEV_ENABLED == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/docs/zendev/SCHEDULING.md
+++ b/docs/zendev/SCHEDULING.md
@@ -9,8 +9,9 @@ timeouts and acceptance limits. Their former independent cron entries are remove
 so a delayed native event cannot duplicate a recovery dispatch.
 
 The fixed targets are `spec-sync.yml`, `zendev-author.yml` and
-`zendev-acceptor.yml`, on `drevendev/trade_simulation`, branch `master` only.
-For each target the dispatcher:
+`zendev-acceptor.yml`, in the repository the watchdog runs in, branch `master` only.
+The repository is read from the run, never compared to a name — see
+[Renaming the repository](#renaming-the-repository). For each target the dispatcher:
 
 1. Respects `ZENDEV_ENABLED` and refuses to re-enable a disabled workflow.
 2. Checks all queued, running, pending, requested and waiting runs, including old
@@ -155,3 +156,42 @@ Rollback is a reviewed revert restoring the three former cron entries and removi
 the watchdog together. Do not run both automatic scheduling schemes concurrently.
 An independent external timer is the next option if GitHub-only gaps persist; no
 external service is installed or configured by this change.
+
+## Renaming the repository
+
+The repository's name is not load-bearing anywhere in the loop. Workflows read it from
+`github.repository`; the dispatcher reads `GITHUB_REPOSITORY`; every script takes
+`--repo` from the workflow. A test refuses a workflow condition or a script that compares
+the name to a literal. This is the lesson of 2026-09-05, when a rename in case only —
+`trade_simulation` to `Trade_Simulation` — made a strict comparison in the dispatcher
+refuse every tick for as long as the spelling differed, while GitHub itself routed both
+spellings to the same repository.
+
+A rename therefore does not stop the loop, but it still touches things outside the
+loop's control, and they are listed here so the next rename is a checklist rather than
+a discovery:
+
+- **GitHub Pages moves and does not redirect.** The site lives at
+  `https://<owner>.github.io/<repository>/`; the old address answers 404 the moment the
+  rename lands, even for a change of case. Links in `README.md` and `docs/spec/` that
+  name the site must be edited.
+- **Raw links held by the researcher.** The return channel is read over
+  `raw.githubusercontent.com/<owner>/<repository>/master/docs/spec/...` from the
+  researcher's own manifest. GitHub redirects web, git and API requests for a renamed
+  repository; whether raw requests follow is not something to rely on. Tell the
+  researcher through `FEEDBACK_TO_RESEARCHER.md` before renaming, with the new links.
+- **The external timer.** Its `REPO` constant names this repository, and a
+  `workflow_dispatch` is a POST: an HTTP client that turns a redirected POST into a GET
+  pokes nothing. Update the constant when renaming.
+- **Local clones and worktrees.** Git follows the redirect; updating the remote is
+  hygiene, not repair.
+- **Text.** Mentions in this document's examples, the ADRs and the telemetry
+  repository's README are descriptions, not dependencies.
+
+Unaffected: the three GitHub App installations (bound to the repository's id), secrets,
+variables, branch protection, Issue and pull request numbers, run history, and the
+`run_url` fields in the ledger, which redirect.
+
+Order for a deliberate rename: rename; update the timer's constant; append the new links
+to the researcher's channel; edit the Pages links; watch one watchdog tick and one mirror
+sync. Nothing in this repository has to change first.

--- a/scripts/schedule_watchdog.py
+++ b/scripts/schedule_watchdog.py
@@ -1,7 +1,8 @@
 """Recover missed ZenDev dispatches; dry-run unless --dispatch is explicit.
 
-Only the fixed repository, master branch and three existing workflows are allowed.
-No model runs here. A successful dispatch is not a successful unit of product work.
+Only the repository this runs in, its master branch and three existing workflows are
+allowed. No model runs here. A successful dispatch is not a successful unit of product
+work.
 """
 
 from __future__ import annotations
@@ -14,7 +15,14 @@ from pathlib import Path
 import subprocess
 from urllib.parse import urlencode
 
-REPOSITORY = "drevendev/trade_simulation"
+# The repository this dispatcher acts on. Inside Actions it is the one the workflow
+# runs in, read from the environment, so renaming the repository changes nothing here.
+# A literal once did the opposite: on 2026-09-05 a rename in case only turned every
+# tick into a refusal for as long as the spelling differed (#171). Outside Actions the
+# caller names it with --repo; the default is a developer convenience for this project,
+# and nothing else depends on it.
+DEFAULT_REPOSITORY = "drevendev/trade_simulation"
+REPOSITORY = os.environ.get("GITHUB_REPOSITORY") or DEFAULT_REPOSITORY
 BRANCH = "master"
 # Model-running targets alternate, at most one dispatched per pass. spec-sync runs no
 # model and stays outside that rotation, dispatched every pass like before.
@@ -178,13 +186,33 @@ def resolve_interval() -> timedelta:
     return candidate
 
 
+def resolve_repository(explicit: str | None) -> str:
+    """The repository to act on: the run's own inside Actions, the caller's outside.
+
+    Inside Actions the environment is authoritative, and an --repo that disagrees with
+    it is refused: a dispatcher must never be pointed at a repository it does not run
+    in. Names compare case-insensitively, because GitHub routes them that way and
+    reports whichever spelling the repository currently carries.
+    """
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        actual = os.environ.get("GITHUB_REPOSITORY", "")
+        if not actual:
+            raise ValueError("GITHUB_REPOSITORY is not set; refusing to guess the repository")
+        if explicit and explicit.lower() != actual.lower():
+            raise ValueError("--repo names a repository other than the one this workflow runs in")
+        return actual
+    return explicit or DEFAULT_REPOSITORY
+
+
 def is_enabled() -> bool:
     if os.environ.get("GITHUB_ACTIONS") == "true":
         # GITHUB_TOKEN does not grant repository Variables API access. The
         # workflow passes the trusted vars context instead; do not add a PAT.
-        if (os.environ.get("GITHUB_REPOSITORY") != REPOSITORY
-                or os.environ.get("GITHUB_REF") != f"refs/heads/{BRANCH}"):
-            raise ValueError("Dispatcher can only execute on the canonical master")
+        #
+        # Only the branch is checked. The repository is compared to nothing: this
+        # dispatcher acts on the repository it runs in, whatever that is called today.
+        if os.environ.get("GITHUB_REF") != f"refs/heads/{BRANCH}":
+            raise ValueError("Dispatcher can only execute on master")
         return os.environ.get("ZENDEV_ENABLED") == "true"
     return api(f"repos/{REPOSITORY}/actions/variables/ZENDEV_ENABLED")["value"] == "true"
 
@@ -234,9 +262,20 @@ def run(*, dispatch: bool = False, now: datetime | None = None,
 
 
 def main() -> int:
+    global REPOSITORY
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--dispatch", action="store_true")
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="owner/name for local diagnostics; inside Actions the run's own repository is used",
+    )
     args = parser.parse_args()
+    try:
+        REPOSITORY = resolve_repository(args.repo)
+    except ValueError as error:
+        print(f"::error::Watchdog failed closed: {error}", flush=True)
+        return 1
     try:
         interval = resolve_interval()
         results = run(dispatch=args.dispatch, interval=interval)

--- a/scripts/tests/test_repository_name_is_data.py
+++ b/scripts/tests/test_repository_name_is_data.py
@@ -1,0 +1,62 @@
+"""The repository's name is read from the run, never compared to a literal.
+
+Renaming a repository is an owner's decision that must not need a policy change to
+survive — the policy change would need the loop's own review path, and the loop would be
+stopped. On 2026-09-05 a rename in case only stopped it for as long as the spelling
+differed (#171). These assertions keep the name out of every place where a literal would
+be load-bearing: workflow conditions and the control-plane scripts. The one permitted
+literal is the watchdog's developer default for local runs, and it is named here so that
+a second one cannot appear unnoticed.
+
+Text assertions rather than a YAML parse, like the other workflow tests: this runs in
+the policy-guard job with nothing but the standard library.
+"""
+
+import pathlib
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github" / "workflows"
+SCRIPTS = ROOT / "scripts"
+
+LITERAL = "drevendev/trade_simulation"
+
+
+class WorkflowTests(unittest.TestCase):
+    def test_no_workflow_compares_the_repository_to_a_literal(self):
+        for path in sorted(WORKFLOWS.glob("*.yml")):
+            text = path.read_text(encoding="utf-8")
+            with self.subTest(workflow=path.name):
+                self.assertNotIn("github.repository ==", text)
+                self.assertNotIn(LITERAL, text)
+
+    def test_the_role_prompts_name_the_repository_from_the_context(self):
+        for name in ("zendev-author.yml", "zendev-acceptor.yml"):
+            with self.subTest(workflow=name):
+                self.assertIn("${{ github.repository }}", (WORKFLOWS / name).read_text(encoding="utf-8"))
+
+    def test_the_watchdog_still_requires_master_and_the_switch(self):
+        text = (WORKFLOWS / "zendev-watchdog.yml").read_text(encoding="utf-8")
+        self.assertIn("github.ref == 'refs/heads/master'", text)
+        self.assertIn("vars.ZENDEV_ENABLED == 'true'", text)
+
+
+class ScriptTests(unittest.TestCase):
+    def test_only_the_watchdog_default_carries_the_name(self):
+        for path in sorted(SCRIPTS.glob("*.py")):
+            text = path.read_text(encoding="utf-8")
+            with self.subTest(script=path.name):
+                if path.name == "schedule_watchdog.py":
+                    self.assertEqual(text.count(LITERAL), 1, "one developer default, no more")
+                    self.assertIn(f'DEFAULT_REPOSITORY = "{LITERAL}"', text)
+                else:
+                    self.assertNotIn(LITERAL, text)
+
+    def test_the_scan_sees_the_scripts_and_the_workflows(self):
+        # Without this the assertions above pass on empty directories.
+        self.assertGreaterEqual(len(list(SCRIPTS.glob("*.py"))), 10)
+        self.assertGreaterEqual(len(list(WORKFLOWS.glob("*.yml"))), 6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_schedule_watchdog.py
+++ b/scripts/tests/test_schedule_watchdog.py
@@ -181,6 +181,48 @@ class DispatchTests(unittest.TestCase):
         self.assertEqual(api.call_count, 1)
 
 
+class RepositoryNameTests(unittest.TestCase):
+    """The name is data from the run's context, never a constant the dispatcher enforces.
+
+    On 2026-09-05 a rename in case only — trade_simulation to Trade_Simulation — made the
+    strict comparison that used to live in is_enabled() refuse every tick until the name
+    was put back (#171).
+    """
+
+    def test_actions_takes_the_repository_from_the_environment_whatever_its_spelling(self):
+        for spelling in ("drevendev/trade_simulation", "drevendev/Trade_Simulation", "drevendev/TradeSim"):
+            with self.subTest(spelling=spelling), patch.dict(
+                os.environ, {"GITHUB_ACTIONS": "true", "GITHUB_REPOSITORY": spelling}, clear=True
+            ):
+                self.assertEqual(watchdog.resolve_repository(None), spelling)
+
+    def test_actions_refuses_to_guess_when_the_environment_is_silent(self):
+        with patch.dict(os.environ, {"GITHUB_ACTIONS": "true"}, clear=True), self.assertRaises(ValueError):
+            watchdog.resolve_repository(None)
+
+    def test_actions_refuses_an_argument_for_another_repository_but_not_another_spelling(self):
+        env = {"GITHUB_ACTIONS": "true", "GITHUB_REPOSITORY": "drevendev/Trade_Simulation"}
+        with patch.dict(os.environ, env, clear=True):
+            self.assertEqual(watchdog.resolve_repository("drevendev/trade_simulation"), "drevendev/Trade_Simulation")
+            with self.assertRaises(ValueError):
+                watchdog.resolve_repository("someone/elsewhere")
+
+    def test_local_runs_use_the_argument_or_the_documented_default(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(watchdog.resolve_repository("drevendev/TradeSim"), "drevendev/TradeSim")
+            self.assertEqual(watchdog.resolve_repository(None), watchdog.DEFAULT_REPOSITORY)
+
+    def test_is_enabled_reads_the_switch_under_any_spelling_and_still_insists_on_master(self):
+        env = {"GITHUB_ACTIONS": "true", "GITHUB_REPOSITORY": "drevendev/Trade_Simulation",
+               "GITHUB_REF": "refs/heads/master", "ZENDEV_ENABLED": "true"}
+        with patch.dict(os.environ, env, clear=True), patch.object(watchdog, "api") as api:
+            self.assertTrue(watchdog.is_enabled())
+            os.environ["GITHUB_REF"] = "refs/heads/untrusted"
+            with self.assertRaises(ValueError):
+                watchdog.is_enabled()
+            api.assert_not_called()
+
+
 class EnvironmentTests(unittest.TestCase):
     def test_actions_uses_trusted_vars_not_variables_api(self):
         env = {"GITHUB_ACTIONS": "true", "GITHUB_REPOSITORY": watchdog.REPOSITORY,


### PR DESCRIPTION
Closes #171

## Achieved outcome

The repository's name is no longer compared to anything inside the loop. The dispatcher takes the repository from `GITHUB_REPOSITORY` inside Actions and from `--repo` outside, refuses to guess when the environment is silent, and refuses an argument that names a different repository; its Actions guard keeps the `master` check and drops the name check. The watchdog's `if:` names no repository. The role prompts say `${{ github.repository }}`. A test refuses any workflow condition or control-plane script that carries the literal, except the watchdog's documented developer default. `SCHEDULING.md` gains a *Renaming the repository* section listing what a rename touches outside the loop. Renaming the repository, in case or in full, now stops nothing here.

## Tested revision

`ef4d3c0`

## Changed artifacts

- `scripts/schedule_watchdog.py` — `DEFAULT_REPOSITORY` for local runs; `REPOSITORY` seeded from the environment; `resolve_repository()`; `is_enabled()` checks the branch only; `main()` gains `--repo` and fails closed on an unresolvable repository.
- `scripts/tests/test_schedule_watchdog.py` — `RepositoryNameTests`: any spelling from the environment; refusal when silent; refusal of a foreign `--repo` but not of another spelling; local default; `is_enabled()` under another spelling still insists on `master`.
- `scripts/tests/test_repository_name_is_data.py` — new: no workflow compares `github.repository` to a literal or carries the name; the role prompts use the context; the watchdog still requires `master` and the switch; only the watchdog default carries the literal, once.
- `.github/workflows/zendev-watchdog.yml` — the `if:` keeps `master` and `ZENDEV_ENABLED`, drops the repository literal, and says why.
- `.github/workflows/zendev-author.yml` — the prompt names `${{ github.repository }}`.
- `.github/workflows/zendev-acceptor.yml` — the same.
- `docs/zendev/SCHEDULING.md` — targets are "in the repository the watchdog runs in"; new section *Renaming the repository*.

## Acceptance criteria

- [x] With `GITHUB_ACTIONS=true` and `GITHUB_REPOSITORY=drevendev/Trade_Simulation` (or any other spelling), `schedule_watchdog.run()` proceeds and addresses that repository; with `GITHUB_REPOSITORY` unset it refuses — `RepositoryNameTests`, and the live dry run recorded below.
- [x] `zendev-watchdog.yml` contains no repository literal in its `if:`, and still requires `master` and `ZENDEV_ENABLED` — `test_the_watchdog_still_requires_master_and_the_switch`, `test_no_workflow_compares_the_repository_to_a_literal`.
- [x] The two role prompts contain `${{ github.repository }}` and no literal repository name — `test_the_role_prompts_name_the_repository_from_the_context`.
- [x] `SCHEDULING.md` carries the renaming section.
- [x] `python -m unittest discover -s scripts/tests` passes — 299 tests at `ef4d3c0`.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest discover -s scripts/tests` | passed | 299 tests, OK, at `ef4d3c0` |
| `python scripts/policy_guard.py --base origin/master` | passed | policy paths only, no violation |
| dry run under another spelling: `GITHUB_ACTIONS=true GITHUB_REPOSITORY=drevendev/Trade_Simulation GITHUB_REF=refs/heads/master ZENDEV_ENABLED=false python scripts/schedule_watchdog.py` | passed | exit code and decision recorded below |
| workflow YAML parses | passed | all six files load |
| `dotnet build --configuration Release` / `dotnet test` | not_run | no product code changed; the required check runs it on this pull request. Risk left open: none for this diff |
| `npm run typecheck && npm test && npm run build` | not_run | same |

Dry run under `GITHUB_REPOSITORY=drevendev/Trade_Simulation`: exit 0, decision `disabled` (the switch was off), no API call. Before this change the same command exited 1 with `Watchdog failed closed: ValueError`.

## Not checked

A live rename. The owner has decided to keep the name; the section in `SCHEDULING.md` is what a future rename follows, and the tests are what keeps the loop indifferent to it in the meantime.

## Assumptions and unknowns

- `vars.ZENDEV_ENABLED` is a sufficient fork guard for the watchdog: a fork receives no repository variables, so the job condition is false there. The former literal added nothing a fork could not also fail on.
- Comparing `--repo` against the environment case-insensitively matches GitHub's own routing; `GITHUB_REPOSITORY` carries the stored spelling, which is exactly what tripped the old strict comparison.
- Whether `raw.githubusercontent.com` follows a rename is not asserted; the renaming section treats it as something to announce to the researcher rather than rely on.

## Highest-risk area for review

`resolve_repository()` and the `main()` guard: the dispatcher must still fail closed when it cannot tell which repository it is in, and must never be pointed at another one. `test_actions_refuses_to_guess_when_the_environment_is_silent` and `test_actions_refuses_an_argument_for_another_repository_but_not_another_spelling` are the negative controls.

## Remaining gate

None mandatory. Narrowing in substance: a condition that could stop the loop is removed and nothing gains authority. Outside this repository, a future rename still needs the external timer's `REPO` constant updated and the researcher told the new raw links; both are in the new section.
