### PR TITLE
Read a review's state as its verdict, and count only the role's own refusals

### DIFF
--- a/.github/workflows/zendev-acceptor.yml
+++ b/.github/workflows/zendev-acceptor.yml
@@ -228,7 +228,8 @@ jobs:
         run: |
           python "${RUNNER_TEMP}/control-plane/rework_limit.py" \
             --repo "${{ github.repository }}" \
-            --pull "${{ steps.select.outputs.target }}"
+            --pull "${{ steps.select.outputs.target }}" \
+            --reviewer "${{ steps.identity.outputs.app-slug }}"
 
       # The ledger lives in a private repository and is written by the MACHINE identity.
       # Its token is minted here, at the end, scoped to that repository alone: the model

--- a/docs/zendev/ACCEPTOR_RUNBOOK.md
+++ b/docs/zendev/ACCEPTOR_RUNBOOK.md
@@ -28,7 +28,11 @@ A pull request labelled `status:needs-decision` is never eligible: that label me
 the decision was handed to a person, and a review run cannot take it back.
 A head revision without a prior verdict is eligible as before. Inspect both formal
 reviews and verdict comments: a verdict posted as a comment because GitHub refuses
-a same-account review counts equally.
+a same-account review counts equally. A formal review in the `APPROVED` or
+`CHANGES_REQUESTED` state is a verdict whatever its words, from whichever account; a
+review left in the `COMMENTED` state is prose. Only a comment by the pull request's
+author counts as a correction handoff — a QA note from another account posted after a
+verdict is evidence for the next review, and does not reopen the head.
 
 **Machine-generated pull requests are never eligible.** A pull request whose head
 branch is `spec-mirror` is produced by a workflow, gated mechanically and merged by
@@ -224,7 +228,9 @@ matters, and what would satisfy it. Set the Issue back to `status:in-progress`.
 Vague dissatisfaction is not a verdict.
 
 The third refusal on one pull request is the last. After your run, the forge counts the
-`REQUEST_CHANGES` verdicts on the pull request (`scripts/rework_limit.py`); at three it
+`REQUEST_CHANGES` verdicts posted under your own identity on the pull request
+(`scripts/rework_limit.py`) — a QA review from another account is evidence for you, not
+a round of the loop; at three it
 closes the pull request with the record of every verdict, deletes the loop's branch, and
 returns the Issue to `status:ready` with the same record. You do nothing differently —
 post the verdict as always — but know that a third refusal ends this branch, so it must

--- a/docs/zendev/AUTHOR_RUNBOOK.md
+++ b/docs/zendev/AUTHOR_RUNBOOK.md
@@ -107,7 +107,9 @@ actually fixed.
 
 ### The rework bound (items 1 and 2)
 
-Rework on one pull request is bounded at three `REQUEST_CHANGES` verdicts. At the third,
+Rework on one pull request is bounded at three `REQUEST_CHANGES` verdicts posted by the
+ACCEPTOR's own identity. A refusing review from another account is a defect to address,
+and it may keep the branch unmergeable, but it is not a round of the bound. At the third,
 the forge closes the pull request with the record of every verdict, deletes its branch,
 and returns the Issue to `status:ready` with the same record (`scripts/rework_limit.py`).
 A pull request closed this way is not yours to reopen, and its branch is gone: take the

--- a/scripts/rework_limit.py
+++ b/scripts/rework_limit.py
@@ -17,8 +17,11 @@ What counts as a refusal is what the selector already counts as a verdict, narro
 the refusing kind: a comment whose first marked line says `REQUEST_CHANGES` in one of
 the shapes the runbook prescribes, or a formal review in the `CHANGES_REQUESTED` state.
 An `ACCEPT`, a correction handoff, prose that mentions an earlier refusal — none of
-those count. Neither does an operator's QA comment: the bound is on the automated loop's
-own rounds.
+those count. Neither does a refusal from any other account, once the run says who it is
+(`--reviewer`): the bound is on the automated loop's own rounds, and a QA review posted
+under the operator's account is evidence for the next review, not a round. On #193 two
+such reviews and two of the role's own made four, and the bound closed a pull request
+the loop itself had refused twice.
 
 Two things it never does. It never deletes a branch that is not the loop's (`claude/**`);
 an operator's branch stays. And it never fails the acceptor run: the outcome for the
@@ -33,6 +36,8 @@ import json
 import re
 import subprocess
 import sys
+
+from select_review_target import normalize_login
 
 LIMIT = 3
 LOOP_PREFIX = "claude/"
@@ -60,9 +65,19 @@ def is_refusal(entry) -> bool:
     return bool(REFUSAL_LINE.search(entry.get("body") or ""))
 
 
-def decide(entries, limit=LIMIT):
-    """(bound reached, the refusals). Pure."""
-    refusals = [entry for entry in entries if is_refusal(entry)]
+def decide(entries, limit=LIMIT, reviewer=None):
+    """(bound reached, the refusals). Pure.
+
+    With `reviewer` named, only that identity's refusals are rounds of the loop; without
+    it every refusal counts, which is the reading a record without identities gets.
+    """
+    wanted = normalize_login(reviewer) if reviewer else None
+    refusals = [
+        entry
+        for entry in entries
+        if is_refusal(entry)
+        and (wanted is None or normalize_login(entry.get("author")) == wanted)
+    ]
     return len(refusals) >= limit, refusals
 
 
@@ -83,6 +98,7 @@ def entries_of(pull):
             "createdAt": comment.get("createdAt") or "",
             "state": None,
             "url": comment.get("url"),
+            "author": (comment.get("author") or {}).get("login") or "",
         }
         for comment in pull.get("comments") or []
     ]
@@ -92,6 +108,7 @@ def entries_of(pull):
             "createdAt": review.get("submittedAt") or "",
             "state": review.get("state"),
             "url": None,
+            "author": (review.get("author") or {}).get("login") or "",
         }
         for review in pull.get("reviews") or []
         if review.get("submittedAt")
@@ -200,6 +217,10 @@ def main() -> int:
     parser.add_argument("--repo", required=True, help="owner/name")
     parser.add_argument("--pull", type=int, required=True, help="the pull request just reviewed")
     parser.add_argument("--limit", type=int, default=LIMIT, help="refusals that end the rework")
+    parser.add_argument(
+        "--reviewer",
+        help="login of this role's own identity; only its refusals are rounds of the loop",
+    )
     parser.add_argument("--dry-run", action="store_true", help="decide, but change nothing")
     args = parser.parse_args()
 
@@ -213,8 +234,9 @@ def main() -> int:
         print(f"rework-limit: #{args.pull} is {pull.get('state')}; nothing to bound")
         return 0
 
-    reached, refusals = decide(entries_of(pull), args.limit)
-    print(f"rework-limit: #{args.pull} has {len(refusals)} refusal(s); bound is {args.limit}")
+    reached, refusals = decide(entries_of(pull), args.limit, args.reviewer)
+    whose = f" by {normalize_login(args.reviewer)}" if args.reviewer else ""
+    print(f"rework-limit: #{args.pull} has {len(refusals)} refusal(s){whose}; bound is {args.limit}")
     if not reached:
         return 0
     if args.dry_run:

--- a/scripts/select_review_target.py
+++ b/scripts/select_review_target.py
@@ -43,6 +43,16 @@ since none of them may be red at acceptance — so that reading would withhold m
 the reviews worth having. A red test suite still selects, because the reviewer can
 judge the criteria too and return one complete list instead of two partial ones.
 
+## What is a verdict
+
+A comment in one of the shapes the runbooks prescribe — a heading or bold marker,
+optionally the role and the word "verdict", then `ACCEPT` or `REQUEST_CHANGES` — or a
+formal review whose state is `APPROVED` or `CHANGES_REQUESTED`, whatever its words. A
+review left in the `COMMENTED` state is prose. On #193 the role's own
+`## ACCEPTOR Verdict: ACCEPT` was not a verdict to an earlier reading of this, so the
+next run reviewed the same head again and refused it: two verdicts on one revision,
+which is what this exists to prevent (#152).
+
 ## How a verdict is tied to a head
 
 Two independent signals, either of which counts:
@@ -56,8 +66,11 @@ latency, while a repeated one costs a run *and* leaves contradictory comments on
 pull request — the asymmetry says which way to lean.
 
 A verdict is not final if a correction followed it. A non-verdict comment newer than
-the newest verdict is read as the AUTHOR's correction handoff, which is what section
-1's same-head exception turns on.
+the newest verdict, posted by the pull request's author, is read as the AUTHOR's
+correction handoff, which is what section 1's same-head exception turns on. A note
+from any other account after the verdict — an operator's, a QA reviewer's — is
+evidence for the next review, not a correction: on #190 such a note reopened an
+accepted head, the run that followed refused it, and the bound closed the pull request.
 
 ## What this does not do
 
@@ -89,11 +102,15 @@ import machine_pr_guard
 # exists to stop. A bare word with no marker must be the shouted form the runbook
 # specifies; anything less would swallow ordinary sentences that open with "Accept".
 MARKED_VERDICT = re.compile(
-    r"^\s*(?:#{1,4}\s*|\*\*)\s*(?:VERDICT\s*[:\-—]\s*)?"
+    r"^\s*(?:#{1,4}\s*|\*\*)\s*(?:ACCEPTOR\s+)?(?:VERDICT\s*[:\-—]\s*)?"
     r"(?:ACCEPT|REQUEST_CHANGES)\b",
     re.MULTILINE | re.IGNORECASE,
 )
 BARE_VERDICT = re.compile(r"^\s*(?:ACCEPT|REQUEST_CHANGES)\b", re.MULTILINE)
+
+# A formal review carries its verdict in its state, whatever its words. A review left in
+# the `COMMENTED` state is prose, however strongly it is worded.
+REVIEW_VERDICT_STATES = ("APPROVED", "CHANGES_REQUESTED")
 
 HUMAN_OWNED_LABEL = "status:needs-decision"
 MERGEABILITY_CHECK = "mergeability"
@@ -104,9 +121,42 @@ def is_verdict(body: str) -> bool:
     return bool(MARKED_VERDICT.search(body) or BARE_VERDICT.search(body))
 
 
+def is_verdict_entry(entry) -> bool:
+    """A comment in a verdict shape, or a formal review in a verdict state."""
+    if (entry.get("state") or "").upper() in REVIEW_VERDICT_STATES:
+        return True
+    return is_verdict(entry.get("body") or "")
+
+
+def normalize_login(login) -> str:
+    """One spelling for one identity.
+
+    `gh` prints a GitHub App as `app/name` on the pull request it authored and as `name`
+    on the comments it posted; the web shows it as `name[bot]`. Comparing any two of
+    those verbatim says "different", which is how a role fails to recognise itself.
+    """
+    login = (login or "").strip()
+    if login.startswith("app/"):
+        login = login[len("app/"):]
+    if login.endswith("[bot]"):
+        login = login[: -len("[bot]")]
+    return login.lower()
+
+
+def is_the_authors(entry, author: str) -> bool:
+    """Whether an entry was posted by the pull request's author.
+
+    Unknown on either side reads as yes: a record that carries no identities keeps the
+    older, wider reading rather than silently never reopening anything.
+    """
+    if not author or "author" not in entry:
+        return True
+    return normalize_login(entry.get("author")) == author
+
+
 def judges_head(comment, head_sha: str, head_committed_at: str) -> bool:
-    """Whether this comment is a verdict on the current head revision."""
-    if not is_verdict(comment["body"]):
+    """Whether this entry is a verdict on the current head revision."""
+    if not is_verdict_entry(comment):
         return False
     if head_sha[:7] and head_sha[:7] in (comment["body"] or ""):
         return True
@@ -173,10 +223,13 @@ def eligible(pull, head_committed_at: str, comments):
         return True, "no verdict on the current head"
 
     newest_verdict = max(c["createdAt"] for c in verdicts)
+    author = normalize_login((pull.get("author") or {}).get("login"))
     corrections = [
         c
         for c in comments
-        if not is_verdict(c["body"]) and c["createdAt"] > newest_verdict
+        if not is_verdict_entry(c)
+        and c["createdAt"] > newest_verdict
+        and is_the_authors(c, author)
     ]
     if corrections:
         return True, "a correction was posted after the last verdict on this head"
@@ -215,7 +268,7 @@ def load_pulls(repo: str):
             "--limit",
             "100",
             "--json",
-            "number,createdAt,isDraft,labels,headRefName,headRefOid,statusCheckRollup",
+            "number,createdAt,isDraft,labels,headRefName,headRefOid,statusCheckRollup,author",
         ]
     )
     return json.loads(raw)
@@ -227,13 +280,25 @@ def load_comments(repo: str, number: int):
     )
     data = json.loads(raw)
     comments = [
-        {"body": c.get("body", ""), "createdAt": c.get("createdAt", "")}
+        {
+            "body": c.get("body", ""),
+            "createdAt": c.get("createdAt", ""),
+            "state": None,
+            "author": (c.get("author") or {}).get("login", ""),
+        }
         for c in data.get("comments", [])
     ]
-    # A formal review counts equally; the role posts comments only because GitHub
-    # refuses a same-account review, which is an accident of identity, not of meaning.
+    # A formal review counts equally, and its state is read as well as its words: the
+    # role posts comments only because GitHub refuses a same-account review, which is an
+    # accident of identity, not of meaning, while another account's review carries its
+    # verdict in the state and rarely in a heading.
     comments += [
-        {"body": r.get("body", ""), "createdAt": r.get("submittedAt", "")}
+        {
+            "body": r.get("body", ""),
+            "createdAt": r.get("submittedAt", ""),
+            "state": r.get("state"),
+            "author": (r.get("author") or {}).get("login", ""),
+        }
         for r in data.get("reviews", [])
         if r.get("submittedAt")
     ]

--- a/scripts/tests/test_rework_limit.py
+++ b/scripts/tests/test_rework_limit.py
@@ -147,5 +147,55 @@ class WorkflowTests(unittest.TestCase):
         self.assertNotIn("python scripts/rework_limit.py", self.text())
 
 
+
+def by(author, entry):
+    return {**entry, "author": author}
+
+
+# #193 exactly: two refusing reviews from the QA reviewer's account, one refusal and
+# one revised refusal from the role itself, on one head, in ninety minutes.
+TIMELINE_ON_193 = [
+    by("drevendev", review("CHANGES_REQUESTED", "2026-09-06T05:57:55Z", "CODE_RUNTIME_QA_M1_18: one new blocker.")),
+    by("zendev-acceptor", review("CHANGES_REQUESTED", "2026-09-06T06:34:19Z", "## ACCEPTOR Verdict: REQUEST_CHANGES")),
+    by("drevendev", review("CHANGES_REQUESTED", "2026-09-06T06:56:33Z", "CODE_RUNTIME_QA_M1_19: one more.")),
+    by("zendev-acceptor", comment("## ACCEPTOR Verdict: REQUEST_CHANGES (Revised)", "2026-09-06T07:04:35Z")),
+]
+
+
+class WhoseRoundsTests(unittest.TestCase):
+    def test_only_the_named_reviewers_refusals_are_rounds(self):
+        reached, refusals = rl.decide(TIMELINE_ON_193, reviewer="zendev-acceptor")
+        self.assertFalse(reached)
+        self.assertEqual(len(refusals), 2)
+
+    def test_without_a_name_every_refusal_counts(self):
+        # The reading that closed #193 at four; kept for a record without identities.
+        reached, refusals = rl.decide(TIMELINE_ON_193)
+        self.assertTrue(reached)
+        self.assertEqual(len(refusals), 4)
+
+    def test_the_apps_spellings_do_not_hide_the_reviewer(self):
+        for spelling in ("app/zendev-acceptor", "zendev-acceptor[bot]", "Zendev-Acceptor"):
+            with self.subTest(spelling=spelling):
+                entries = [by(spelling, e) for e in REFUSALS_ON_130]
+                reached, refusals = rl.decide(entries, reviewer="zendev-acceptor")
+                self.assertTrue(reached)
+                self.assertEqual(len(refusals), 3)
+
+    def test_entries_carry_who_posted_them(self):
+        pull = {
+            "comments": [{"body": "## REQUEST_CHANGES", "createdAt": "2026-09-06T06:34:19Z", "author": {"login": "zendev-acceptor"}}],
+            "reviews": [{"body": "", "submittedAt": "2026-09-06T05:57:55Z", "state": "CHANGES_REQUESTED", "author": {"login": "drevendev"}}],
+        }
+        entries = rl.entries_of(pull)
+        self.assertEqual([e["author"] for e in entries], ["drevendev", "zendev-acceptor"])
+
+    def test_the_workflow_tells_the_bound_who_the_role_is(self):
+        text = WORKFLOW.read_text(encoding="utf-8")
+        bound = text.index("control-plane/rework_limit.py")
+        step = text[bound : text.find("- name:", bound)]
+        self.assertIn('--reviewer "${{ steps.identity.outputs.app-slug }}"', step)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_select_review_target.py
+++ b/scripts/tests/test_select_review_target.py
@@ -238,5 +238,116 @@ class MachineGeneratedTests(unittest.TestCase):
         self.assertEqual(select.choose(candidates), 105)
 
 
+
+def entry(body, created, state=None, author=None):
+    e = {"body": body, "createdAt": created, "state": state}
+    if author is not None:
+        e["author"] = author
+    return e
+
+
+def authored(login="app/zendev-author", **kw):
+    p = pull(**kw)
+    p["author"] = {"login": login}
+    return p
+
+
+class TwoReviewerTests(unittest.TestCase):
+    """The loop's own identity and another account both post on the same head."""
+
+    def test_the_runbooks_prescribed_heading_is_a_verdict(self):
+        # #152 exactly: the role wrote the heading the runbook prescribes, the selector
+        # did not read it as a verdict, and the next run reviewed the head again.
+        for body in (
+            "## ACCEPTOR Verdict: ACCEPT",
+            "## ACCEPTOR verdict: REQUEST_CHANGES",
+            "## ACCEPTOR VERDICT: REQUEST_CHANGES\n\n**Head revision**: 0bcc816",
+            "## ACCEPTOR Verdict: ACCEPT \u2713",
+            "**ACCEPTOR verdict: ACCEPT** at revision abc1234",
+        ):
+            with self.subTest(body=body):
+                self.assertTrue(select.is_verdict(body))
+
+    def test_a_role_heading_without_a_verdict_word_is_not_one(self):
+        for body in (
+            "## ACCEPTOR Run Assessment \u2014 BLOCKED",
+            "## Merged by ACCEPTOR",
+            "## ACCEPTOR claim\n\nreviewing #84",
+        ):
+            with self.subTest(body=body):
+                self.assertFalse(select.is_verdict(body))
+
+    def test_a_formal_review_state_is_a_verdict_whatever_its_words(self):
+        prose = "CODE_RUNTIME_QA_M1_18 \u2014 one new schema/conformance blocker."
+        self.assertTrue(select.is_verdict_entry(entry(prose, "t", state="CHANGES_REQUESTED")))
+        self.assertTrue(select.is_verdict_entry(entry(prose, "t", state="APPROVED")))
+        self.assertFalse(select.is_verdict_entry(entry(prose, "t", state="COMMENTED")))
+        self.assertFalse(select.is_verdict_entry(entry(prose, "t")))
+
+    def test_another_accounts_refusing_review_judges_the_head(self):
+        # The QA reviewer's review carried its verdict in its state and none in its
+        # words; read by words alone the head looked unjudged.
+        comments = [
+            entry("CODE_RUNTIME_QA_M1_18: one new blocker.", "2026-09-06T05:57:55Z",
+                  state="CHANGES_REQUESTED", author="drevendev"),
+        ]
+        ok, reason = select.eligible(authored(), COMMITTED, comments)
+        self.assertFalse(ok)
+        self.assertIn("no correction since", reason)
+
+    def test_a_qa_note_from_another_account_is_not_a_correction(self):
+        # #190 exactly: accepted at 04:33, a QA reviewer commented at 05:01, the 05:30
+        # run reopened the head as "corrected" and refused it: the third refusal.
+        comments = [
+            entry("## ACCEPT\n\nAll conditions hold.", "2026-09-06T04:33:23Z",
+                  author="zendev-acceptor"),
+            entry("R103 follow-up on the evidence-state repair: one contradiction remains.",
+                  "2026-09-06T05:01:48Z", state="COMMENTED", author="drevendev"),
+        ]
+        ok, reason = select.eligible(authored(), COMMITTED, comments)
+        self.assertFalse(ok)
+        self.assertIn("no correction since", reason)
+
+    def test_the_authors_own_handoff_is_still_a_correction(self):
+        comments = [
+            entry("## REQUEST_CHANGES\n\nmetadata", "2026-09-06T04:33:23Z",
+                  author="zendev-acceptor"),
+            entry("## AUTHOR handoff\n\nCorrected the body.", "2026-09-06T05:01:48Z",
+                  author="zendev-author"),
+        ]
+        ok, reason = select.eligible(authored(), COMMITTED, comments)
+        self.assertTrue(ok)
+        self.assertIn("correction", reason)
+
+    def test_the_apps_two_spellings_are_one_identity(self):
+        # `gh` prints the author as `app/zendev-author` on the pull request and as
+        # `zendev-author` on its comments; the web shows `zendev-author[bot]`.
+        for spelling in ("zendev-author", "app/zendev-author", "zendev-author[bot]"):
+            self.assertEqual(select.normalize_login(spelling), "zendev-author")
+
+    def test_a_record_without_identities_keeps_the_wider_reading(self):
+        # No author on the pull request, none on the comments: the older behaviour.
+        comments = [
+            comment("## REQUEST_CHANGES\n\nmetadata", "2026-09-05T06:13:23Z"),
+            comment("## AUTHOR handoff\n\nCorrected.", "2026-09-05T06:20:00Z"),
+        ]
+        ok, _ = select.eligible(pull(), COMMITTED, comments)
+        self.assertTrue(ok)
+
+    def test_the_selector_and_the_bound_read_one_refusal_shape(self):
+        # Two regular expressions, one meaning: a refusal the bound counts must be a
+        # verdict the selector sees, or the same head is reviewed again after it.
+        import rework_limit as rl
+        for body in (
+            "## ACCEPTOR Verdict: REQUEST_CHANGES",
+            "## VERDICT: REQUEST_CHANGES",
+            "**REQUEST_CHANGES**\n\nfix it",
+            "REQUEST_CHANGES at revision 9e14cdb",
+        ):
+            with self.subTest(body=body):
+                self.assertTrue(select.is_verdict(body))
+                self.assertTrue(rl.is_refusal({"body": body, "state": None}))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #152. Refs #122.

## Summary

Two reviewers now post on the loop's pull requests: the ACCEPTOR role, and a QA reviewer writing formal reviews under the operator's account. The control plane read them inconsistently, and that cost two pull requests today.

- `select_review_target.py` read verdicts by their words only. The role's own `## ACCEPTOR Verdict: ACCEPT` heading was not a verdict to it (#152), and a QA review in the `CHANGES_REQUESTED` state with no verdict word was not one either, while a QA `COMMENTED` review posted after a verdict was read as the AUTHOR's correction handoff. So the same head was handed to the reviewer again: #190 (accepted 04:33Z, "corrected" by a QA note 05:01Z, refused 05:32Z, the third refusal), #193 (accepted 06:03Z, refused 06:34Z, refused again 07:04Z).
- `rework_limit.py` counted every `CHANGES_REQUESTED` review as a round of the loop. #193 closed at four refusals, two of them the QA reviewer's.

## What changes

- A verdict is a comment in a runbook shape **or** a formal review whose state is `APPROVED` / `CHANGES_REQUESTED`, whatever its words. A `COMMENTED` review is prose. The marked shape now accepts the runbook's `ACCEPTOR verdict:` heading.
- Only a comment by the pull request's author posted after the newest verdict is a correction. A record without identities keeps the previous, wider reading.
- The rework bound counts the refusals posted by the role's own identity when the workflow names it (`--reviewer`, from the App token's `app-slug`); without a name it counts every refusal, as before.
- Both runbooks say so.

## Changed artifacts

- .github/workflows/zendev-acceptor.yml
- docs/zendev/ACCEPTOR_RUNBOOK.md
- docs/zendev/AUTHOR_RUNBOOK.md
- scripts/rework_limit.py
- scripts/select_review_target.py
- scripts/tests/test_rework_limit.py
- scripts/tests/test_select_review_target.py

## Verification

- `python -m unittest discover -s scripts/tests`: 313 tests passed, 14 of them new (the #152 heading, review states, the #190 and #193 timelines replayed, identity spellings, the workflow argument, and a shape-parity control between selector and bound).
- The patched selector against the live repository at 07:25Z: `#196 eligible: no verdict on the current head`, `#198 eligible`, `target=196`. Nothing changes where nothing was misread.
- `rework_limit.py --pull 196 --reviewer zendev-acceptor --dry-run`: 0 refusals by zendev-acceptor, bound 3.
- Product suites not run: no product code changed.

## Not done here

- #122's single-run double verdict (ACCEPT then REQUEST_CHANGES inside one run, as on #193 at 07:03Z/07:04Z) is model behaviour and stays open.
- No QA finding is turned into an Issue by this change; the M1 repair Issues are filed separately.

Policy change: accepted by the operator session, not by the ACCEPTOR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
