### PR TITLE
Resolve the ledger conflict the forge created, and stop calling a silent run completed

### DIFF
--- a/.github/workflows/mergeability.yml
+++ b/.github/workflows/mergeability.yml
@@ -22,8 +22,11 @@ on:
   push:
   workflow_dispatch:
 
-# `statuses: write` is the whole grant. This workflow writes one commit status and
-# reads pull request metadata; it never checks out a branch's code and never merges.
+# `statuses: write` is the whole grant `github.token` needs: this workflow writes one
+# commit status and reads pull request metadata. The two repair steps at the end act as
+# the MACHINE app instead, whose own installation permits the push — a workflow token
+# with `contents: write` would push without starting any workflow, which is the one
+# thing a repaired branch must do.
 permissions:
   contents: read
   pull-requests: read
@@ -49,7 +52,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      # Full history: the ledger resolver below merges `master` into a branch, and a
+      # shallow clone has no merge base to do it from.
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
@@ -108,3 +115,21 @@ jobs:
             exit 0
           fi
           python scripts/update_branches.py --repo "${{ github.repository }}" --all-open
+
+      # `dirty` is a conflict, and a conflict is the author's — except in the two files
+      # the forge generates for every pull request, where it is the forge's own doing.
+      # See scripts/resolve_ledger_conflicts.py; it refuses everything else, and every
+      # refusal aborts its merge. Same guards as the sweep above: `master` only, the
+      # reviewed definition, the MACHINE identity's token so the push is measured.
+      - name: Resolve conflicts the forge itself created in the ledger
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+        env:
+          GH_TOKEN: ${{ steps.identity.outputs.token }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::warning::no MACHINE identity token; ledger conflicts stay with the author"
+            exit 0
+          fi
+          git config user.name "zendev-machine[bot]"
+          git config user.email "zendev-machine[bot]@users.noreply.github.com"
+          python scripts/resolve_ledger_conflicts.py --repo "${{ github.repository }}" --all-open

--- a/docs/zendev/AUTHOR_RUNBOOK.md
+++ b/docs/zendev/AUTHOR_RUNBOOK.md
@@ -34,11 +34,17 @@ Section 7 says how to write your row.
 Take the first applicable item and stop searching:
 
 1. an open pull request of yours with **changes requested** — address the feedback;
-2. an open pull request of yours with a **failing required check** — fix it. One
-   exception: a `mergeability` failure that reads *the base has moved* is not yours.
-   The forge merges `master` into loop branches itself on the next push to `master`
-   and the branch is re-measured; a genuine conflict (*conflicts with the base branch*)
-   still is yours;
+2. an open pull request of yours with a **failing required check** — fix it. Two
+   exceptions, both the forge's own work on the next push to `master`, after which the
+   branch is re-measured: a `mergeability` failure that reads *the base has moved*, and
+   a conflict confined to `docs/spec/implementation_status.csv` and the document
+   generated from it, which every pull request rewrites and which
+   `scripts/resolve_ledger_conflicts.py` merges by requirement identifier. A conflict
+   touching any other file is yours. If you cannot resolve one — the two sides record
+   different evidence for the same requirement, or the conflict is in code whose correct
+   resolution you cannot establish — say so on the pull request, naming the conflicting
+   paths and what you could not decide, and stop. A run that ends without saying that is
+   recorded as `unknown`, and the next run repeats it;
 3. an Issue labelled `status:blocked` whose blocking condition is now demonstrably
    resolved — unblock it;
 4. an Issue labelled `status:ready`, highest `priority:*` first, respecting

--- a/scripts/implementation_status.py
+++ b/scripts/implementation_status.py
@@ -42,9 +42,23 @@ import pathlib
 import sys
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
-REGISTRY = REPO_ROOT / "docs" / "spec" / "mirror" / "REQUIREMENTS_REGISTRY.csv"
-LEDGER = REPO_ROOT / "docs" / "spec" / "implementation_status.csv"
-RENDERED = REPO_ROOT / "docs" / "spec" / "IMPLEMENTATION_STATUS.md"
+
+# Relative to a checkout, so the generator can run over a tree other than its own. It
+# has to: `resolve_ledger_conflicts.py` regenerates the document inside a merge, and a
+# generator that could only ever write beside itself would have to be copied to do it.
+REGISTRY_PATH = pathlib.PurePosixPath("docs/spec/mirror/REQUIREMENTS_REGISTRY.csv")
+LEDGER_PATH = pathlib.PurePosixPath("docs/spec/implementation_status.csv")
+RENDERED_PATH = pathlib.PurePosixPath("docs/spec/IMPLEMENTATION_STATUS.md")
+
+REGISTRY = REPO_ROOT / REGISTRY_PATH
+LEDGER = REPO_ROOT / LEDGER_PATH
+RENDERED = REPO_ROOT / RENDERED_PATH
+
+
+def paths_for(root=None):
+    """(registry, ledger, rendered) under `root`, or under this repository. Pure."""
+    base = REPO_ROOT if root is None else pathlib.Path(root)
+    return base / REGISTRY_PATH, base / LEDGER_PATH, base / RENDERED_PATH
 
 BEGIN = "<!-- coverage:generated:begin -->"
 END = "<!-- coverage:generated:end -->"
@@ -185,17 +199,22 @@ def splice(document: str, block: str) -> str:
     return document[:start] + block + document[end:]
 
 
-def main() -> int:
+def main(argv=None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--check",
         action="store_true",
         help="fail if the rendered file does not match the sources; write nothing",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--root",
+        help="the checkout to read and write in; defaults to this repository",
+    )
+    args = parser.parse_args(argv)
 
-    registry = read_registry()
-    ledger = read_ledger()
+    registry_path, ledger_path, rendered = paths_for(args.root)
+    registry = read_registry(registry_path)
+    ledger = read_ledger(ledger_path)
 
     problems = validate(registry, ledger)
     if problems:
@@ -203,11 +222,11 @@ def main() -> int:
             print("::error::implementation-status: %s" % problem)
         return 1
 
-    document = RENDERED.read_text(encoding="utf-8")
+    document = rendered.read_text(encoding="utf-8")
     if BEGIN not in document or END not in document:
         print(
             "::error::implementation-status: %s has no generated block; expected the "
-            "markers %s and %s" % (RENDERED.name, BEGIN, END)
+            "markers %s and %s" % (rendered.name, BEGIN, END)
         )
         return 1
 
@@ -218,16 +237,16 @@ def main() -> int:
             print(
                 "::error::implementation-status: %s is stale. Regenerate it with "
                 "`python scripts/implementation_status.py` and commit the result."
-                % RENDERED.name
+                % rendered.name
             )
             return 1
         print(
             "implementation-status: %s matches %d ledger row(s) over %d registry row(s)"
-            % (RENDERED.name, len(ledger), len(registry))
+            % (rendered.name, len(ledger), len(registry))
         )
         return 0
 
-    RENDERED.write_text(updated, encoding="utf-8")
+    rendered.write_text(updated, encoding="utf-8")
     print(
         "implementation-status: rendered %d ledger row(s) over %d registry row(s)"
         % (len(ledger), len(registry))

--- a/scripts/record_usage.py
+++ b/scripts/record_usage.py
@@ -23,7 +23,9 @@ could not answer the questions that matter for the budget:
 - **What kind of run it was.** ``completed``, ``no_work``, ``blocked``, ``failed`` or
   ``unknown``. The workflow decides ``no_work`` and ``failed``; the rest is read from
   what the model wrote and is marked as a heuristic, because a transcript that discusses
-  a blocker it does not have looks blocked to a string search.
+  a blocker it does not have looks blocked to a string search. A run that ends claiming
+  nothing is ``unknown``, never ``completed``: a green action says the process exited,
+  not that a unit of work exists.
 - **Which work it touched.** Issue and pull request numbers and requirement identifiers
   mentioned in the transcript, and whether an author run was reworking a refusal. These
   are what let cost be read per merged requirement instead of per run.
@@ -231,8 +233,12 @@ def classify_outcome(conclusion, text):
         return "blocked", "heuristic"
     if NO_WORK.search(text or ""):
         return "no_work", "heuristic"
-    if conclusion == "success":
-        return "completed", "heuristic"
+    # A green action and a final message that claims nothing is not a completed run.
+    # It used to be recorded as one: on 2026-09-06 an author run met two pull requests
+    # it could not merge, spent thirteen turns, said nothing, and was filed as
+    # `completed` beside the runs that had merged requirements. The ledger's own
+    # question — what did this cost per unit of work — cannot survive that. `unknown`
+    # is what is actually known here; the run left no evidence either way.
     return "unknown", "heuristic"
 
 

--- a/scripts/resolve_ledger_conflicts.py
+++ b/scripts/resolve_ledger_conflicts.py
@@ -1,0 +1,370 @@
+"""Resolve the one conflict the forge itself created: the implementation ledger.
+
+Every pull request that implements a requirement appends a row to
+``docs/spec/implementation_status.csv`` and regenerates
+``docs/spec/IMPLEMENTATION_STATUS.md`` from it. Two files, written by every branch. So
+any two pull requests in flight conflict with each other, and any correction an
+operator makes to the ledger conflicts with every branch that is open at the time.
+
+That is not a hypothetical. On 2026-09-06 a correction returning two rows to
+``PARTIAL`` made both open pull requests ``dirty`` in the same minute. Neither was
+about those rows; both had merely appended a row of their own next to them. The AUTHOR
+run that met them spent thirteen turns, said nothing, and ended — and would have done
+so again every cycle, because its own ladder puts a failing check on its pull request
+above every Issue in the queue. Two pull requests were closed by hand.
+
+A conflict in product code is a judgement and stays the author's. A conflict in a file
+the forge generates is not: the generated document is a pure function of the ledger, and
+the ledger is a table keyed by requirement identifier, not prose. This resolves that
+case and only that case.
+
+## What it does
+
+For an open loop pull request (``claude/**``) that GitHub reports as ``dirty``:
+
+1. merge ``master`` into the branch and list the unmerged paths;
+2. **refuse unless every one of them is a ledger file.** One product file among them and
+   the whole merge is abandoned: the author's judgement is needed for that file, and a
+   half-resolved merge is worse than none;
+3. merge the ledger rows three ways, by requirement identifier — the same rule git
+   applies to lines, applied to rows. A row only one side touched takes that side. A row
+   both sides changed differently is a real disagreement about evidence, and the whole
+   merge is abandoned for the author to settle;
+4. regenerate the document from the merged ledger rather than merging its text, because
+   it is generated and its text is not a source;
+5. commit the merge and push it with the loop's own credential, so the branch is
+   measured again.
+
+## What it never does
+
+It never resolves a conflict outside those two files, never picks a winner between two
+rows that disagree, never touches a branch that is not the loop's, and never leaves a
+partially resolved merge behind: every refusal aborts the merge first. It exits 0
+whatever happened, like the sweep it runs beside — the outcome for a pull request is the
+state the forge left it in, printed per branch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import pathlib
+import subprocess
+import sys
+
+import implementation_status
+import machine_pr_guard
+from update_branches import failure_detail
+
+LOOP_PREFIX = "claude/"
+DIRTY = "dirty"
+
+LEDGER_CSV = "docs/spec/implementation_status.csv"
+LEDGER_DOCUMENT = "docs/spec/IMPLEMENTATION_STATUS.md"
+# The generated document is not merged, it is rewritten from the merged rows. The CSV is
+# the only file here whose content is a source.
+RESOLVABLE = frozenset({LEDGER_CSV, LEDGER_DOCUMENT})
+
+# Stage numbers `git show :N:path` reads out of a conflicted index.
+BASE, OURS, THEIRS = 1, 2, 3
+
+# A credential helper that answers from the environment, so the token is never an
+# argument: a command line is visible to every other process on the machine, and this
+# one runs beside a model.
+CREDENTIAL_HELPER = (
+    '!f() { echo "username=x-access-token"; echo "password=${GH_TOKEN}"; }; f'
+)
+
+
+# --------------------------------------------------------------------- pure
+
+
+def should_resolve(pull):
+    """(bool, reason). Pure: decides from one pull request object as the API returns it.
+
+    Deliberately the same shape and the same refusals as `update_branches.should_update`,
+    one state apart: that one repairs `behind`, this one attempts `dirty`.
+    """
+    head = pull.get("head") or {}
+    base = pull.get("base") or {}
+    ref = head.get("ref") or ""
+    head_repo = (head.get("repo") or {}).get("full_name")
+    base_repo = (base.get("repo") or {}).get("full_name")
+
+    if pull.get("state", "open") != "open":
+        return False, "not open"
+    if pull.get("draft"):
+        return False, "draft"
+    if not head_repo or head_repo != base_repo:
+        return False, "head is not in this repository"
+    if machine_pr_guard.classify(ref) is not None:
+        return False, "machine class: a merge commit from anyone else fails its committer gate"
+    if not ref.startswith(LOOP_PREFIX):
+        return False, f"not a loop branch ({LOOP_PREFIX}**)"
+    if pull.get("mergeable") is None:
+        return False, "mergeability not yet computed"
+    state = pull.get("mergeable_state")
+    if state != DIRTY:
+        return False, f"mergeable_state is {state!r}, not {DIRTY!r}"
+    return True, DIRTY
+
+
+def only_the_ledger(paths):
+    """Whether every unmerged path is one this may rewrite. Pure.
+
+    An empty set is not resolvable: nothing conflicted, so there is nothing here to do
+    and a caller that pushed anyway would be pushing an unexplained merge.
+    """
+    paths = list(paths)
+    return bool(paths) and all(path in RESOLVABLE for path in paths)
+
+
+def parse_ledger(text):
+    """(header, rows) from a ledger CSV, or (None, []) for a side that has no file."""
+    if text is None:
+        return None, []
+    rows = list(csv.reader(io.StringIO(text)))
+    if not rows:
+        return None, []
+    return rows[0], [row for row in rows[1:] if row]
+
+
+def merge_ledger_rows(base, ours, theirs):
+    """Three-way merge of ledger rows by requirement identifier. Pure.
+
+    Returns (rows, disagreements). The rule is git's own, one level up from lines: a row
+    only one side changed takes that side; a row both sides changed differently is a
+    disagreement this must not settle. A row absent from a side is a deletion by that
+    side, and reads the same way.
+
+    Order follows `theirs` — the base branch, the accepted history — with rows that exist
+    only on the branch appended after it, which is the shape an append-only ledger has
+    anyway.
+    """
+    def by_id(rows):
+        return {row[0]: row for row in rows if row}
+
+    base_rows, our_rows, their_rows = by_id(base), by_id(ours), by_id(theirs)
+
+    merged, disagreements, seen = [], [], set()
+    for identifier in [row[0] for row in theirs if row] + [row[0] for row in ours if row]:
+        if identifier in seen:
+            continue
+        seen.add(identifier)
+
+        mine = our_rows.get(identifier)
+        yours = their_rows.get(identifier)
+        original = base_rows.get(identifier)
+
+        if mine == yours:
+            row = mine
+        elif mine == original:
+            row = yours  # only the base branch touched it
+        elif yours == original:
+            row = mine  # only this branch touched it
+        else:
+            disagreements.append(identifier)
+            continue
+        if row is not None:
+            merged.append(row)
+    return merged, disagreements
+
+
+def render_ledger(header, rows, newline="\r\n"):
+    """The merged rows as a CSV document, in the ledger's own line ending. Pure."""
+    out = io.StringIO()
+    writer = csv.writer(out, lineterminator=newline)
+    if header:
+        writer.writerow(header)
+    writer.writerows(rows)
+    return out.getvalue()
+
+
+# ---------------------------------------------------------------------- git
+
+
+def git(args, root, token=None, check=False):
+    command = ["git", "-C", str(root)]
+    if token is not None:
+        command += ["-c", f"credential.helper={CREDENTIAL_HELPER}"]
+    command += list(args)
+    # UTF-8 explicitly, not by locale: see the note in machine_pr_guard.py.
+    result = subprocess.run(
+        command, capture_output=True, text=True, encoding="utf-8", errors="replace"
+    )
+    if check and result.returncode:
+        # Never the raw stderr: this runs with a credential in the environment and a
+        # failed transport can echo a URL back.
+        raise RuntimeError(f"git {args[0]} failed ({failure_detail(result.stderr, result.returncode)})")
+    return result
+
+
+def unmerged_paths(root):
+    result = git(["diff", "--name-only", "--diff-filter=U"], root, check=True)
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def stage(root, number, path):
+    """One side of a conflicted file, or None when that side does not have it."""
+    result = git(["show", f":{number}:{path}"], root)
+    return result.stdout if result.returncode == 0 else None
+
+
+def abandon(root):
+    git(["merge", "--abort"], root)
+
+
+# ------------------------------------------------------------------ per pull
+
+
+def resolve(root, pull, dry_run=False, push=True):
+    """Attempt one pull request. Returns a sentence saying what happened."""
+    number = pull["number"]
+    branch = pull["head"]["ref"]
+
+    ok, reason = should_resolve(pull)
+    if not ok:
+        return f"left alone: {reason}"
+
+    try:
+        git(["fetch", "origin", "master", branch], root, check=True)
+        git(["checkout", "-B", f"zendev/resolve-{number}", f"origin/{branch}"], root, check=True)
+    except RuntimeError as error:
+        return f"not attempted: {error}"
+
+    merge = git(["merge", "--no-commit", "--no-ff", "origin/master"], root)
+    if merge.returncode == 0:
+        # It merges after all: `dirty` was stale, and a merge nobody asked for is not
+        # this script's to push. `update_branches.py` owns the clean case.
+        abandon(root)
+        return "left alone: it merges cleanly now; the sweep owns that case"
+
+    conflicted = unmerged_paths(root)
+    if not only_the_ledger(conflicted):
+        abandon(root)
+        outside = sorted(set(conflicted) - RESOLVABLE)
+        return f"left to the author: conflicts outside the ledger ({', '.join(outside) or 'none listed'})"
+
+    header, rows = None, []
+    if LEDGER_CSV in conflicted:
+        base_header, base_rows = parse_ledger(stage(root, BASE, LEDGER_CSV))
+        our_header, our_rows = parse_ledger(stage(root, OURS, LEDGER_CSV))
+        their_header, their_rows = parse_ledger(stage(root, THEIRS, LEDGER_CSV))
+        header = their_header or our_header or base_header
+        if our_header and their_header and our_header != their_header:
+            abandon(root)
+            return "left to the author: the ledger's columns differ between the two sides"
+        rows, disagreements = merge_ledger_rows(base_rows, our_rows, their_rows)
+        if disagreements:
+            abandon(root)
+            return (
+                "left to the author: both sides changed "
+                + ", ".join(disagreements)
+                + " differently, and which evidence stands is a judgement"
+            )
+    else:
+        # Only the generated document conflicted. The ledger merged cleanly, so the
+        # document follows from the merged file already in the tree.
+        header, rows = parse_ledger((root / LEDGER_CSV).read_text(encoding="utf-8"))
+
+    if dry_run:
+        abandon(root)
+        return f"would resolve {len(conflicted)} ledger path(s) into {len(rows)} row(s)"
+
+    (root / LEDGER_CSV).write_text(render_ledger(header, rows), encoding="utf-8", newline="")
+    if implementation_status.main(["--root", str(root)]) != 0:
+        abandon(root)
+        return "left to the author: the merged ledger does not validate"
+
+    git(["add", LEDGER_CSV, LEDGER_DOCUMENT], root, check=True)
+    still = unmerged_paths(root)
+    if still:
+        abandon(root)
+        return f"left to the author: {len(still)} path(s) still unmerged after the rewrite"
+
+    message = (
+        "Merge master into this branch, resolving the generated ledger\n\n"
+        "The conflict was confined to docs/spec/implementation_status.csv and the\n"
+        "document generated from it. Rows were merged by requirement identifier, each\n"
+        "taken from the side that changed it, and the document was regenerated rather\n"
+        "than merged. No product file was touched. See scripts/resolve_ledger_conflicts.py."
+    )
+    try:
+        git(["commit", "--no-verify", "-m", message], root, check=True)
+    except RuntimeError as error:
+        abandon(root)
+        return f"not resolved: {error}"
+
+    if not push:
+        return f"resolved locally, not pushed ({len(rows)} row(s))"
+    result = git(["push", "origin", f"HEAD:{branch}"], root, token=True)
+    if result.returncode:
+        return f"resolved but not pushed: {failure_detail(result.stderr, result.returncode)}"
+    return f"resolved and pushed: {len(rows)} ledger row(s), {len(conflicted)} path(s) merged"
+
+
+# --------------------------------------------------------------------- main
+
+
+def _gh(args):
+    return subprocess.run(
+        ["gh", *args], capture_output=True, text=True, encoding="utf-8"
+    )
+
+
+def read_pull(repo, number):
+    result = _gh(["api", f"repos/{repo}/pulls/{number}"])
+    if result.returncode:
+        raise RuntimeError(f"could not read #{number}: {failure_detail(result.stderr, result.returncode)}")
+    return json.loads(result.stdout)
+
+
+def open_pull_numbers(repo):
+    result = _gh(["api", f"repos/{repo}/pulls?state=open&per_page=100"])
+    if result.returncode:
+        raise RuntimeError(f"could not list pull requests: {failure_detail(result.stderr, result.returncode)}")
+    return [int(pull["number"]) for pull in json.loads(result.stdout)]
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="owner/name")
+    parser.add_argument("--root", default=".", help="the checkout to merge in")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--pull", type=int, help="one pull request number")
+    group.add_argument("--all-open", action="store_true", help="every open pull request")
+    parser.add_argument("--dry-run", action="store_true", help="decide and merge, but push nothing")
+    args = parser.parse_args(argv)
+
+    root = pathlib.Path(args.root).resolve()
+    started_on = git(["rev-parse", "--abbrev-ref", "HEAD"], root).stdout.strip()
+
+    try:
+        numbers = [args.pull] if args.pull else open_pull_numbers(args.repo)
+    except (RuntimeError, ValueError, KeyError, json.JSONDecodeError) as error:
+        print(f"::warning::resolve-ledger: {error}")
+        return 0
+
+    for number in numbers:
+        try:
+            pull = read_pull(args.repo, number)
+        except (RuntimeError, ValueError, KeyError, json.JSONDecodeError) as error:
+            print(f"::warning::resolve-ledger: {error}")
+            continue
+        ref = (pull.get("head") or {}).get("ref") or "?"
+        try:
+            outcome = resolve(root, pull, dry_run=args.dry_run)
+        except (RuntimeError, OSError, ValueError, KeyError) as error:
+            abandon(root)
+            outcome = f"not resolved: {type(error).__name__}"
+        print(f"resolve-ledger: #{number} {ref} {outcome}")
+
+    if started_on and started_on != "HEAD":
+        git(["checkout", "--force", started_on], root)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_record_usage.py
+++ b/scripts/tests/test_record_usage.py
@@ -145,10 +145,29 @@ class OutcomeTests(unittest.TestCase):
             with self.subTest(text=text):
                 self.assertEqual(rec.classify_outcome("success", text), ("blocked", "heuristic"))
 
-    def test_prose_mentioning_blockers_is_not_a_blocked_run(self):
-        # The claim comment every run posts says "Known blockers: none".
+    def test_prose_mentioning_blockers_is_neither_blocked_nor_completed(self):
+        # The claim comment every run posts says "Known blockers: none". It is not a
+        # blocked run — and a run whose last word is a claim delivered nothing either.
         text = "**AUTHOR claim**\n\nKnown blockers: none. Proceeding."
-        self.assertEqual(rec.classify_outcome("success", text), ("completed", "heuristic"))
+        self.assertEqual(rec.classify_outcome("success", text), ("unknown", "heuristic"))
+
+    def test_a_run_that_claims_nothing_is_unknown_not_completed(self):
+        # 2026-09-06 08:10Z: an author run met two pull requests it could not merge,
+        # spent thirteen turns and ended saying nothing. The action was green, so the
+        # ledger filed it beside the runs that had merged requirements.
+        for text in (
+            "",
+            "I reviewed the open pull requests and the queue.",
+            "Both pull requests conflict with master.",
+        ):
+            with self.subTest(text=text):
+                self.assertEqual(rec.classify_outcome("success", text), ("unknown", "heuristic"))
+
+    def test_a_green_action_alone_never_makes_a_run_completed(self):
+        # The removed fallback: `success` used to mean completed once every shape had
+        # been tried. A process that exited is not a unit of work.
+        self.assertEqual(rec.classify_outcome("success", "nothing to report"), ("unknown", "heuristic"))
+        self.assertEqual(rec.classify_outcome(None, "nothing to report"), ("unknown", "heuristic"))
 
     def test_a_handoff_is_completed_whatever_else_it_mentions(self):
         # Run 33986212612 opened #163 and was recorded as blocked, because its text

--- a/scripts/tests/test_resolve_ledger_conflicts.py
+++ b/scripts/tests/test_resolve_ledger_conflicts.py
@@ -1,0 +1,310 @@
+"""The forge resolves what the forge generated, and refuses everything else.
+
+The last test is the one that matters: it builds the conflict of 2026-09-06 out of real
+commits in a real repository and proves the merge comes out with both sides' evidence.
+"""
+
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import implementation_status  # noqa: E402
+import resolve_ledger_conflicts as resolver  # noqa: E402
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "mergeability.yml"
+
+HEADER = ["REQ_ID", "STATUS", "ISSUE", "PR", "MERGE_COMMIT", "EVIDENCE"]
+
+
+def row(identifier, status="IMPLEMENTED", evidence="a named test"):
+    return [identifier, status, "1", "2", "", evidence]
+
+
+def pull(ref="claude/issue-1-example", state="dirty", mergeable=False, draft=False,
+         head_repo="drevendev/trade_simulation", base_repo="drevendev/trade_simulation"):
+    return {
+        "number": 1,
+        "state": "open",
+        "draft": draft,
+        "mergeable": mergeable,
+        "mergeable_state": state,
+        "head": {"ref": ref, "sha": "a" * 40, "repo": {"full_name": head_repo}},
+        "base": {"ref": "master", "repo": {"full_name": base_repo}},
+    }
+
+
+class ShouldResolveTests(unittest.TestCase):
+    def test_a_conflicting_loop_branch_is_attempted(self):
+        ok, reason = resolver.should_resolve(pull())
+        self.assertTrue(ok)
+        self.assertEqual(reason, "dirty")
+
+    def test_a_branch_that_is_merely_behind_belongs_to_the_sweep(self):
+        # `update_branches.py` owns that state; two scripts pushing to one branch would
+        # race, and the forge's own endpoint does it without a checkout.
+        ok, reason = resolver.should_resolve(pull(state="behind"))
+        self.assertFalse(ok)
+        self.assertIn("behind", reason)
+
+    def test_a_clean_branch_is_not_touched(self):
+        for state in ("clean", "blocked", "unstable"):
+            with self.subTest(state=state):
+                ok, _ = resolver.should_resolve(pull(state=state))
+                self.assertFalse(ok)
+
+    def test_an_uncomputed_answer_is_not_a_reason_to_act(self):
+        ok, reason = resolver.should_resolve(pull(mergeable=None))
+        self.assertFalse(ok)
+        self.assertIn("not yet computed", reason)
+
+    def test_a_machine_branch_is_never_resolved(self):
+        ok, reason = resolver.should_resolve(pull(ref="spec-mirror"))
+        self.assertFalse(ok)
+        self.assertIn("machine class", reason)
+
+    def test_an_operator_branch_is_left_alone(self):
+        for ref in ("policy/204-something", "docs/a-note", "fix/a-bug"):
+            with self.subTest(ref=ref):
+                ok, reason = resolver.should_resolve(pull(ref=ref))
+                self.assertFalse(ok)
+                self.assertIn("not a loop branch", reason)
+
+    def test_a_fork_head_is_not_ours_to_move(self):
+        ok, reason = resolver.should_resolve(pull(head_repo="someone/trade_simulation"))
+        self.assertFalse(ok)
+        self.assertIn("not in this repository", reason)
+
+    def test_drafts_and_closed_pull_requests_are_skipped(self):
+        self.assertFalse(resolver.should_resolve(pull(draft=True))[0])
+        closed = pull()
+        closed["state"] = "closed"
+        self.assertFalse(resolver.should_resolve(closed)[0])
+
+
+class ResolvablePathsTests(unittest.TestCase):
+    def test_the_two_generated_ledger_files_are_resolvable(self):
+        self.assertTrue(resolver.only_the_ledger(
+            ["docs/spec/implementation_status.csv", "docs/spec/IMPLEMENTATION_STATUS.md"]
+        ))
+
+    def test_one_product_file_among_them_refuses_the_whole_merge(self):
+        # Half a resolution is worse than none: the author must see the conflict whole.
+        self.assertFalse(resolver.only_the_ledger(
+            ["docs/spec/implementation_status.csv", "src/simulation/worldState.ts"]
+        ))
+
+    def test_a_neighbouring_specification_file_is_not_the_ledger(self):
+        for path in (
+            "docs/spec/FEEDBACK_TO_RESEARCHER.md",
+            "docs/spec/mirror/REQUIREMENTS_REGISTRY.csv",
+            "scripts/implementation_status.py",
+        ):
+            with self.subTest(path=path):
+                self.assertFalse(resolver.only_the_ledger([path]))
+
+    def test_nothing_conflicting_is_not_something_to_resolve(self):
+        self.assertFalse(resolver.only_the_ledger([]))
+
+
+class MergeRowsTests(unittest.TestCase):
+    def test_each_side_keeps_the_row_only_it_touched(self):
+        # #196 and #198, exactly: each branch appended a row of its own while master
+        # changed a different one. Nothing here is a disagreement.
+        base = [row("REQ-A"), row("REQ-B")]
+        ours = [row("REQ-A"), row("REQ-B"), row("REQ-NEW")]
+        theirs = [row("REQ-A", "PARTIAL", "the row master demoted"), row("REQ-B")]
+
+        merged, disagreements = resolver.merge_ledger_rows(base, ours, theirs)
+
+        self.assertEqual(disagreements, [])
+        self.assertEqual([r[0] for r in merged], ["REQ-A", "REQ-B", "REQ-NEW"])
+        self.assertEqual(merged[0][1], "PARTIAL")
+
+    def test_both_sides_changing_one_row_is_a_disagreement_this_refuses(self):
+        # Master demoted the row; the branch promoted it with new evidence. Which
+        # evidence stands is exactly the judgement this must not make.
+        base = [row("REQ-A")]
+        ours = [row("REQ-A", "IMPLEMENTED", "the repair's new test")]
+        theirs = [row("REQ-A", "PARTIAL", "returned by QA")]
+
+        merged, disagreements = resolver.merge_ledger_rows(base, ours, theirs)
+
+        self.assertEqual(disagreements, ["REQ-A"])
+        self.assertEqual(merged, [])
+
+    def test_the_same_change_on_both_sides_is_not_a_disagreement(self):
+        base = [row("REQ-A")]
+        same = [row("REQ-A", "PARTIAL")]
+        merged, disagreements = resolver.merge_ledger_rows(base, same, list(same))
+        self.assertEqual(disagreements, [])
+        self.assertEqual(merged, same)
+
+    def test_a_row_deleted_on_one_side_stays_deleted(self):
+        base = [row("REQ-A"), row("REQ-B")]
+        ours = [row("REQ-A"), row("REQ-B")]
+        theirs = [row("REQ-A")]
+        merged, disagreements = resolver.merge_ledger_rows(base, ours, theirs)
+        self.assertEqual(disagreements, [])
+        self.assertEqual([r[0] for r in merged], ["REQ-A"])
+
+    def test_a_row_deleted_by_one_side_and_changed_by_the_other_is_a_disagreement(self):
+        base = [row("REQ-A")]
+        ours = [row("REQ-A", "PARTIAL")]
+        theirs = []
+        _, disagreements = resolver.merge_ledger_rows(base, ours, theirs)
+        self.assertEqual(disagreements, ["REQ-A"])
+
+    def test_the_base_branchs_order_is_kept_and_new_rows_follow_it(self):
+        base = []
+        ours = [row("REQ-MINE")]
+        theirs = [row("REQ-ONE"), row("REQ-TWO")]
+        merged, _ = resolver.merge_ledger_rows(base, ours, theirs)
+        self.assertEqual([r[0] for r in merged], ["REQ-ONE", "REQ-TWO", "REQ-MINE"])
+
+    def test_rendering_round_trips_through_the_parser(self):
+        rows = [row("REQ-A", evidence='evidence with a comma, a "quote" and a\nnewline')]
+        text = resolver.render_ledger(HEADER, rows)
+        self.assertIn("\r\n", text)
+        header, parsed = resolver.parse_ledger(text)
+        self.assertEqual(header, HEADER)
+        self.assertEqual(parsed, rows)
+
+
+class WorkflowTests(unittest.TestCase):
+    def text(self):
+        return WORKFLOW.read_text(encoding="utf-8")
+
+    def test_the_resolver_runs_from_master_only_and_after_the_sweep(self):
+        rows = self.text().splitlines()
+        sweep = next(i for i, r in enumerate(rows) if "update_branches.py" in r)
+        resolve = next(i for i, r in enumerate(rows) if "resolve_ledger_conflicts.py" in r)
+        self.assertLess(sweep, resolve)
+        step = self.text()[self.text().rindex("- name:", 0, self.text().index("resolve_ledger_conflicts.py")):]
+        self.assertIn("github.ref == 'refs/heads/master'", step.split("run:")[0])
+
+    def test_the_resolver_acts_as_the_machine_identity_so_the_push_is_measured(self):
+        body = self.text()
+        step = body[body.rindex("- name:", 0, body.index("resolve_ledger_conflicts.py")):]
+        self.assertIn("steps.identity.outputs.token", step.split("run:")[0])
+        self.assertNotIn("github.token", step.split("run:")[0])
+
+    def test_the_checkout_has_the_history_a_merge_needs(self):
+        # A shallow clone has no merge base, and the merge would fail on every branch.
+        self.assertIn("fetch-depth: 0", self.text())
+
+    def test_the_token_is_never_an_argument(self):
+        self.assertNotIn("${GH_TOKEN}@", self.text())
+        self.assertIn("${GH_TOKEN}", resolver.CREDENTIAL_HELPER)
+
+
+def git(args, cwd):
+    subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True, encoding="utf-8"
+    )
+
+
+class RealMergeTests(unittest.TestCase):
+    """The conflict of 2026-09-06, built out of commits and resolved."""
+
+    def build(self, tmp, extra_conflict=False):
+        origin = tmp / "origin.git"
+        work = tmp / "work"
+        subprocess.run(["git", "init", "--bare", "-b", "master", str(origin)],
+                       check=True, capture_output=True)
+        subprocess.run(["git", "clone", str(origin), str(work)], check=True, capture_output=True)
+        git(["config", "user.name", "test"], work)
+        git(["config", "user.email", "test@example.invalid"], work)
+
+        registry = work / "docs" / "spec" / "mirror"
+        registry.mkdir(parents=True)
+        (registry / "REQUIREMENTS_REGISTRY.csv").write_text(
+            "REQ_ID,AREA,STATUS\nREQ-A,CORE,READY\nREQ-B,CORE,READY\nREQ-NEW,CORE,READY\n",
+            encoding="utf-8",
+        )
+        (work / "docs" / "spec" / "IMPLEMENTATION_STATUS.md").write_text(
+            "# Implementation status\n\n## Coverage\n\n"
+            f"{implementation_status.BEGIN}\n{implementation_status.END}\n",
+            encoding="utf-8",
+        )
+        if extra_conflict:
+            (work / "src").mkdir()
+            (work / "src" / "worldState.ts").write_text("export const base = 1;\n", encoding="utf-8")
+
+        self.write_ledger(work, [row("REQ-A"), row("REQ-B")])
+        git(["add", "-A"], work)
+        git(["commit", "-m", "base"], work)
+        git(["push", "origin", "master"], work)
+        return origin, work
+
+    def write_ledger(self, work, rows):
+        (work / "docs" / "spec" / "implementation_status.csv").write_text(
+            resolver.render_ledger(HEADER, rows), encoding="utf-8", newline=""
+        )
+        self.assertEqual(implementation_status.main(["--root", str(work)]), 0)
+
+    def diverge(self, work, extra_conflict=False):
+        """A branch that appends a row, and a master that changes another."""
+        git(["checkout", "-b", "claude/issue-1-example"], work)
+        self.write_ledger(work, [row("REQ-A"), row("REQ-B"), row("REQ-NEW", evidence="the branch's own")])
+        if extra_conflict:
+            (work / "src" / "worldState.ts").write_text("export const branch = 2;\n", encoding="utf-8")
+        git(["add", "-A"], work)
+        git(["commit", "-m", "branch work"], work)
+        git(["push", "origin", "claude/issue-1-example"], work)
+
+        git(["checkout", "master"], work)
+        self.write_ledger(work, [row("REQ-A", "PARTIAL", "returned by QA"), row("REQ-B")])
+        if extra_conflict:
+            (work / "src" / "worldState.ts").write_text("export const master = 3;\n", encoding="utf-8")
+        git(["add", "-A"], work)
+        git(["commit", "-m", "operator correction"], work)
+        git(["push", "origin", "master"], work)
+
+    def test_a_conflict_confined_to_the_ledger_is_merged_with_both_sides(self):
+        with tempfile.TemporaryDirectory() as name:
+            tmp = pathlib.Path(name)
+            _, work = self.build(tmp)
+            self.diverge(work)
+
+            outcome = resolver.resolve(work, pull(), push=False)
+
+            self.assertIn("resolved", outcome, outcome)
+            self.assertNotIn("left to the author", outcome)
+            # Both sides' evidence survived, and the generated document agrees with it.
+            header, rows = resolver.parse_ledger(
+                (work / resolver.LEDGER_CSV).read_text(encoding="utf-8")
+            )
+            self.assertEqual(header, HEADER)
+            by_id = {r[0]: r for r in rows}
+            self.assertEqual(by_id["REQ-A"][1], "PARTIAL")
+            self.assertEqual(by_id["REQ-NEW"][5], "the branch's own")
+            self.assertEqual(implementation_status.main(["--root", str(work), "--check"]), 0)
+            # A merge commit, with nothing left unmerged.
+            self.assertEqual(resolver.unmerged_paths(work), [])
+
+    def test_a_conflict_touching_product_code_is_left_whole_for_the_author(self):
+        with tempfile.TemporaryDirectory() as name:
+            tmp = pathlib.Path(name)
+            _, work = self.build(tmp, extra_conflict=True)
+            self.diverge(work, extra_conflict=True)
+
+            outcome = resolver.resolve(work, pull(), push=False)
+
+            self.assertIn("left to the author", outcome)
+            self.assertIn("src/worldState.ts", outcome)
+            # The merge was abandoned, not left half-done.
+            self.assertEqual(resolver.unmerged_paths(work), [])
+            status = subprocess.run(
+                ["git", "-C", str(work), "status", "--porcelain"],
+                capture_output=True, text=True, check=True,
+            )
+            self.assertEqual(status.stdout.strip(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #204.

## Summary

The implementation ledger is two files that every pull request rewrites: `docs/spec/implementation_status.csv` and the document generated from it. So any two branches in flight conflict with each other, and any correction an operator makes to the ledger conflicts with every branch open at the time.

That happened at 07:27Z on 2026-09-06. PR #202 returned two rows to `PARTIAL` and both open pull requests went `dirty` in the same minute. Neither was about those rows; each had merely appended a row of its own next to them. The AUTHOR run at 08:10Z met them, spent 13 turns and $0.15, said nothing, and was recorded as `completed`. It would have done that every cycle, because the runbook's ladder puts a failing check on its own pull request above every Issue in the queue, so #200 and #201 were unreachable. Both pull requests were closed by hand.

## What changes

**The forge resolves what the forge generated.** A new `scripts/resolve_ledger_conflicts.py` runs beside the existing `behind` sweep, from `master` only, as the MACHINE identity. For a `claude/**` pull request GitHub reports as `dirty` it merges `master` and then:

- **refuses unless every unmerged path is one of those two files.** One product file among them and the whole merge is abandoned. Half a resolution is worse than none.
- **merges the ledger rows three ways, keyed by requirement identifier.** Git's own rule, one level up from lines: a row only one side changed takes that side. A row both sides changed differently is a disagreement about evidence, and the merge is abandoned for the author to settle.
- **regenerates the document instead of merging its text**, because it is generated and its text is not a source.
- **pushes as the MACHINE app**, so the branch is measured again. The token is never an argument: a credential helper reads it from the environment.

**A silent run is no longer `completed`.** `classify_outcome` had a final fallback turning a green action into `completed` once every shape had been tried. That is how the 08:10Z run came to sit in the ledger beside runs that merged requirements. It now returns `unknown`.

I deviated from acceptance criterion 3 as I wrote it in the Issue, which said `blocked`. The classifier reads only the run's last message; a message claiming nothing does not say the run was blocked, it says nothing. `unknown` is what is actually known, and the existing vocabulary already has it.

**The generator learned `--root`**, so it can render into a tree other than its own. The resolver needs that inside a merge, and a generator that could only write beside itself would have had to be copied to do it.

**The runbook** now names both forge repairs as exceptions to item 2, and says what an AUTHOR posts when it cannot resolve a conflict: the conflicting paths and what it could not decide, then stop.

## Changed artifacts

- .github/workflows/mergeability.yml
- docs/zendev/AUTHOR_RUNBOOK.md
- scripts/implementation_status.py
- scripts/record_usage.py
- scripts/resolve_ledger_conflicts.py
- scripts/tests/test_record_usage.py
- scripts/tests/test_resolve_ledger_conflicts.py

## Verification

`python -m unittest discover -s scripts/tests`: **340 tests passed**, 27 of them new.

The two that carry the weight build the 6 September conflict out of real commits in a real repository, then resolve it:

| Test | What it proves |
| --- | --- |
| `test_a_conflict_confined_to_the_ledger_is_merged_with_both_sides` | The branch's appended row and master's demoted row both survive; `implementation_status.py --check` passes on the result; nothing is left unmerged. Criterion 1. |
| `test_a_conflict_touching_product_code_is_left_whole_for_the_author` | The same conflict plus one product file: refused, named in the outcome, merge aborted, working tree clean. Criterion 2. |

Row-level controls: both sides changing one row differently is refused by identifier; a deletion on one side is honoured; a deletion against a change is refused; the base branch's row order is kept and branch-only rows follow it.

Also: `python scripts/implementation_status.py --check` passes unchanged; `python scripts/policy_guard.py --base origin/master` passes. `python scripts/resolve_ledger_conflicts.py --repo drevendev/trade_simulation --pull 205 --dry-run` against the live repository leaves #205 alone, correctly, without touching git.

Product suites not run: no product code changed.

## Risk and rollback

The resolver only ever pushes a merge commit to a `claude/**` branch, and only when the merge it just performed had nothing outside the two ledger files left unmerged. Every refusal aborts first, so a failed attempt leaves the branch exactly as it was. Rollback is removing the workflow step; the script is inert without it.

Not addressed here: the ledger's shape. One file per requirement would make these conflicts impossible rather than resolvable, but it changes the generator, the linter, both runbooks and the researcher's protocol, which reads the CSV. That belongs in ZenKit's design, not in a repair.

Policy change: accepted by the operator session, not by the ACCEPTOR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
