### PR TITLE
Raise the per-run circuit breakers to $5.00 and $3.00

### DIFF
--- a/.github/workflows/zendev-acceptor.yml
+++ b/.github/workflows/zendev-acceptor.yml
@@ -168,11 +168,20 @@ jobs:
           # bill. The model is part of what governs a run, so it is declared here and
           # recorded in the telemetry ledger for every run.
           #
-          # Circuit breaker, not a budget: expected acceptor spend on this model is
-          # well under a dollar, so this only fires on a genuine runaway. A hard stop
-          # here is ungraceful — the run cannot report its own blocker — which is why
-          # the ceiling is generous rather than tight.
-          claude_args: --model claude-haiku-4-5 --max-budget-usd 2.00
+          # Circuit breaker, not a budget. A hard stop here is ungraceful — the run is
+          # cut mid-work and cannot report its own blocker, and what it leaves behind
+          # is an open branch nobody explains — so the ceiling is deliberately generous
+          # and only ever fires on a runaway.
+          #
+          # Measured over 88 recorded acceptor runs to 2026-09-06: mean $0.29, 95th
+          # percentile $0.60, highest $0.74. That highest one reached 37% of the
+          # former $2.00 ceiling and still finished; a margin that thin is a stop
+          # waiting to happen, on a run doing nothing wrong. Raised to $3.00 by the
+          # owner on that evidence. It is not a licence to spend: the binding resource
+          # is the subscription window, where the whole loop occupies about three
+          # points of a five-hour block, and a run approaching this figure is a defect
+          # to read in the ledger rather than a budget being used up.
+          claude_args: --model claude-haiku-4-5 --max-budget-usd 3.00
           settings: |
             {
               "permissions": {

--- a/.github/workflows/zendev-author.yml
+++ b/.github/workflows/zendev-author.yml
@@ -158,11 +158,20 @@ jobs:
           # bill. The model is part of what governs a run, so it is declared here and
           # recorded in the telemetry ledger for every run.
           #
-          # Circuit breaker, not a budget: expected author spend on this model is
-          # well under a dollar, so this only fires on a genuine runaway. A hard stop
-          # here is ungraceful — the run cannot report its own blocker — which is why
-          # the ceiling is generous rather than tight.
-          claude_args: --model claude-haiku-4-5 --max-budget-usd 3.00
+          # Circuit breaker, not a budget. A hard stop here is ungraceful — the run is
+          # cut mid-work and cannot report its own blocker, and what it leaves behind
+          # is an open branch nobody explains — so the ceiling is deliberately generous
+          # and only ever fires on a runaway.
+          #
+          # Measured over 108 recorded author runs to 2026-09-06: mean $0.67, 95th
+          # percentile $1.70, highest $2.79. That highest one reached 93% of the
+          # former $3.00 ceiling and still finished; a margin that thin is a stop
+          # waiting to happen, on a run doing nothing wrong. Raised to $5.00 by the
+          # owner on that evidence. It is not a licence to spend: the binding resource
+          # is the subscription window, where the whole loop occupies about three
+          # points of a five-hour block, and a run approaching this figure is a defect
+          # to read in the ledger rather than a budget being used up.
+          claude_args: --model claude-haiku-4-5 --max-budget-usd 5.00
           settings: |
             {
               "permissions": {


### PR DESCRIPTION
Closes #212.

## Summary

Raises the per-run circuit breakers: author `$3.00` → `$5.00`, acceptor `$2.00` → `$3.00`.

**No run has ever been stopped by a ceiling.** This is not a repair. It is a margin decision the owner took on measured evidence, and the Issue records both sides of it.

| role | old ceiling | runs | mean | p95 | highest | highest as % of old |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| author | $3.00 | 108 | $0.67 | $1.70 | $2.79 | 93% |
| acceptor | $2.00 | 88 | $0.29 | $0.60 | $0.74 | 37% |

The author's run of 2026-09-04T12:40 finished successfully on seven cents of margin, over 85 turns. A ceiling that close to a legitimate run is a stop waiting to happen, and when it happens the run is cut mid-work, cannot post its own blocker, and leaves an open branch nobody explains.

The argument against, which the owner heard and overrode: a per-run ceiling is the only bound on a runaway, and every dollar added is added to the worst case.

The comment above each figure is replaced with the measurement, so the next reader sees why the number is what it is rather than re-deriving it, and is told plainly that the raised figure is not headroom to spend — the binding resource is the subscription window, where the whole loop occupies about three points of a five-hour block.

## Changed artifacts

- .github/workflows/zendev-author.yml
- .github/workflows/zendev-acceptor.yml

## Verification

- `python -m unittest discover -s scripts/tests`: 340 tests passed. Nothing pins these figures, so nothing needed changing; the run proves that.
- Both workflow files re-parse as YAML.
- `python scripts/policy_guard.py --base origin/master` passes.
- Product suites not run: no product code changed.

Detection if a ceiling ever does fire: a run cut mid-work posts neither a handoff nor a verdict, and since #206 the ledger records such a run as `unknown` rather than `completed`.

Policy change: accepted by the operator session, not by the ACCEPTOR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
