### PR TITLE
Give the QA voice's findings labels, so the loop can see them

### DIFF
--- a/.github/workflows/qa-intake.yml
+++ b/.github/workflows/qa-intake.yml
@@ -1,0 +1,58 @@
+name: QA intake
+
+# Labels an Issue opened by the external QA voice (SLOPSTER, acting as the account in
+# vars.ZENDEV_QA_LOGIN), which has read access only and therefore cannot label its own
+# findings. Without this, a finding is unreachable: every work-selection item in the
+# AUTHOR runbook is expressed over labels.
+#
+# This workflow never runs a model. It reads three declaration lines and applies
+# labels that already exist in the repository — never status:ready, so a finding
+# becomes visible without becoming work. See scripts/qa_intake.py.
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions: {}
+
+concurrency:
+  # Per Issue: `opened` and a fast `reopened` must not race on the same label set.
+  group: qa-intake-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  label:
+    # The author check is repeated inside the script, which is what actually enforces
+    # it. Here it is a cost gate: no runner starts for the many Issues this never
+    # touches. An unset ZENDEV_QA_LOGIN disables the job rather than matching nobody
+    # noisily on every Issue in the repository.
+    if: vars.ZENDEV_QA_LOGIN != '' && github.event.issue.user.login == vars.ZENDEV_QA_LOGIN
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      # The MACHINE identity, as for every other change this repository makes without
+      # a model. It needs Issues: read and write; Contents and Pull requests, which it
+      # already holds, are not enough to label.
+      - name: Act as the MACHINE identity
+        id: identity
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.ZENDEV_MACHINE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ZENDEV_MACHINE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Label the finding
+        env:
+          GH_TOKEN: ${{ steps.identity.outputs.token }}
+        run: |
+          python scripts/qa_intake.py \
+            --repo "${{ github.repository }}" \
+            --issue "${{ github.event.issue.number }}" \
+            --qa-author "${{ vars.ZENDEV_QA_LOGIN }}"

--- a/scripts/qa_intake.py
+++ b/scripts/qa_intake.py
@@ -1,0 +1,154 @@
+"""Label an Issue opened by the external QA voice, so the loop can see it at all.
+
+SLOPSTER acts as a GitHub account with read access to a public repository. Read access
+is enough to open an Issue and comment on a pull request, and deliberately not enough
+to label anything: an account that could label could also mark its own finding
+`status:ready` and put work into the AUTHOR's queue without anyone reading it.
+
+But an Issue with no labels is invisible. Every one of the six work-selection items in
+the AUTHOR runbook is expressed over labels, so a finding that arrives unlabelled is
+not "low priority" — it is unreachable, and the QA voice would be talking to nobody.
+
+This closes that gap and nothing more. It reads three declaration lines the QA
+manifest requires, applies only labels that already exist in the repository, and marks
+the Issue `status:needs-triage` — never `status:ready`. Promotion to work stays a
+judgement, made by the AUTHOR at triage; this job only makes the finding visible.
+
+## Why it does not simply trust the declarations
+
+An unknown or malformed value is dropped, not created. The label set is the
+repository's vocabulary for what kind of thing an Issue is, and letting an outside
+account extend it by writing a new word in a body would make the vocabulary meaningless
+— and the label list is what several guards key on. A finding whose `Area:` is
+unreadable still arrives, still carries `qa` and `status:needs-triage`, and a human or
+the AUTHOR gives it the right axis at triage. Losing an axis costs one triage; taking
+the word on trust costs the meaning of every axis.
+
+## Why it will not add a second status label
+
+An open Issue carrying two `status:*` labels is a live defect (#214): it happened
+twice in one day and needed an operator both times. On `reopened` the Issue may
+already carry one, so this adds `status:needs-triage` only when no `status:*` label is
+present at all.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+# `Type: bug`, `**Priority:** high`, `- Area: simulation-core`. Anchored to the start
+# of a line so a sentence mentioning a type in prose is not a declaration.
+DECLARATION = re.compile(
+    r"^[\s>*_-]*\**\s*(type|area|priority)\s*\**\s*:\s*\**\s*([A-Za-z0-9][A-Za-z0-9 _./-]*?)\s*\**\s*$",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+QA_LABEL = "qa"
+TRIAGE_LABEL = "status:needs-triage"
+STATUS_PREFIX = "status:"
+
+
+def declared_labels(body: str):
+    """Map the declaration lines of an Issue body to candidate label names.
+
+    The first declaration of an axis wins. A body that says `Type: bug` twice with
+    different values is malformed, and picking the last would let a trailing line in a
+    quoted reply silently override the author's own heading.
+    """
+    found = {}
+    for axis, value in DECLARATION.findall(body or ""):
+        axis = axis.lower()
+        if axis in found:
+            continue
+        found[axis] = "%s:%s" % (axis, value.strip().lower().replace(" ", "-"))
+    return [found[axis] for axis in ("type", "area", "priority") if axis in found]
+
+
+def labels_to_apply(body: str, existing, known):
+    """The labels to add: declared ones the repository knows, plus qa and triage.
+
+    `existing` is what the Issue already carries, `known` the repository's whole label
+    vocabulary. Returns a sorted list so the result is stable to compare in a test and
+    in a log; applying a label an Issue already has is a no-op, but saying so in the
+    log is noise.
+    """
+    known = {name.lower() for name in known}
+    have = {name.lower() for name in existing}
+    add = {name for name in declared_labels(body) if name in known} - have
+
+    if QA_LABEL in known:
+        add.add(QA_LABEL)
+    if not any(name.startswith(STATUS_PREFIX) for name in have) and TRIAGE_LABEL in known:
+        add.add(TRIAGE_LABEL)
+    return sorted(add - have)
+
+
+def _gh(args):
+    # UTF-8 explicitly, not by locale: an Issue body holding an em dash otherwise
+    # raises inside the reader thread on a Windows console, several frames from here.
+    return subprocess.run(
+        ["gh", *args], check=True, capture_output=True, text=True, encoding="utf-8"
+    ).stdout
+
+
+def normalize_login(login) -> str:
+    login = (login or "").strip()
+    if login.endswith("[bot]"):
+        login = login[: -len("[bot]")]
+    return login.lower()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="owner/name")
+    parser.add_argument("--issue", required=True, type=int)
+    parser.add_argument(
+        "--qa-author",
+        required=True,
+        help="the only account whose Issues this labels; anything else is left alone",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    issue = json.loads(
+        _gh(["issue", "view", str(args.issue), "--repo", args.repo,
+             "--json", "author,body,labels,state"])
+    )
+    author = normalize_login((issue.get("author") or {}).get("login"))
+    if author != normalize_login(args.qa_author):
+        print(f"qa-intake: #{args.issue} is {author or 'unknown'}'s, not the QA voice's; leaving it alone")
+        return 0
+
+    known = [row["name"] for row in json.loads(
+        _gh(["label", "list", "--repo", args.repo, "--limit", "200", "--json", "name"])
+    )]
+    existing = [row["name"] for row in issue.get("labels") or []]
+    add = labels_to_apply(issue.get("body") or "", existing, known)
+
+    if not add:
+        print(f"qa-intake: #{args.issue} already carries everything this would add")
+        return 0
+
+    print(f"qa-intake: #{args.issue} += {', '.join(add)}")
+    if args.dry_run:
+        return 0
+
+    # One call: two calls can half-apply, and a finding carrying `qa` but no status is
+    # exactly as invisible as one carrying nothing.
+    try:
+        _gh(["issue", "edit", str(args.issue), "--repo", args.repo,
+             *sum((["--add-label", name] for name in add), [])])
+    except subprocess.CalledProcessError as error:
+        # Never fail the job. A finding that arrives unlabelled is a triage cost; a red
+        # workflow on every QA Issue is a broken control plane, and the louder signal
+        # would be the wrong one.
+        print(f"::warning::qa-intake: labelling #{args.issue} failed: {error.stderr.strip()[:200]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_qa_intake.py
+++ b/scripts/tests/test_qa_intake.py
@@ -1,0 +1,145 @@
+"""What the intake job may and may not do to a finding from the external QA voice.
+
+The QA account has read access only, so without this job its Issues carry no labels
+and no work-selection item in the AUTHOR runbook can reach them. The tests below fix
+both halves of that: the finding becomes visible, and it does not become work.
+"""
+
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import qa_intake  # noqa: E402
+
+KNOWN = [
+    "type:bug", "type:feature", "type:process", "type:docs",
+    "area:simulation-core", "area:tooling", "area:market",
+    "priority:high", "priority:normal", "priority:low",
+    "status:needs-triage", "status:ready", "status:in-progress", "qa", "policy",
+]
+
+BODY = """## Goal
+
+The genesis reconciliation compares the wrong totals.
+
+Type: bug
+Area: simulation-core
+Priority: high
+"""
+
+
+class DeclarationTests(unittest.TestCase):
+    def test_the_three_declaration_lines_become_labels(self):
+        self.assertEqual(
+            qa_intake.declared_labels(BODY),
+            ["type:bug", "area:simulation-core", "priority:high"],
+        )
+
+    def test_the_shapes_a_writer_actually_uses(self):
+        for body in (
+            "Type: bug",
+            "**Type:** bug",
+            "- Type: bug",
+            "> Type:  bug  ",
+            "type: BUG",
+        ):
+            with self.subTest(body=body):
+                self.assertEqual(qa_intake.declared_labels(body), ["type:bug"])
+
+    def test_a_multiword_area_becomes_the_hyphenated_label(self):
+        self.assertEqual(
+            qa_intake.declared_labels("Area: simulation core"), ["area:simulation-core"]
+        )
+
+    def test_prose_mentioning_an_axis_is_not_a_declaration(self):
+        # Anchored to the line start, or every finding that discusses its own type
+        # would relabel itself from the middle of a sentence.
+        for body in (
+            "The Type: bug declaration was missing from the earlier report.",
+            "I would call this a type: bug, but see below.",
+        ):
+            with self.subTest(body=body):
+                self.assertEqual(qa_intake.declared_labels(body), [])
+
+    def test_the_first_declaration_of_an_axis_wins(self):
+        # A quoted reply repeating the heading must not override the author's own.
+        body = "Type: bug\n\n> Type: feature\n"
+        self.assertEqual(qa_intake.declared_labels(body), ["type:bug"])
+
+
+class LabelSelectionTests(unittest.TestCase):
+    def test_a_well_formed_finding_gets_its_axes_plus_qa_and_triage(self):
+        self.assertEqual(
+            qa_intake.labels_to_apply(BODY, [], KNOWN),
+            ["area:simulation-core", "priority:high", "qa", "status:needs-triage",
+             "type:bug"],
+        )
+
+    def test_an_unknown_value_is_dropped_and_the_finding_still_arrives(self):
+        # The outside account must not be able to extend the repository's vocabulary,
+        # and losing one axis costs a triage while inventing a label costs the meaning
+        # of every axis. The finding still becomes visible.
+        body = "Type: bug\nArea: quantum-tunnelling\nPriority: high\n"
+        self.assertEqual(
+            qa_intake.labels_to_apply(body, [], KNOWN),
+            ["priority:high", "qa", "status:needs-triage", "type:bug"],
+        )
+
+    def test_a_finding_with_no_declarations_still_becomes_visible(self):
+        self.assertEqual(
+            qa_intake.labels_to_apply("just prose", [], KNOWN),
+            ["qa", "status:needs-triage"],
+        )
+
+    def test_it_never_grants_status_ready(self):
+        # The QA voice may not put work into the AUTHOR's queue. Promotion is a
+        # judgement made at triage, by the AUTHOR.
+        body = BODY + "\nStatus: ready\nstatus:ready\n"
+        applied = qa_intake.labels_to_apply(body, [], KNOWN)
+        self.assertNotIn("status:ready", applied)
+        self.assertIn("status:needs-triage", applied)
+
+    def test_it_does_not_add_a_second_status_label(self):
+        # #214: an open Issue carrying two status:* labels happened twice in one day
+        # and needed an operator both times. On `reopened` one may already stand.
+        applied = qa_intake.labels_to_apply(BODY, ["status:in-progress"], KNOWN)
+        self.assertNotIn("status:needs-triage", applied)
+        self.assertIn("qa", applied)
+
+    def test_labels_already_present_are_not_re_applied(self):
+        applied = qa_intake.labels_to_apply(BODY, ["qa", "type:bug"], KNOWN)
+        self.assertEqual(applied, ["area:simulation-core", "priority:high",
+                                   "status:needs-triage"])
+
+    def test_nothing_to_add_is_an_empty_list_not_an_error(self):
+        have = ["type:bug", "area:simulation-core", "priority:high", "qa",
+                "status:needs-triage"]
+        self.assertEqual(qa_intake.labels_to_apply(BODY, have, KNOWN), [])
+
+    def test_a_label_the_repository_does_not_have_yet_is_not_invented(self):
+        # If `qa` has not been created, the job must still label what it can rather
+        # than fail on a label that does not exist.
+        without_qa = [name for name in KNOWN if name != "qa"]
+        applied = qa_intake.labels_to_apply(BODY, [], without_qa)
+        self.assertNotIn("qa", applied)
+        self.assertIn("status:needs-triage", applied)
+
+    def test_the_policy_label_is_never_granted_from_a_body(self):
+        # `policy` marks the control plane, which the AUTHOR must not take. An outside
+        # account naming it must not be able to move an Issue into that class.
+        applied = qa_intake.labels_to_apply("Type: process\nArea: tooling\npolicy\n",
+                                            [], KNOWN)
+        self.assertNotIn("policy", applied)
+
+
+class IdentityTests(unittest.TestCase):
+    def test_the_bot_suffix_is_not_part_of_the_identity(self):
+        self.assertEqual(qa_intake.normalize_login("AndyDev"), "andydev")
+        self.assertEqual(qa_intake.normalize_login("zendev-machine[bot]"),
+                         "zendev-machine")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #261

## Goal

Let SLOPSTER's findings reach the loop. The QA account has read access only — enough
to open an Issue, not to label one — and an Issue with no labels is invisible to every
work-selection item in the AUTHOR runbook.

Depends on #257 (verdict ownership). Merging this first would put a second QA voice
into a queue that still reads any account's review as a verdict.

## Scope — every changed path

- `scripts/qa_intake.py` — new. Reads `Type:` / `Area:` / `Priority:` declaration
  lines, applies only labels that already exist, plus `qa` and `status:needs-triage`.
  Acts only on Issues authored by `vars.ZENDEV_QA_LOGIN`.
- `scripts/tests/test_qa_intake.py` — new. 15 tests.
- `.github/workflows/qa-intake.yml` — new. `issues: [opened, reopened]`, gated on the
  QA login, MACHINE identity, no model.

## Non-goals

Does not grant `status:ready` — promotion to work is a judgement the AUTHOR makes at
triage. Does not create labels. Does not comment. Does not touch Issues from any other
account, including the researcher's and the operator's.

## Acceptance criteria

- A well-formed finding gets its three axes plus `qa` and `status:needs-triage`.
- An unknown axis value is dropped; the finding still arrives labelled `qa`.
- `status:ready` is never applied, however the body is written.
- No second `status:*` label is added when one already stands (#214).
- An Issue from any other account is untouched.
- A labelling failure warns; the job stays green.

## Verification

```
python -m unittest discover -s scripts/tests   →  Ran 355 tests … OK
```

Live check after merge: open one Issue from the QA account by hand and confirm the
labels appear within a minute; open one from `drevendev` and confirm it is untouched.

## Needs from the operator before this can work

1. `zendev-machine` app → **Issues: Read and write**, and accept the new permission on
   the `trade_simulation` installation. Contents and Pull requests are not enough.
2. Repository variable **`ZENDEV_QA_LOGIN`** = the QA account's login. Unset, the job
   never runs.
3. The `qa` label. The script skips it if absent, so this is not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
