### PR TITLE
Name the setup each run was under, and tag a milestone when the ledger says so

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,59 @@
+name: Release tag
+
+# Cuts v0.<milestone>.<patch> when every requirement of a milestone reads IMPLEMENTED
+# in docs/spec/implementation_status.csv. No model runs: the ledger already records
+# the Issue, pull request and merge commit behind each requirement, so nothing is left
+# to judge. See scripts/release_tag.py.
+#
+# Idempotent by construction. Each tag's message carries a coverage-digest of the
+# (requirement, merge commit) pairs behind it, and a milestone whose newest tag
+# carries the same digest is not re-cut. A push that changed no coverage does nothing.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'docs/spec/implementation_status.csv'
+      - 'docs/zendev/milestones.json'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  # Two pushes landing together must not both decide the same patch number.
+  group: release-tag
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Tags are the state this job reads, so it needs all of them, and it needs
+      # history to push one.
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Act as the MACHINE identity
+        id: identity
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.ZENDEV_MACHINE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ZENDEV_MACHINE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Cut the tag if a milestone is newly complete
+        env:
+          GH_TOKEN: ${{ steps.identity.outputs.token }}
+        run: |
+          git config user.name "zendev-machine[bot]"
+          git config user.email "${{ steps.identity.outputs.app-slug }}[bot]@users.noreply.github.com"
+          git remote set-url origin \
+            "https://x-access-token:${{ steps.identity.outputs.token }}@github.com/${{ github.repository }}.git"
+          python scripts/release_tag.py

--- a/.github/workflows/zendev-acceptor.yml
+++ b/.github/workflows/zendev-acceptor.yml
@@ -120,6 +120,10 @@ jobs:
         run: |
           cp scripts/record_usage.py "${RUNNER_TEMP}/record_usage.py"
           cp scripts/subscription_usage.py "${RUNNER_TEMP}/subscription_usage.py"
+          # The scheme the record will name must travel with the recorder: read from
+          # the working tree it would be whatever the branch under review claims.
+          cp scripts/schemes.py "${RUNNER_TEMP}/schemes.py"
+          cp docs/zendev/schemes.json "${RUNNER_TEMP}/schemes.json"
           # The whole control plane too: the rework bound below imports its neighbours.
           cp -r scripts "${RUNNER_TEMP}/control-plane"
 

--- a/.github/workflows/zendev-author.yml
+++ b/.github/workflows/zendev-author.yml
@@ -125,6 +125,10 @@ jobs:
         run: |
           cp scripts/record_usage.py "${RUNNER_TEMP}/record_usage.py"
           cp scripts/subscription_usage.py "${RUNNER_TEMP}/subscription_usage.py"
+          # The scheme the record will name must travel with the recorder: read from
+          # the working tree it would be whatever the branch under review claims.
+          cp scripts/schemes.py "${RUNNER_TEMP}/schemes.py"
+          cp docs/zendev/schemes.json "${RUNNER_TEMP}/schemes.json"
 
       # The subscription is metered in rolling windows, not dollars. One reading before
       # the model and one after; the recorder writes the difference to the private

--- a/docs/spec/FEEDBACK_TO_RESEARCHER.md
+++ b/docs/spec/FEEDBACK_TO_RESEARCHER.md
@@ -253,6 +253,30 @@ If you cannot create Issues from where you run, say so once in `ANSWERS_TO_IMPLE
 and keep posting the findings; the operator will convert them, with a delay of hours
 rather than minutes.
 
+## 2026-09-07 — REQUIREMENTS_REGISTRY — milestone membership is not machine-readable
+
+Observed: `EXECUTION_ORDER.md` states milestone membership in prose. M0 and M3 name
+their requirements explicitly; M1 and M2 say only "M1 rows" and "M2 rows", and
+`REQUIREMENTS_REGISTRY.csv` has no column saying which milestone a row gates.
+
+Problem:  the repository now cuts a release tag when every requirement of a milestone
+reads IMPLEMENTED in the ledger. That needs the mapping as data. Read from prose it has
+to be transcribed by hand, and a hand copy of your data goes stale the first time you
+add a requirement — silently, since a requirement belonging to no milestone would
+simply never appear in any gate.
+
+Proposal: add a `MILESTONE` column to `REQUIREMENTS_REGISTRY.csv`, one value per row
+(`M0`…`M12`), left empty for the cross-cutting rows — REQ-SCOPE-001, REQ-SCOPE-002,
+REQ-VISUALIZATION-001, REQ-VISUALIZATION-002 — which gate no single milestone. No other
+file needs to change.
+
+Impact:  until then M1 and M2 membership is a transcription in
+`docs/zendev/milestones.json` marked `prose`, every release note repeats that
+provenance, and a test fails the build if the transcription and the registry diverge.
+The tags are correct, but their membership is our reading of your text rather than your
+statement of it. When the column lands, `milestones.json` is deleted and the tagger
+reads the registry directly.
+
 ### How your reviews count
 
 Since 2026-09-06 (Issue #152):

--- a/docs/zendev/milestones.json
+++ b/docs/zendev/milestones.json
@@ -1,0 +1,44 @@
+{
+  "_comment": [
+    "Which requirements each milestone gate covers, so a release tag can be cut from",
+    "the ledger without a person deciding what 'M1 is done' means.",
+    "",
+    "PROVISIONAL for M1 and M2. The mapping is the researcher's data and belongs in",
+    "REQUIREMENTS_REGISTRY.csv as a MILESTONE column; there is none, and",
+    "EXECUTION_ORDER.md carries the mapping only in prose. M0 and M3 are quoted there",
+    "explicitly and are marked `explicit` below; M1 and M2 are read off the milestone",
+    "descriptions and the named Milestone Preview, and are marked `prose`.",
+    "",
+    "The request to the researcher is in FEEDBACK_TO_RESEARCHER.md. When the column",
+    "arrives, this file is deleted and the tagger reads the registry instead.",
+    "",
+    "test_release_tag.py asserts every executable requirement in the registry appears",
+    "in exactly one milestone here, so a requirement arriving from the researcher",
+    "fails the build until it is mapped rather than silently escaping every gate.",
+    "",
+    "`unassigned` holds rows that gate no single milestone: scope statements and the",
+    "cross-cutting visibility rule."
+  ],
+  "source": {"M0": "explicit", "M1": "prose", "M2": "prose", "M3": "explicit"},
+  "milestones": {
+    "M0": [
+      "REQ-MIGRATION-001", "REQ-MIGRATION-002", "REQ-MIGRATION-003",
+      "REQ-MIGRATION-004", "REQ-VISUALIZATION-003"
+    ],
+    "M1": [
+      "REQ-CORE-001", "REQ-CORE-002", "REQ-CORE-003",
+      "REQ-CONFIG-001", "REQ-CONFIG-002", "REQ-CONFIG-003", "REQ-CONFIG-004",
+      "REQ-CONFIG-005", "REQ-VISUALIZATION-004"
+    ],
+    "M2": [
+      "REQ-CORE-004", "REQ-CORE-005", "REQ-CORE-006",
+      "REQ-ACCEPTANCE-001", "REQ-ACCEPTANCE-002", "REQ-ACCEPTANCE-003",
+      "REQ-VISUALIZATION-005"
+    ],
+    "M3": [
+      "REQ-MARKET-001", "REQ-MARKET-002", "REQ-MARKET-003", "REQ-MARKET-004",
+      "REQ-MARKET-005", "REQ-ACCEPTANCE-004", "REQ-VISUALIZATION-006"
+    ]
+  },
+  "unassigned": ["REQ-SCOPE-001", "REQ-SCOPE-002", "REQ-VISUALIZATION-001", "REQ-VISUALIZATION-002"]
+}

--- a/docs/zendev/schemes.json
+++ b/docs/zendev/schemes.json
@@ -1,0 +1,90 @@
+{
+  "_comment": [
+    "A scheme is the setup the loop runs under: which roles exist, which identity owns",
+    "the formal verdict, which model each role uses, which gates are mandatory, what",
+    "bounds a run, and who else has a voice. Change any of it and the numbers from",
+    "before are numbers about a different system.",
+    "",
+    "The rule for cutting a new scheme is mechanical on purpose: any field below",
+    "changes, the scheme number goes up. Arguing case by case about whether a change",
+    "is 'significant' is how a comparison quietly stops being one.",
+    "",
+    "Each scheme is tagged `scheme/N` on the commit where it took effect, with this",
+    "descriptor in the tag message, and every telemetry record carries {id, digest} so",
+    "a measurement window can be sliced by scheme without knowing any dates."
+  ],
+  "active": "scheme/3",
+  "schemes": [
+    {
+      "id": "scheme/1",
+      "in_force_from": "2026-09-05T18:40:00Z",
+      "commit": "",
+      "summary": "Three GitHub Apps live; author and acceptor on Haiku; the formal verdict is read from any account.",
+      "roles": {
+        "author": {"identity": "zendev-author[bot]", "model": "claude-haiku-4-5", "max_budget_usd": 3.0},
+        "acceptor": {"identity": "zendev-acceptor[bot]", "model": "claude-haiku-4-5", "max_budget_usd": 2.0},
+        "machine": {"identity": "zendev-machine[bot]", "model": null}
+      },
+      "verdict_owner": "any account",
+      "voices": ["EndlessZen as drevendev, formal reviews on code"],
+      "required_checks": ["build-and-test", "typescript", "policy-guard", "mergeability"],
+      "rework_limit": 3,
+      "cadence_minutes": 25,
+      "note": "Retired by the budget change in #213."
+    },
+    {
+      "id": "scheme/2",
+      "in_force_from": "2026-09-06T11:43:00Z",
+      "commit": "5c9f9ec",
+      "summary": "As scheme/1 with the per-run ceilings raised. The measured day of 2026-09-06/07 lies entirely inside this scheme.",
+      "roles": {
+        "author": {"identity": "zendev-author[bot]", "model": "claude-haiku-4-5", "max_budget_usd": 5.0},
+        "acceptor": {"identity": "zendev-acceptor[bot]", "model": "claude-haiku-4-5", "max_budget_usd": 3.0},
+        "machine": {"identity": "zendev-machine[bot]", "model": null}
+      },
+      "verdict_owner": "any account",
+      "voices": ["EndlessZen as drevendev, formal reviews on code"],
+      "required_checks": ["build-and-test", "typescript", "policy-guard", "mergeability"],
+      "rework_limit": 3,
+      "cadence_minutes": 25,
+      "note": "Measured: 125 runs, $41.15, 8 requirements landed, and 65% of spend in pull requests that could no longer be accepted. Retired for that reason."
+    },
+    {
+      "id": "scheme/3",
+      "in_force_from": "",
+      "commit": "",
+      "summary": "The ACCEPTOR identity alone owns the formal verdict; every other account's review is evidence.",
+      "roles": {
+        "author": {"identity": "zendev-author[bot]", "model": "claude-haiku-4-5", "max_budget_usd": 5.0},
+        "acceptor": {"identity": "zendev-acceptor[bot]", "model": "claude-haiku-4-5", "max_budget_usd": 3.0},
+        "machine": {"identity": "zendev-machine[bot]", "model": null}
+      },
+      "verdict_owner": "zendev-acceptor",
+      "voices": ["EndlessZen as drevendev, formal reviews on code (read as evidence)"],
+      "required_checks": ["build-and-test", "typescript", "policy-guard", "mergeability"],
+      "rework_limit": 3,
+      "cadence_minutes": 25,
+      "note": "In force from the merge of the verdict-ownership pull request. `in_force_from` and `commit` are filled by the operator at that merge."
+    },
+    {
+      "id": "scheme/4",
+      "in_force_from": "",
+      "commit": "",
+      "summary": "SLOPSTER joins as an external QA voice with read access only; its findings reach the loop through the intake job.",
+      "roles": {
+        "author": {"identity": "zendev-author[bot]", "model": "claude-haiku-4-5", "max_budget_usd": 5.0},
+        "acceptor": {"identity": "zendev-acceptor[bot]", "model": "claude-haiku-4-5", "max_budget_usd": 3.0},
+        "machine": {"identity": "zendev-machine[bot]", "model": null}
+      },
+      "verdict_owner": "zendev-acceptor",
+      "voices": [
+        "EndlessZen as drevendev, owns the specification",
+        "SLOPSTER as AndyDev, read-only: comments and Issues, never a formal review"
+      ],
+      "required_checks": ["build-and-test", "typescript", "policy-guard", "mergeability"],
+      "rework_limit": 3,
+      "cadence_minutes": 25,
+      "note": "Not in force. Activated when the QA voice's hourly cadence starts."
+    }
+  ]
+}

--- a/scripts/record_usage.py
+++ b/scripts/record_usage.py
@@ -44,6 +44,10 @@ import sys
 import urllib.error
 import urllib.request
 
+# Staged next to this module by the workflow, for the reason given in its own header.
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import schemes  # noqa: E402
+
 TOKEN_FIELDS = (
     "input_tokens",
     "output_tokens",
@@ -356,6 +360,20 @@ def main() -> int:
     if before is None or after is None:
         warn("a subscription reading is missing; the subscription block carries nulls")
 
+    # Which setup produced this run. Without it a window of records cannot be sliced
+    # by scheme, and comparing two days means trusting that nothing changed between
+    # them — which, over the three days this loop has run, was never true.
+    scheme_stamp = schemes.stamp()
+    if scheme_stamp is None:
+        warn("no active scheme could be read; the record carries no scheme block")
+    else:
+        drift = schemes.check_observed(schemes.active(schemes.load()), args.role, model)
+        if drift:
+            # Loud, and not fatal. The record is still worth writing — it is the
+            # evidence of the drift.
+            warn(f"scheme drift: {drift}")
+            scheme_stamp = dict(scheme_stamp, matches_observed=False)
+
     now = dt.datetime.now(dt.timezone.utc)
     record = {
         "recorded_at": now.isoformat(timespec="seconds"),
@@ -372,6 +390,7 @@ def main() -> int:
         "duration_ms": extra.get("duration_ms"),
         "num_turns": extra.get("num_turns"),
         "session_id": extra.get("session_id"),
+        "scheme": scheme_stamp,
         "subscription": subscription_block(before, after),
         "run_id": args.run_id,
         "run_url": args.run_url,

--- a/scripts/release_tag.py
+++ b/scripts/release_tag.py
@@ -1,0 +1,226 @@
+"""Cut a release tag when a milestone's requirements are all implemented.
+
+The roadmap has versions but the repository has never had a tag, so "what shipped at
+M1" is answerable only by reading merge history. This makes it mechanical: the ledger
+already records, per requirement, the Issue, the pull request and the merge commit
+that satisfied it, and a milestone is done exactly when every one of its rows says
+IMPLEMENTED. No judgement is left, so no model runs and no review is needed — the
+same class as the mirror's own pull requests.
+
+## Versions
+
+`v0.<milestone>.<patch>`. The major stays 0 until the product says otherwise; the
+minor is the milestone number, so a tag's name says what it gates.
+
+The patch exists because a milestone does not stay done. Post-merge QA returned
+REQ-CONFIG-003 and REQ-CONFIG-004 to PARTIAL after M1 had been reached; when repairs
+land, the milestone is complete again but at different commits, and overwriting the
+old tag would erase what "M1" meant to anyone who read it earlier. So the old tag
+stands and a patch is cut beside it.
+
+## How a re-release is detected without keeping state
+
+Each tag's message carries `coverage-digest`, a hash of the (requirement, merge
+commit) pairs behind it. A milestone whose newest tag carries a different digest has
+been satisfied by different commits since, and earns the next patch. Nothing has to be
+remembered between runs: the tags are the state.
+
+This is also what makes the job idempotent. It runs on every push to master, and on a
+push that changed nothing about coverage the digest is identical and nothing is cut.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import pathlib
+import re
+import subprocess
+import sys
+
+IMPLEMENTED = "IMPLEMENTED"
+TAG = re.compile(r"^v0\.(\d+)\.(\d+)$")
+DIGEST_LINE = re.compile(r"^coverage-digest:\s*([0-9a-f]{6,64})\s*$", re.MULTILINE)
+
+
+def coverage_digest(rows) -> str:
+    """A hash of what actually backs a milestone: requirement and merge commit.
+
+    Sorted, so the row order in the ledger cannot make an unchanged milestone look
+    re-released.
+    """
+    pairs = sorted((row["REQ_ID"], (row.get("MERGE_COMMIT") or "").strip()) for row in rows)
+    canonical = json.dumps(pairs, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+
+def milestone_number(name: str) -> int:
+    return int(name[1:])
+
+
+def complete(rows, required_ids):
+    """Whether every required requirement has an IMPLEMENTED row.
+
+    A missing row is not complete. The ledger only gains a row when work lands, so
+    "absent" and "not done" are the same fact, and treating absence as success would
+    release a milestone whose work was never started.
+    """
+    by_id = {row["REQ_ID"]: row for row in rows}
+    return all(
+        req_id in by_id
+        and (by_id[req_id].get("STATUS") or "").strip().upper() == IMPLEMENTED
+        for req_id in required_ids
+    )
+
+
+def next_patch(existing):
+    """The patch to cut given the milestone's existing (patch, digest) pairs."""
+    return max(patch for patch, _ in existing) + 1 if existing else 0
+
+
+def plan(rows, milestones, existing):
+    """What to tag now.
+
+    `existing` maps a milestone name to [(patch, digest)] already tagged. Returns a
+    list of entries in milestone order.
+    """
+    out = []
+    for name in sorted(milestones, key=milestone_number):
+        required = milestones[name]
+        if not complete(rows, required):
+            continue
+        backing = [row for row in rows if row["REQ_ID"] in set(required)]
+        digest = coverage_digest(backing)
+        seen = existing.get(name, [])
+        if any(known == digest for _, known in seen):
+            continue
+        out.append({
+            "tag": "v0.%d.%d" % (milestone_number(name), next_patch(seen)),
+            "milestone": name,
+            "requirements": sorted(required),
+            "digest": digest,
+            "rows": sorted(backing, key=lambda row: row["REQ_ID"]),
+        })
+    return out
+
+
+def notes(entry, source: str) -> str:
+    """The tag message and release body: what shipped, and where to verify it."""
+    dash = "—"
+    lines = [
+        "%s complete %s %d requirements." % (entry["milestone"], dash, len(entry["requirements"])),
+        "",
+        "| Requirement | Issue | Pull request | Merge commit |",
+        "| --- | --- | --- | --- |",
+    ]
+    for row in entry["rows"]:
+        issue = (row.get("ISSUE") or "").strip()
+        pull = (row.get("PR") or "").strip()
+        commit = (row.get("MERGE_COMMIT") or "").strip()[:12]
+        lines.append(
+            "| `%s` | %s | %s | %s |" % (
+                row["REQ_ID"],
+                ("#" + issue) if issue else dash,
+                ("#" + pull) if pull else dash,
+                ("`%s`" % commit) if commit else dash,
+            )
+        )
+    lines += [
+        "",
+        "Milestone membership read from docs/zendev/milestones.json (source: %s)." % source,
+        "Generated from docs/spec/implementation_status.csv. No model was involved.",
+        "",
+        "coverage-digest: %s" % entry["digest"],
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def read_rows(path):
+    with io.open(path, encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def _git(args):
+    return subprocess.run(
+        ["git", *args], check=True, capture_output=True, text=True, encoding="utf-8"
+    ).stdout
+
+
+def parse_tag_listing(listing, milestones):
+    """Turn `git tag --list` output into {milestone: [(patch, digest)]}.
+
+    Kept pure so the version arithmetic can be tested without a repository.
+    """
+    found = {name: [] for name in milestones}
+    numbers = {milestone_number(name): name for name in milestones}
+    for block in (listing or "").split("\x00"):
+        if not block.strip():
+            continue
+        ref, _, body = block.partition("\t")
+        match = TAG.match(ref.strip())
+        if not match:
+            continue
+        name = numbers.get(int(match.group(1)))
+        if name is None:
+            continue
+        recorded = DIGEST_LINE.search(body or "")
+        found[name].append((int(match.group(2)), recorded.group(1) if recorded else ""))
+    return found
+
+
+def existing_tags(milestones):
+    listing = _git([
+        "tag", "--list", "v0.*",
+        "--format=%(refname:strip=2)%09%(contents)%00",
+    ])
+    return parse_tag_listing(listing, milestones)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    root = pathlib.Path(__file__).resolve().parents[1]
+    parser.add_argument(
+        "--status", default=str(root / "docs" / "spec" / "implementation_status.csv")
+    )
+    parser.add_argument(
+        "--milestones", default=str(root / "docs" / "zendev" / "milestones.json")
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    document = json.loads(pathlib.Path(args.milestones).read_text(encoding="utf-8"))
+    milestones = document["milestones"]
+    entries = plan(read_rows(args.status), milestones, existing_tags(milestones))
+
+    if not entries:
+        print("release-tag: no milestone is newly complete")
+        return 0
+
+    for entry in entries:
+        source = (document.get("source") or {}).get(entry["milestone"], "unknown")
+        body = notes(entry, source)
+        print("release-tag: %s (%s, digest %s)" % (entry["tag"], entry["milestone"], entry["digest"]))
+        if args.dry_run:
+            print(body)
+            continue
+        _git(["tag", "-a", entry["tag"], "-m", body])
+        _git(["push", "origin", entry["tag"]])
+        # The tag is the durable record; the release is presentation. A release that
+        # fails to create must not lose the tag that already pushed.
+        made = subprocess.run(
+            ["gh", "release", "create", entry["tag"],
+             "--title", "%s %s %s" % (entry["tag"], "—", entry["milestone"]),
+             "--notes", body],
+            check=False, capture_output=True, text=True, encoding="utf-8",
+        )
+        if made.returncode != 0:
+            print("::warning::release-tag: %s tagged, release not created: %s"
+                  % (entry["tag"], made.stderr.strip()[:200]))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/schemes.py
+++ b/scripts/schemes.py
@@ -1,0 +1,128 @@
+"""The setup the loop is running under, named and versioned so measurements compare.
+
+A day of telemetry is only comparable to another day if the system was the same on
+both. It usually was not: between 2026-09-05 and 2026-09-07 the identities changed,
+the per-run ceilings changed, and the ownership of the formal verdict changed. Each of
+those makes the earlier numbers numbers about a different system, and nothing in the
+ledger said so — the boundary lived in one person's memory.
+
+A **scheme** is that setup written down: roles and their identities, the model each
+role runs, who owns the verdict, which voices exist, the mandatory checks, the rework
+bound, the cadence. `docs/zendev/schemes.json` holds them, `scheme/N` tags the commit
+where each took effect, and every telemetry record carries `{id, digest}` so a window
+can be sliced by scheme without knowing a single date.
+
+## Why a digest, and what it can and cannot catch
+
+The digest is a hash of the active descriptor. Two records with the same `id` and
+different digests mean the descriptor was edited without the number moving — the
+failure that makes a named scheme worthless.
+
+It cannot, on its own, catch the descriptor drifting away from *reality*: a workflow
+edited to a different model while the descriptor still names the old one hashes the
+same. That is why `check_observed` exists and why the recorder calls it with what the
+run actually used. A claim the run itself contradicts is worth more than any hash.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import pathlib
+
+# The recorder runs from RUNNER_TEMP, not from the working tree: a reviewed branch
+# must not get its own copy of the recorder executed with the ledger credential in the
+# environment (see the staging step in zendev-acceptor.yml). The descriptor has to
+# travel the same way and for the same reason — read from the working tree it would be
+# whatever the branch under review says the setup is.
+#
+# So: an explicit path wins, then a copy staged beside this module, then the
+# repository's own. The last is the one that applies off the runner.
+def _default_path() -> pathlib.Path:
+    here = pathlib.Path(__file__).resolve().parent
+    candidates = [
+        os.environ.get("ZENDEV_SCHEMES_FILE", ""),
+        here / "schemes.json",
+        here.parent / "docs" / "zendev" / "schemes.json",
+    ]
+    for candidate in candidates:
+        if candidate and pathlib.Path(candidate).is_file():
+            return pathlib.Path(candidate)
+    return here.parent / "docs" / "zendev" / "schemes.json"
+
+# Keys that describe the setup. `note`, `_comment`, `in_force_from` and `commit` are
+# prose and bookkeeping: an operator filling in the commit of a merge must not change
+# the identity of the scheme, or every record written before that edit would look like
+# it belonged to a different one.
+DESCRIPTIVE_KEYS = (
+    "id", "roles", "verdict_owner", "voices",
+    "required_checks", "rework_limit", "cadence_minutes",
+)
+
+
+def load(path=None):
+    path = pathlib.Path(path) if path else _default_path()
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def active(document):
+    """The descriptor named by `active`, or None when it names nothing that exists."""
+    wanted = document.get("active")
+    for scheme in document.get("schemes", []):
+        if scheme.get("id") == wanted:
+            return scheme
+    return None
+
+
+def digest(scheme) -> str:
+    """A stable short hash of the descriptive part of a scheme.
+
+    Sorted keys and a compact separator, so re-indenting the file or reordering its
+    keys does not read as a change of setup — only the values do.
+    """
+    if not scheme:
+        return ""
+    subset = {key: scheme[key] for key in DESCRIPTIVE_KEYS if key in scheme}
+    canonical = json.dumps(subset, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:12]
+
+
+def stamp(path=None):
+    """`{"id": ..., "digest": ...}` for a telemetry record, or None if unreadable.
+
+    Never raises. A telemetry record with no scheme block is a small loss; a recorder
+    that dies because a JSON file is malformed loses the whole record, and the record
+    is the only evidence the run happened at all.
+    """
+    try:
+        scheme = active(load(path))
+    except (OSError, ValueError):
+        return None
+    if not scheme:
+        return None
+    return {"id": scheme["id"], "digest": digest(scheme)}
+
+
+def check_observed(scheme, role: str, model: str):
+    """Say why the run contradicts the descriptor, or None when it does not.
+
+    Only checks what a run can actually observe about itself. A run with no model —
+    a role that found no work — observes nothing and contradicts nothing.
+    """
+    if not scheme or not model:
+        return None
+    declared = ((scheme.get("roles") or {}).get(role) or {}).get("model")
+    if not declared:
+        return None
+    # The workflow pins an alias (`claude-haiku-4-5`); the result names the exact build
+    # (`claude-haiku-4-5-20251001`). The alias is the claim, so a prefix match is the
+    # honest comparison — an exact one would report drift on every ordinary run.
+    if model == declared or model.startswith(declared + "-"):
+        return None
+    return f"{scheme['id']} declares {role} on {declared}, the run used {model}"
+
+
+def milestone_map(document):
+    """Milestone -> the requirement ids it gates. Empty when the file carries none."""
+    return {name: list(ids) for name, ids in (document.get("milestones") or {}).items()}

--- a/scripts/tests/test_release_tag.py
+++ b/scripts/tests/test_release_tag.py
@@ -1,0 +1,163 @@
+"""What may be released, and what the milestone map must keep true.
+
+The last test is the important one: it is the only thing standing between a
+requirement the researcher adds and a milestone gate that silently never covers it.
+"""
+
+import csv
+import io
+import json
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import release_tag  # noqa: E402
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+MILESTONES = ROOT / "docs" / "zendev" / "milestones.json"
+REGISTRY = ROOT / "docs" / "spec" / "mirror" / "REQUIREMENTS_REGISTRY.csv"
+STATUS = ROOT / "docs" / "spec" / "implementation_status.csv"
+
+MAP = {"M0": ["REQ-A", "REQ-B"], "M1": ["REQ-C"]}
+
+
+def row(req_id, status="IMPLEMENTED", commit="abc123", issue="1", pull="2"):
+    return {"REQ_ID": req_id, "STATUS": status, "ISSUE": issue, "PR": pull,
+            "MERGE_COMMIT": commit, "EVIDENCE": ""}
+
+
+class CompletenessTests(unittest.TestCase):
+    def test_all_implemented_is_complete(self):
+        self.assertTrue(release_tag.complete([row("REQ-A"), row("REQ-B")], MAP["M0"]))
+
+    def test_one_partial_row_is_not_complete(self):
+        # REQ-CONFIG-003 and REQ-CONFIG-004 sat at PARTIAL for a day after post-merge
+        # QA. A milestone containing them is not released.
+        rows = [row("REQ-A"), row("REQ-B", status="PARTIAL")]
+        self.assertFalse(release_tag.complete(rows, MAP["M0"]))
+
+    def test_a_missing_row_is_not_complete(self):
+        # The ledger gains a row when work lands, so absent and not-done are the same
+        # fact. Treating absence as success would release unstarted work.
+        self.assertFalse(release_tag.complete([row("REQ-A")], MAP["M0"]))
+
+    def test_status_is_read_case_and_space_insensitively(self):
+        rows = [row("REQ-A", status=" implemented "), row("REQ-B")]
+        self.assertTrue(release_tag.complete(rows, MAP["M0"]))
+
+
+class PlanTests(unittest.TestCase):
+    def test_a_newly_complete_milestone_is_tagged_from_zero(self):
+        got = release_tag.plan([row("REQ-A"), row("REQ-B")], {"M0": MAP["M0"]}, {})
+        self.assertEqual([entry["tag"] for entry in got], ["v0.0.0"])
+
+    def test_an_unchanged_milestone_is_not_re_tagged(self):
+        # The job runs on every push to master. Same coverage, same digest, no tag.
+        rows = [row("REQ-A"), row("REQ-B")]
+        digest = release_tag.coverage_digest(rows)
+        got = release_tag.plan(rows, {"M0": MAP["M0"]}, {"M0": [(0, digest)]})
+        self.assertEqual(got, [])
+
+    def test_a_milestone_satisfied_by_different_commits_earns_a_patch(self):
+        # M1 was reached, two rows went back to PARTIAL, repairs landed at new
+        # commits. The old tag stands; a patch is cut beside it.
+        before = [row("REQ-A"), row("REQ-B")]
+        after = [row("REQ-A"), row("REQ-B", commit="def456")]
+        got = release_tag.plan(
+            after, {"M0": MAP["M0"]}, {"M0": [(0, release_tag.coverage_digest(before))]}
+        )
+        self.assertEqual([entry["tag"] for entry in got], ["v0.0.1"])
+
+    def test_the_patch_counts_from_the_highest_existing_tag(self):
+        got = release_tag.plan(
+            [row("REQ-A"), row("REQ-B")], {"M0": MAP["M0"]},
+            {"M0": [(0, "stale"), (1, "alsostale")]},
+        )
+        self.assertEqual([entry["tag"] for entry in got], ["v0.0.2"])
+
+    def test_row_order_in_the_ledger_does_not_look_like_a_re_release(self):
+        forward = [row("REQ-A"), row("REQ-B")]
+        reversed_ = [row("REQ-B"), row("REQ-A")]
+        self.assertEqual(
+            release_tag.coverage_digest(forward), release_tag.coverage_digest(reversed_)
+        )
+
+    def test_an_incomplete_milestone_yields_nothing(self):
+        rows = [row("REQ-A"), row("REQ-B"), row("REQ-C", status="PARTIAL")]
+        got = release_tag.plan(rows, MAP, {})
+        self.assertEqual([entry["tag"] for entry in got], ["v0.0.0"])
+
+
+class TagListingTests(unittest.TestCase):
+    def test_the_digest_is_read_out_of_a_tag_message(self):
+        listing = (
+            "v0.0.0\tM0 complete.\n\ncoverage-digest: 7323469a3507b253\n\x00"
+            "v0.1.0\tM1 complete.\n\ncoverage-digest: aaaabbbbccccdddd\n\x00"
+        )
+        got = release_tag.parse_tag_listing(listing, MAP)
+        self.assertEqual(got["M0"], [(0, "7323469a3507b253")])
+        self.assertEqual(got["M1"], [(0, "aaaabbbbccccdddd")])
+
+    def test_a_tag_without_a_digest_still_holds_its_patch_number(self):
+        # A tag cut by hand blocks nothing, but the next patch must still clear it.
+        got = release_tag.parse_tag_listing("v0.0.0\tcut by hand\x00", MAP)
+        self.assertEqual(got["M0"], [(0, "")])
+        self.assertEqual(release_tag.next_patch(got["M0"]), 1)
+
+    def test_tags_that_are_not_releases_are_ignored(self):
+        # scheme/N marks a change of operating setup and shares the tag namespace.
+        listing = "scheme/3\tverdict ownership\x00v1.2.3\tnot ours\x00"
+        got = release_tag.parse_tag_listing(listing, MAP)
+        self.assertEqual(got, {"M0": [], "M1": []})
+
+
+class TheRepositorysOwnMapTests(unittest.TestCase):
+    """The map is data about the specification, and the specification changes."""
+
+    def test_every_requirement_in_the_registry_is_mapped_exactly_once(self):
+        # This is the guard. The researcher adds requirements through the mirror, and
+        # one that belongs to no milestone is covered by no gate and would never
+        # appear in any release — silently. Failing here is how that gets noticed.
+        document = json.loads(MILESTONES.read_text(encoding="utf-8"))
+        placed = [
+            req_id
+            for ids in document["milestones"].values()
+            for req_id in ids
+        ] + list(document["unassigned"])
+
+        self.assertEqual(
+            len(placed), len(set(placed)), "a requirement is mapped to two milestones"
+        )
+
+        with io.open(REGISTRY, encoding="utf-8", newline="") as handle:
+            registry = {r["REQ_ID"] for r in csv.DictReader(handle)}
+
+        self.assertEqual(
+            registry - set(placed), set(),
+            "requirements in the registry that no milestone claims",
+        )
+        self.assertEqual(
+            set(placed) - registry, set(),
+            "milestones claiming requirements the registry does not have",
+        )
+
+    def test_the_ledger_only_carries_requirements_the_registry_knows(self):
+        with io.open(REGISTRY, encoding="utf-8", newline="") as handle:
+            registry = {r["REQ_ID"] for r in csv.DictReader(handle)}
+        self.assertEqual(
+            {r["REQ_ID"] for r in release_tag.read_rows(STATUS)} - registry, set()
+        )
+
+    def test_the_map_names_a_source_for_every_milestone(self):
+        # M1 and M2 are read off prose, and a release must be able to say so.
+        document = json.loads(MILESTONES.read_text(encoding="utf-8"))
+        self.assertEqual(
+            set(document["milestones"]), set(document["source"]),
+            "every milestone must declare whether its membership is explicit or prose",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_schemes.py
+++ b/scripts/tests/test_schemes.py
@@ -1,0 +1,124 @@
+"""The scheme a run was under, and the two ways that claim can go wrong.
+
+A day of telemetry compares to another day only if the setup was the same. Between
+2026-09-05 and 2026-09-07 the identities, the per-run ceilings and the ownership of
+the verdict all changed, and nothing in the ledger said so.
+"""
+
+import json
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import schemes  # noqa: E402
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+FILE = ROOT / "docs" / "zendev" / "schemes.json"
+
+ONE = {
+    "id": "scheme/1",
+    "roles": {"author": {"identity": "a[bot]", "model": "claude-haiku-4-5",
+                         "max_budget_usd": 3.0}},
+    "verdict_owner": "any account",
+    "voices": [],
+    "required_checks": ["build-and-test"],
+    "rework_limit": 3,
+    "cadence_minutes": 25,
+    "note": "prose that must not affect the digest",
+    "in_force_from": "2026-09-05T18:40:00Z",
+    "commit": "",
+}
+
+
+class DigestTests(unittest.TestCase):
+    def test_prose_and_bookkeeping_do_not_change_the_identity_of_a_scheme(self):
+        # An operator filling in the commit of the merge that put a scheme in force
+        # must not make every record written before that edit look like another one.
+        edited = dict(ONE, note="rewritten later", commit="5c9f9ec",
+                      in_force_from="2026-09-06T11:43:00Z")
+        self.assertEqual(schemes.digest(ONE), schemes.digest(edited))
+
+    def test_a_changed_ceiling_is_a_different_scheme(self):
+        raised = json.loads(json.dumps(ONE))
+        raised["roles"]["author"]["max_budget_usd"] = 5.0
+        self.assertNotEqual(schemes.digest(ONE), schemes.digest(raised))
+
+    def test_a_changed_verdict_owner_is_a_different_scheme(self):
+        owned = dict(ONE, verdict_owner="zendev-acceptor")
+        self.assertNotEqual(schemes.digest(ONE), schemes.digest(owned))
+
+    def test_reformatting_the_file_is_not_a_change(self):
+        reordered = {key: ONE[key] for key in reversed(list(ONE))}
+        self.assertEqual(schemes.digest(ONE), schemes.digest(reordered))
+
+
+class ObservedDriftTests(unittest.TestCase):
+    """The hash cannot see the descriptor drifting from reality. This can."""
+
+    def test_the_pinned_alias_matches_the_exact_build_the_run_reports(self):
+        # The workflow pins `claude-haiku-4-5`; the result names
+        # `claude-haiku-4-5-20251001`. An exact comparison would cry drift every run.
+        self.assertIsNone(
+            schemes.check_observed(ONE, "author", "claude-haiku-4-5-20251001")
+        )
+
+    def test_a_different_model_is_reported(self):
+        message = schemes.check_observed(ONE, "author", "claude-sonnet-5")
+        self.assertIn("scheme/1", message)
+        self.assertIn("claude-sonnet-5", message)
+
+    def test_a_run_with_no_model_contradicts_nothing(self):
+        # A role that found no work observes nothing about itself.
+        self.assertIsNone(schemes.check_observed(ONE, "acceptor", ""))
+
+    def test_a_role_the_scheme_does_not_describe_is_not_drift(self):
+        self.assertIsNone(schemes.check_observed(ONE, "machine", "claude-haiku-4-5"))
+
+
+class StampTests(unittest.TestCase):
+    def test_an_unreadable_file_costs_the_block_not_the_record(self):
+        # The telemetry record is the only evidence a run happened. A recorder that
+        # dies on a malformed JSON file loses that, which is far worse than a record
+        # with no scheme block.
+        self.assertIsNone(schemes.stamp(ROOT / "docs" / "zendev" / "no-such-file.json"))
+
+    def test_the_repositorys_own_file_produces_a_stamp(self):
+        stamp = schemes.stamp(FILE)
+        self.assertIsNotNone(stamp)
+        self.assertTrue(stamp["id"].startswith("scheme/"))
+        self.assertEqual(len(stamp["digest"]), 12)
+
+
+class TheRepositorysOwnSchemesTests(unittest.TestCase):
+    def test_the_active_scheme_exists(self):
+        document = schemes.load(FILE)
+        self.assertIsNotNone(
+            schemes.active(document),
+            "`active` names a scheme that is not in the file",
+        )
+
+    def test_scheme_ids_are_unique_and_numbered_without_gaps(self):
+        ids = [scheme["id"] for scheme in schemes.load(FILE)["schemes"]]
+        self.assertEqual(len(ids), len(set(ids)))
+        numbers = [int(name.split("/")[1]) for name in ids]
+        self.assertEqual(numbers, list(range(1, len(numbers) + 1)))
+
+    def test_every_scheme_declares_who_owns_the_verdict(self):
+        # The field this whole exercise exists to make explicit.
+        for scheme in schemes.load(FILE)["schemes"]:
+            with self.subTest(scheme=scheme["id"]):
+                self.assertTrue((scheme.get("verdict_owner") or "").strip())
+
+    def test_every_scheme_carries_every_descriptive_key(self):
+        # A scheme missing one hashes as if the field were absent everywhere, so two
+        # genuinely different setups could share a digest.
+        for scheme in schemes.load(FILE)["schemes"]:
+            for key in schemes.DESCRIPTIVE_KEYS:
+                with self.subTest(scheme=scheme["id"], key=key):
+                    self.assertIn(key, scheme)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #262

## Goal

Two gaps the measured day exposed: a telemetry record cannot say which setup produced
it, and the repository has no tags at all despite the roadmap being versioned.

## Evidence

Between 2026-09-05 18:40Z and 2026-09-07 the loop ran under at least three different
setups — the three GitHub Apps went live, the per-run ceilings were raised in #213, and
#257 moves ownership of the verdict. Comparing "yesterday" to "today" therefore compares
different systems, and nothing in 330 ledger records says so.

`git tag` is empty. What shipped at M0 is answerable only by reading merge history.

## Scope — every changed path

- `docs/zendev/schemes.json` — new. `scheme/1..4` descriptors; `active` names the one
  in force.
- `scripts/schemes.py` — new. Load, digest the descriptive fields, stamp a record,
  and `check_observed` for descriptor-vs-reality drift.
- `scripts/record_usage.py` — writes `scheme: {id, digest}` into every record; warns
  and marks `matches_observed: false` when the run's model contradicts the descriptor.
- `.github/workflows/zendev-author.yml`, `.github/workflows/zendev-acceptor.yml` —
  stage `schemes.py` and `schemes.json` into `RUNNER_TEMP` beside the recorder.
- `docs/zendev/milestones.json` — new. Milestone → requirements, with a per-milestone
  `source` of `explicit` or `prose`.
- `scripts/release_tag.py` — new. `v0.<milestone>.<patch>` from the ledger.
- `.github/workflows/release-tag.yml` — new. On push to master touching the ledger or
  the map. MACHINE identity, no model.
- `scripts/tests/test_schemes.py`, `scripts/tests/test_release_tag.py` — new, 29 tests.
- `docs/spec/FEEDBACK_TO_RESEARCHER.md` — the request for a `MILESTONE` column in
  `REQUIREMENTS_REGISTRY.csv`, and what the transcription costs until it lands.

## Non-goals

Cuts no tag in this pull request. `scheme/1` and `scheme/2` are retrospective and get
their tags from the operator; `scheme/3` is filled in at the merge of #257. Does not
change any model, ceiling, cadence or gate — the descriptors record what is already
true.

## Acceptance criteria

- Filling in a scheme's `commit` or rewriting its `note` does not change its digest;
  changing a ceiling, the verdict owner or a required check does.
- A run whose model contradicts the active scheme is recorded, warned about, and
  marked — not dropped.
- An unreadable `schemes.json` costs the scheme block, never the record.
- A milestone with one PARTIAL or one missing row is not released.
- The same coverage does not re-tag; different merge commits behind the same milestone
  cut the next patch.
- `scheme/N` tags are ignored by the release tagger.
- Every requirement in `REQUIREMENTS_REGISTRY.csv` belongs to exactly one milestone, or
  the build fails.

## Verification

```
python -m unittest discover -s scripts/tests   →  Ran 370 tests … OK
python scripts/release_tag.py --dry-run        →  v0.0.0 (M0, digest 7323469a3507b253)
```

Staged-recorder path checked by copying `record_usage.py`, `schemes.py` and
`schemes.json` into a bare directory and running it there: `scheme` block present.

## Open dependency on the researcher

Milestone membership for M1 and M2 is read off prose in `EXECUTION_ORDER.md`;
`REQUIREMENTS_REGISTRY.csv` has no `MILESTONE` column. The request goes in the
feedback channel. When the column lands, `milestones.json` is deleted and the tagger
reads the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

