### PR TITLE
Let the release tagger push, and stop hiding git's reason

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -31,9 +31,14 @@ jobs:
     steps:
       # Tags are the state this job reads, so it needs all of them, and it needs
       # history to push one.
+      # persist-credentials: false is load-bearing. checkout leaves an
+      # http.extraheader carrying GITHUB_TOKEN, which this workflow deliberately
+      # grants no permissions at all, and that header wins over a token in the remote
+      # URL. The first run cut v0.0.0 locally and died on the push with exit 128.
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-python@v7
         with:

--- a/docs/zendev/schemes.json
+++ b/docs/zendev/schemes.json
@@ -51,8 +51,8 @@
     },
     {
       "id": "scheme/3",
-      "in_force_from": "",
-      "commit": "",
+      "in_force_from": "2026-09-07T18:04:02Z",
+      "commit": "39cca61d",
       "summary": "The ACCEPTOR identity alone owns the formal verdict; every other account's review is evidence.",
       "roles": {
         "author": {"identity": "zendev-author[bot]", "model": "claude-haiku-4-5", "max_budget_usd": 5.0},
@@ -64,7 +64,7 @@
       "required_checks": ["build-and-test", "typescript", "policy-guard", "mergeability"],
       "rework_limit": 3,
       "cadence_minutes": 25,
-      "note": "In force from the merge of the verdict-ownership pull request. `in_force_from` and `commit` are filled by the operator at that merge."
+      "note": "In force from the merge of #257. Neither `in_force_from` nor `commit` is a descriptive key, so filling them in here does not change the digest and does not retroactively move the records already written under this scheme."
     },
     {
       "id": "scheme/4",

--- a/scripts/release_tag.py
+++ b/scripts/release_tag.py
@@ -144,9 +144,21 @@ def read_rows(path):
 
 
 def _git(args):
-    return subprocess.run(
-        ["git", *args], check=True, capture_output=True, text=True, encoding="utf-8"
-    ).stdout
+    """Run git, and on failure say what git said.
+
+    The first live run died on `git push origin v0.0.0` with exit 128 and printed
+    nothing but the exit code: `check=True` raises CalledProcessError, whose str() does
+    not include stderr. The cause was one line of git output that never reached the log.
+    """
+    done = subprocess.run(
+        ["git", *args], capture_output=True, text=True, encoding="utf-8"
+    )
+    if done.returncode != 0:
+        raise RuntimeError(
+            "git %s failed (%d): %s"
+            % (" ".join(args), done.returncode, (done.stderr or done.stdout).strip())
+        )
+    return done.stdout
 
 
 def parse_tag_listing(listing, milestones):


### PR DESCRIPTION
Closes #265

## Goal

Let the release tagger push the tag it cuts, and report git's own error when it cannot.

## Evidence

First live run, on the merge of #259:

```
release-tag: v0.0.0 (M0, digest 7323469a3507b253)
subprocess.CalledProcessError: Command '['git', 'push', 'origin', 'v0.0.0']'
returned non-zero exit status 128
```

`actions/checkout` leaves an `http.extraheader` carrying `GITHUB_TOKEN`; the workflow
declares `permissions: {}` on purpose, so that credential can do nothing, and it wins
over the app token in the remote URL. `CalledProcessError` does not carry stderr, so
git's one-line reason never reached the log.

## Scope — every changed path

- `.github/workflows/release-tag.yml` — `persist-credentials: false` on checkout.
- `scripts/release_tag.py` — `_git` raises with git's stderr.
- `docs/zendev/schemes.json` — `scheme/3` records `in_force_from` 2026-09-07T18:04:02Z
  and commit `39cca61d`, the merge of #257.

## Non-goals

Widening the job's permissions. It still declares `permissions: {}` and acts only
through the MACHINE app token.

## Acceptance criteria

- The tagger pushes `v0.0.0` and creates its release on a rerun.
- A failing git command reports git's own stderr.
- Filling in `scheme/3`'s commit does not change its digest.

## Verification

```
python -m unittest discover -s scripts/tests   →  Ran 395 tests … OK
```

Digest before and after the `schemes.json` edit: `f388453edf68` both times — the
property `in_force_from` and `commit` were excluded from the digest to provide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)