### PR TITLE
End pull requests no run can reach any more

### DIFF
--- a/.github/workflows/zendev-acceptor.yml
+++ b/.github/workflows/zendev-acceptor.yml
@@ -252,6 +252,23 @@ jobs:
             --pull "${{ steps.select.outputs.target }}" \
             --reviewer "${{ steps.identity.outputs.app-slug }}"
 
+      # The other way a branch stops. The bound above ends the loud failure — three
+      # refusals — and this ends the quiet one: a pull request nothing has advanced for
+      # a day that no review run can select either. Over 2026-09-06/07 four of those
+      # accumulated and every one had to be found by a person and closed by hand.
+      #
+      # Runs on every acceptor tick, including the ones with no review target: a queue
+      # with nothing selectable is exactly when this has work to do. It closes nothing
+      # a run could still pick up, nothing a person has claimed with
+      # status:needs-decision, no draft and no machine branch.
+      - name: End pull requests no run can reach any more
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ZENDEV_STALE_PR_HOURS: ${{ vars.ZENDEV_STALE_PR_HOURS }}
+        run: |
+          python "${RUNNER_TEMP}/control-plane/stale_pull_requests.py"             --repo "${{ github.repository }}"             --acceptor "${{ steps.identity.outputs.app-slug }}"
+
       # The ledger lives in a private repository and is written by the MACHINE identity.
       # Its token is minted here, at the end, scoped to that repository alone: the model
       # never holds it. A failed mint is a gap in the bookkeeping, not a failed run.

--- a/scripts/rework_limit.py
+++ b/scripts/rework_limit.py
@@ -191,12 +191,27 @@ def issue_status_labels(repo: str, issue: int):
     return [label["name"] for label in json.loads(raw).get("labels", []) if label["name"].startswith("status:")]
 
 
-def close_out(repo: str, pull, refusals, limit: int) -> None:
+def retire(repo: str, pull, pull_comment: str, issue_comment) -> None:
+    """End a pull request and return its Issue to the queue.
+
+    The mechanics of a pull request dying: say why on the pull request, close it,
+    delete the loop's branch, move the Issue back to `status:ready` carrying exactly
+    one status label, and say why there too.
+
+    The words are the caller's, because there is more than one reason a branch should
+    stop — the rework bound below, and a branch no run can reach any more
+    (`stale_pull_requests.py`) — but there must be only one way it happens. Two
+    closers would drift, and the second one to drift would be the one that forgets to
+    return the Issue, which is how work disappears.
+
+    `issue_comment` is a callable taking the Issue number, since what to say about an
+    Issue usually names it.
+    """
     number = pull["number"]
     head_ref = pull.get("headRefName") or ""
     issue = linked_issue(pull.get("body"), head_ref)
 
-    _gh(["pr", "comment", str(number), "--repo", repo, "--body", summary(pull, refusals, limit, issue)])
+    _gh(["pr", "comment", str(number), "--repo", repo, "--body", pull_comment])
     close = ["pr", "close", str(number), "--repo", repo]
     if head_ref.startswith(LOOP_PREFIX):
         close.append("--delete-branch")
@@ -204,12 +219,24 @@ def close_out(repo: str, pull, refusals, limit: int) -> None:
 
     if issue is None:
         return
+    # Exactly one status label survives. An Issue carrying two is #214, which happened
+    # three times in two days and needed an operator every time.
     args = ["issue", "edit", str(issue), "--repo", repo, "--add-label", STATUS_READY]
     for label in issue_status_labels(repo, issue):
         if label != STATUS_READY:
             args += ["--remove-label", label]
     _gh(args)
-    _gh(["issue", "comment", str(issue), "--repo", repo, "--body", issue_note(pull, refusals, limit)])
+    _gh(["issue", "comment", str(issue), "--repo", repo, "--body", issue_comment(issue)])
+
+
+def close_out(repo: str, pull, refusals, limit: int) -> None:
+    issue = linked_issue(pull.get("body"), pull.get("headRefName") or "")
+    retire(
+        repo,
+        pull,
+        summary(pull, refusals, limit, issue),
+        lambda _issue: issue_note(pull, refusals, limit),
+    )
 
 
 def main() -> int:

--- a/scripts/stale_pull_requests.py
+++ b/scripts/stale_pull_requests.py
@@ -1,0 +1,258 @@
+"""Close a pull request no run can reach any more, and return its work to the queue.
+
+Over 2026-09-06 and 07 the loop accumulated pull requests that nothing would ever
+touch again: #208 carried the ACCEPTOR's own ACCEPT on a head branch protection would
+not merge; #223 was refused, then labelled for a human, then went dirty; #238 sat clean
+and approved with no run able to select it; #242 was quietly superseded by a duplicate.
+Two thirds of a measured day's spend sat in that pile. Every one of them had to be
+found by a person and ended by hand.
+
+The rework bound already ends the loud failure: three refusals and the branch stops.
+This ends the quiet one.
+
+## Age is the symptom; unreachability is the disease
+
+"Close pull requests older than a day" is the obvious rule and the wrong one. A pull
+request can be a day old and perfectly healthy — three review rounds at half an hour
+each, plus the time an AUTHOR run needs to answer them, is normal — while a pull
+request can become unreachable within an hour and never recover.
+
+So the test is two-part, and both halves must hold:
+
+* **nothing has advanced it** for the window (default 24 hours), and
+* **no review run could select it right now** — `select_review_target.eligible` says no.
+
+The second half is what makes this safe. A pull request a run could pick up is not
+stuck, it is queued, however old it is; closing it would punish a busy queue. And every
+pull request in the pile above was ineligible for hours before anyone noticed.
+
+## What counts as advancing it
+
+The head moved, the ACCEPTOR posted a verdict, or the pull request's own author
+commented. Nothing else.
+
+A comment from a third party — the QA voice, an operator, the researcher — is evidence,
+not progress, exactly as it is for a verdict. This is deliberate and it is the same rule
+the rest of the loop now follows: a voice that cannot move a pull request cannot keep it
+alive either. Otherwise an hourly QA run would hold every dead branch open forever,
+which is the failure this exists to end, arriving by a politer road.
+
+## What it will not close
+
+* Machine-generated pull requests. `stale_mirror_pr.py` owns those, with a much shorter
+  fuse, and two closers on one class would drift.
+* Drafts. Unfinished is not stuck.
+* Anything labelled `status:needs-decision`. That label means a person took the
+  decision, and a job that overrides it is not a bound, it is a race with the operator.
+  These are reported loudly instead — an untouched one is the operator's queue, and
+  saying so is this job's other half.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import subprocess
+import sys
+
+import machine_pr_guard
+import rework_limit
+import select_review_target as select
+
+DEFAULT_HOURS = 24
+HUMAN_OWNED_LABEL = select.HUMAN_OWNED_LABEL
+
+
+def parse_time(value):
+    """GitHub timestamps, as aware datetimes. Unreadable reads as the epoch.
+
+    A timestamp that cannot be parsed must not make a pull request look freshly
+    touched: the safe direction is "old", because the eligibility half of the test still
+    has to agree before anything closes.
+    """
+    try:
+        return dt.datetime.fromisoformat((value or "").replace("Z", "+00:00"))
+    except ValueError:
+        return dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+
+
+def last_progress(pull, head_committed_at, acceptor=""):
+    """When this pull request last moved, by the definition in the module docstring."""
+    author = select.normalize_login((pull.get("author") or {}).get("login"))
+    moments = [parse_time(head_committed_at)]
+
+    for comment in pull.get("comments") or []:
+        if select.is_the_authors(
+            {"author": (comment.get("author") or {}).get("login")}, author
+        ):
+            moments.append(parse_time(comment.get("createdAt")))
+
+    for review in pull.get("reviews") or []:
+        entry = {
+            "author": (review.get("author") or {}).get("login"),
+            "state": review.get("state"),
+            "body": review.get("body"),
+            "createdAt": review.get("submittedAt"),
+        }
+        if select.is_verdict_entry(entry, acceptor):
+            moments.append(parse_time(review.get("submittedAt")))
+
+    # A verdict the ACCEPTOR posted as a comment counts the same as a formal one: which
+    # shape it takes is an accident of GitHub's same-account rule, not of meaning.
+    if acceptor:
+        for comment in pull.get("comments") or []:
+            entry = {
+                "author": (comment.get("author") or {}).get("login"),
+                "state": None,
+                "body": comment.get("body"),
+                "createdAt": comment.get("createdAt"),
+            }
+            if select.is_verdict_entry(entry, acceptor):
+                moments.append(parse_time(comment.get("createdAt")))
+
+    return max(moments)
+
+
+def verdict(pull, head_committed_at, now, hours, eligible_now, acceptor=""):
+    """Return (action, reason). Pure: no network, no clock of its own.
+
+    action is one of "close", "report", "keep".
+    """
+    if pull.get("isDraft"):
+        return "keep", "draft: unfinished is not stuck"
+
+    machine = machine_pr_guard.classify(pull.get("headRefName") or "")
+    if machine is not None:
+        return "keep", f"{machine.branch} is machine-generated; stale_mirror_pr.py owns it"
+
+    idle_hours = (now - last_progress(pull, head_committed_at, acceptor)).total_seconds() / 3600
+    if idle_hours < hours:
+        return "keep", f"advanced {idle_hours:.1f}h ago, inside the {hours}h window"
+
+    if eligible_now:
+        return "keep", f"idle {idle_hours:.1f}h but a review run can select it: queued, not stuck"
+
+    labels = {label["name"] for label in pull.get("labels") or []}
+    if HUMAN_OWNED_LABEL in labels:
+        return "report", (
+            f"idle {idle_hours:.1f}h and unreachable, but {HUMAN_OWNED_LABEL} means a "
+            "person owns this decision"
+        )
+
+    return "close", f"idle {idle_hours:.1f}h and no review run can select it"
+
+
+def summary(pull, reason: str, hours: int, issue) -> str:
+    lines = [
+        "## Closed as unreachable",
+        "",
+        f"Closed by the forge, not by a reviewer: {reason}.",
+        "",
+        "Two things had to be true at once. Nothing has advanced this pull request for "
+        f"{hours} hours — no commit on its head, no verdict from the ACCEPTOR, no "
+        "comment from its own author — and no review run can select it as it stands, so "
+        "nothing was going to change that on its own.",
+        "",
+        "This is not a judgement about the change. The commits stay reachable from this "
+        "pull request and the record below stays readable.",
+    ]
+    if issue is not None:
+        lines += [
+            "",
+            f"Issue #{issue} returns to `{rework_limit.STATUS_READY}`. The next AUTHOR run "
+            "starts from `master`; a branch this far behind costs more to revive than to "
+            "rewrite, which is what the queue kept proving.",
+        ]
+    else:
+        lines += [
+            "",
+            "No linked Issue could be read from the body or the branch name, so a person "
+            "decides what returns to the queue.",
+        ]
+    return "\n".join(lines)
+
+
+def issue_note(pull, reason: str, hours: int):
+    def note(issue: int) -> str:
+        return (
+            "## Returned to the queue by the forge\n\n"
+            f"Pull request {pull.get('url')} was closed as unreachable: {reason}. Nothing "
+            f"had advanced it for {hours} hours and no review run could select it.\n\n"
+            "Its commits remain reachable from that pull request; its branch is gone. "
+            "Start from `master`, and read the pull request first — whatever was already "
+            "solved there is worth carrying over, and whatever refused it is worth not "
+            "repeating."
+        )
+    return note
+
+
+def _gh(args):
+    return subprocess.run(
+        ["gh", *args], check=True, capture_output=True, text=True, encoding="utf-8"
+    ).stdout
+
+
+def load_pulls(repo: str):
+    raw = _gh([
+        "pr", "list", "--repo", repo, "--state", "open", "--limit", "100", "--json",
+        "number,createdAt,updatedAt,isDraft,labels,headRefName,headRefOid,"
+        "statusCheckRollup,author,url,body,comments,reviews",
+    ])
+    return json.loads(raw)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="owner/name")
+    parser.add_argument("--acceptor", default="", help="login of the ACCEPTOR identity")
+    parser.add_argument(
+        "--hours", type=int, default=int(os.environ.get("ZENDEV_STALE_PR_HOURS") or DEFAULT_HOURS),
+        help="hours without progress before an unreachable pull request is closed",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    now = dt.datetime.now(dt.timezone.utc)
+    closed = 0
+    for pull in load_pulls(args.repo):
+        number = pull["number"]
+        committed_at = select.head_commit_date(args.repo, pull["headRefOid"])
+        eligible_now, _ = select.eligible(
+            pull, committed_at, select.load_comments(args.repo, number), args.acceptor
+        )
+        action, reason = verdict(
+            pull, committed_at, now, args.hours, eligible_now, args.acceptor
+        )
+        print(f"  #{number} {action}: {reason}")
+
+        if action == "report":
+            # Not a failure of the loop, and not this job's to resolve — but a pull
+            # request a person owns and has not touched in a day is the one thing here
+            # nothing else will ever surface.
+            print(f"::warning::#{number} waits on a person: {reason}")
+        if action != "close" or args.dry_run:
+            continue
+
+        issue = rework_limit.linked_issue(pull.get("body"), pull.get("headRefName") or "")
+        try:
+            rework_limit.retire(
+                args.repo,
+                pull,
+                summary(pull, reason, args.hours, issue),
+                issue_note(pull, reason, args.hours),
+            )
+            closed += 1
+        except subprocess.CalledProcessError as error:
+            # One pull request failing to close must not stop the rest, and must not
+            # fail the run that hosts this: the queue is still better off than before.
+            print(f"::warning::stale-pull-requests: closing #{number} failed: "
+                  f"{type(error).__name__}")
+
+    print(f"stale-pull-requests: closed {closed}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_stale_pull_requests.py
+++ b/scripts/tests/test_stale_pull_requests.py
@@ -1,0 +1,150 @@
+"""When a pull request no run can reach is ended, and when it is left alone.
+
+Each closing test replays a pull request that actually accumulated in the queue on
+2026-09-06/07 and had to be ended by hand. Each keeping test is a way this bound could
+destroy work that was fine.
+"""
+
+import datetime as dt
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import stale_pull_requests as stale  # noqa: E402
+
+NOW = dt.datetime(2026, 9, 8, 12, 0, tzinfo=dt.timezone.utc)
+HOURS = 24
+ACCEPTOR = "zendev-acceptor"
+OLD = "2026-09-06T10:00:00Z"   # 50 hours before NOW
+RECENT = "2026-09-08T06:00:00Z"  # 6 hours before NOW
+
+
+def pull(number=208, draft=False, labels=(), head_ref="claude/issue-201-config-004",
+         author="app/zendev-author", comments=(), reviews=()):
+    return {
+        "number": number,
+        "isDraft": draft,
+        "labels": [{"name": name} for name in labels],
+        "headRefName": head_ref,
+        "headRefOid": "20045a28" + "0" * 32,
+        "author": {"login": author},
+        "url": f"https://github.com/drevendev/trade_simulation/pull/{number}",
+        "body": f"Closes #{number - 8}",
+        "comments": [{"body": b, "createdAt": t, "author": {"login": who}}
+                     for b, t, who in comments],
+        "reviews": [{"body": b, "submittedAt": t, "state": s, "author": {"login": who}}
+                    for b, t, s, who in reviews],
+    }
+
+
+def call(p, committed=OLD, eligible=False, hours=HOURS):
+    return stale.verdict(p, committed, NOW, hours, eligible, ACCEPTOR)
+
+
+class ClosesWhatNothingCanReachTests(unittest.TestCase):
+    def test_208_accepted_on_a_head_that_cannot_merge(self):
+        # The ACCEPTOR's own ACCEPT sat on the head, so no run would select it again;
+        # branch protection would not merge it. 36 hours, ended by hand.
+        action, reason = call(pull(reviews=[
+            ("", "2026-09-06T10:03:14Z", "CHANGES_REQUESTED", ACCEPTOR),
+        ]))
+        self.assertEqual(action, "close")
+        self.assertIn("no review run can select it", reason)
+
+    def test_242_quietly_superseded_by_a_duplicate(self):
+        action, _ = call(pull(number=242, head_ref="claude/issue-240-acceptance-003"))
+        self.assertEqual(action, "close")
+
+    def test_the_window_is_measured_from_the_head_not_from_the_opening(self):
+        # A pull request opened days ago whose head moved an hour ago is working.
+        action, reason = call(pull(), committed=RECENT)
+        self.assertEqual(action, "keep")
+        self.assertIn("inside the", reason)
+
+
+class RefusesToDestroyWorkTests(unittest.TestCase):
+    def test_a_selectable_pull_request_is_queued_not_stuck(self):
+        # The half that makes this safe. Age alone must never close anything.
+        action, reason = call(pull(), eligible=True)
+        self.assertEqual(action, "keep")
+        self.assertIn("queued, not stuck", reason)
+
+    def test_a_draft_is_left_alone(self):
+        action, reason = call(pull(draft=True))
+        self.assertEqual(action, "keep")
+        self.assertIn("draft", reason)
+
+    def test_the_mirror_is_not_this_jobs_to_close(self):
+        # stale_mirror_pr.py owns that class with a much shorter fuse.
+        action, reason = call(pull(head_ref="spec-mirror"))
+        self.assertEqual(action, "keep")
+        self.assertIn("machine-generated", reason)
+
+    def test_a_pull_request_a_person_owns_is_reported_never_closed(self):
+        # #223 carried this label for hours. Overriding it would be a race with the
+        # operator, not a bound.
+        action, reason = call(pull(number=223, labels=["status:needs-decision"]))
+        self.assertEqual(action, "report")
+        self.assertIn("a person owns this decision", reason)
+
+    def test_the_authors_own_comment_is_progress(self):
+        action, reason = call(pull(comments=[
+            ("## AUTHOR handoff: rebased onto master", RECENT, "app/zendev-author"),
+        ]))
+        self.assertEqual(action, "keep")
+        self.assertIn("advanced", reason)
+
+    def test_an_acceptor_verdict_is_progress(self):
+        action, _ = call(pull(reviews=[("", RECENT, "CHANGES_REQUESTED", ACCEPTOR)]))
+        self.assertEqual(action, "keep")
+
+    def test_an_acceptor_verdict_posted_as_a_comment_counts_the_same(self):
+        # Which shape a verdict takes is an accident of GitHub's same-account rule.
+        action, _ = call(pull(comments=[
+            ("## ACCEPTOR Verdict: ACCEPT", RECENT, "zendev-acceptor[bot]"),
+        ]))
+        self.assertEqual(action, "keep")
+
+
+class ThirdPartyVoicesDoNotKeepABranchAliveTests(unittest.TestCase):
+    """The same rule the verdict follows: a voice that cannot move it cannot hold it."""
+
+    def test_a_qa_comment_is_evidence_not_progress(self):
+        # SLOPSTER runs hourly. If its comments reset the clock, no branch is ever
+        # unreachable again and this bound quietly stops existing.
+        action, reason = call(pull(comments=[
+            ("## SLOPSTER QA: FINDING\nHead `20045a28`", RECENT, "andy-zen-dev"),
+        ]))
+        self.assertEqual(action, "close")
+        self.assertIn("no review run can select it", reason)
+
+    def test_a_researcher_review_is_evidence_not_progress(self):
+        action, _ = call(pull(reviews=[
+            ("looks fine to me", RECENT, "APPROVED", "drevendev"),
+        ]))
+        self.assertEqual(action, "close")
+
+    def test_an_operator_comment_is_evidence_not_progress(self):
+        action, _ = call(pull(comments=[("bumping this", RECENT, "drevendev")]))
+        self.assertEqual(action, "close")
+
+
+class WindowTests(unittest.TestCase):
+    def test_the_window_is_configurable(self):
+        # 50 hours idle: inside a 72-hour window, outside a 24-hour one.
+        self.assertEqual(call(pull(), hours=72)[0], "keep")
+        self.assertEqual(call(pull(), hours=24)[0], "close")
+
+    def test_an_unreadable_timestamp_reads_as_old_not_as_fresh(self):
+        # Failing toward "old" is safe: eligibility still has to agree before anything
+        # closes. Failing toward "fresh" would silently disable the bound.
+        self.assertEqual(
+            stale.parse_time("not a date"),
+            dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #272

## Goal

Bound the quiet failure of a pull request, the way the rework limit bounds the loud one.

## Evidence

Four pull requests over 2026-09-06/07 stopped being reachable and each had to be ended
by hand: **#208** (36 hours, ACCEPTOR's own ACCEPT on a head branch protection would not
merge), **#223** (refused → labelled for a human → dirty), **#238** (13 hours clean and
approved, unselectable), **#242** (superseded by a duplicate that redid the work). Two
thirds of that day's $41 sat in that pile. The rework bound fired on none of them: none
failed loudly.

## Scope — every changed path

- `scripts/stale_pull_requests.py` — new. The two-part test, the exclusions, the report.
- `scripts/tests/test_stale_pull_requests.py` — new, 15 tests. Each closing test replays
  one of the four pull requests above; each keeping test is a way this could destroy
  work that was fine.
- `scripts/rework_limit.py` — extract `retire()`, called by both bounds.
- `.github/workflows/zendev-acceptor.yml` — run it on every acceptor tick, including
  ticks with no review target: a queue with nothing selectable is exactly when this has
  work to do.

## The rule

Closes only when **both** hold:

1. nothing has advanced it for `ZENDEV_STALE_PR_HOURS` (default **24**), where progress
   means the head moved, the ACCEPTOR posted a verdict, or the pull request's own author
   commented; **and**
2. `select_review_target.eligible` says no run can select it as it stands.

Never closes: drafts, machine branches (`stale_mirror_pr.py` owns those), or anything
labelled `status:needs-decision` — those are reported with a warning instead.

## Non-goals

Closing by age alone. Age is the symptom; unreachability is the disease, and part 2 is
what keeps a busy queue from being punished for being busy.

Overriding a person. `status:needs-decision` is a decision someone took.

## Acceptance criteria

- Both halves required; either alone keeps the pull request.
- A third-party comment (QA voice, researcher, operator) does not reset the clock —
  otherwise an hourly QA run holds every dead branch open and the bound stops existing.
- A verdict the ACCEPTOR posted as a comment counts the same as a formal review.
- A closed pull request returns its Issue to `status:ready` with exactly one status
  label and a record of why.
- An unreadable timestamp reads as old, not as fresh; eligibility still has to agree.
- One failure does not stop the rest or fail the hosting run.

## Verification

```
python -m unittest discover -s scripts/tests   →  Ran 410 tests … OK
```

Dry run against the live queue, which must close nothing healthy:

```
#271 keep: spec-mirror is machine-generated; stale_mirror_pr.py owns it
#267 keep: advanced 1.2h ago, inside the 24h window
#252 keep: advanced 10.7h ago, inside the 24h window
stale-pull-requests: closed 0
```

## Tuning without a pull request

`ZENDEV_STALE_PR_HOURS` is a repository variable. 24 is deliberately generous — healthy
pull requests in this repository land in minutes to a few hours — so it can be tightened
once there is a day of evidence under it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)