### PR TITLE
Make master compile again after #208 landed on a moved base

### DIFF
--- a/src/simulation/genesisReconciliation.test.ts
+++ b/src/simulation/genesisReconciliation.test.ts
@@ -31,8 +31,6 @@ function createTestConfig(): SimulationConfig {
       inventorySignalWeight: 0.5,
       basePriceAdjustmentSpeed: 0.1,
       maxAbsoluteLogPriceMovePerTick: 0.1,
-      minimumPrice: 0.01,
-      maximumPrice: 1000,
       targetInventoryCoverageTicks: 1.0,
       expectationAlpha: 0.1,
     },

--- a/src/simulation/worldState.ts
+++ b/src/simulation/worldState.ts
@@ -545,6 +545,9 @@ export function buildInitialWorld(
     seed,
     definitionRegistry,
     simulationConfig: frozenConfig,
+    // Empty, like the WorldState this reconciliation precedes: genesis queues no
+    // transition, and reconciliation reads stocks, never the queue.
+    pendingTransitions: createEmptyPendingTransitions(),
     worldGenesisLedger,
     regions: regionRegistry,
     states: stateRegistry,


### PR DESCRIPTION
Closes #274

## Goal

Get `master` compiling. It has been red since 2026-09-07T22:55:19Z and every open pull
request inherits the failure, so nothing can merge.

## Evidence

```
src/simulation/worldState.ts(542,9): error TS2741: Property 'pendingTransitions' is
  missing in type '{ ... }' but required in type 'WorldState'.
src/simulation/genesisReconciliation.test.ts(34,7): error TS2353: 'minimumPrice' does
  not exist in type 'MarketConfig'.
```

Both arrived with the merge of #208. That branch opened 2026-09-06 09:49 and merged
2026-09-07 22:55 — 36 hours during which `master` gained `WorldState.pendingTransitions`
(#247) and reshaped `MarketConfig` (#250). Its own checks were green against the base it
was written on; branch protection runs `strict: false`, so being out of date did not
stop the merge.

## Scope — every changed path

- `src/simulation/worldState.ts` — the temporary `WorldState` built for genesis
  reconciliation gets `pendingTransitions: createEmptyPendingTransitions()`, the same
  value the real `WorldState` is built with fifty lines below.
- `src/simulation/genesisReconciliation.test.ts` — drop `minimumPrice` and
  `maximumPrice` from the `markets` literal. They are real fields of the pricing config
  in `marketPricing.ts`, not of `MarketConfig`; nothing reads them here.

## Non-goals

Changing what reconciliation does. Touching `MarketConfig`. Changing branch protection —
`strict: false` is deliberate, and requiring every branch to be current would serialize
the queue; this is the cost of it, paid once at a manual merge of a very old branch.

## Acceptance criteria

- `npm run typecheck` clean.
- `npm test` passes, no test removed or weakened.
- The temporary `WorldState` carries an empty `PendingTransitions`.

## Verification

```
npm run typecheck   →  clean
npm test            →  Test Files 33 passed (33) · Tests 396 passed (396)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)