### PR TITLE
Let the ACCEPTOR clear the one merge gate it can clear

### DIFF
--- a/.github/workflows/zendev-acceptor.yml
+++ b/.github/workflows/zendev-acceptor.yml
@@ -221,13 +221,18 @@ jobs:
               status:needs-decision and stop; a human accepts that class of change.
             - If you cannot decide, name the exact gate in a comment and leave the
               pull request open. Never merge to clear a queue.
-            - Standing refusals from accounts other than yours on this pull request:
-              "${{ steps.select.outputs.blocked_by }}". When that list is not empty,
-              branch protection will refuse the merge and you do not own that gate.
-              Do not post ACCEPT you cannot carry out: say in a comment which account
-              holds the merge and what it asked for, label the pull request
-              status:needs-decision, and stop. Judging the change is still yours —
-              if it also needs rework, request changes as usual.
+            - Your own earlier refusal still stands on this pull request:
+              "${{ steps.select.outputs.self_refusal }}". If that is true and you
+              accept, post a formal approving review rather than a comment —
+              `gh pr review <n> --approve --body "<verdict>"` — because GitHub reads
+              the latest review per reviewer and only that supersedes your refusal.
+              A comment does not, and the merge will be refused.
+            - Standing refusals from other accounts: "${{ steps.select.outputs.blocked_by }}".
+              When that list is not empty, branch protection will refuse the merge and
+              you do not own that gate. Do not post ACCEPT you cannot carry out: say in
+              a comment which account holds the merge and what it asked for, label the
+              pull request status:needs-decision, and stop. Judging the change is still
+              yours — if it also needs rework, request changes as usual.
 
       - name: Read the subscription windows after the model ran
         if: always() && steps.select.outputs.target != 'none'

--- a/docs/zendev/ACCEPTOR_RUNBOOK.md
+++ b/docs/zendev/ACCEPTOR_RUNBOOK.md
@@ -243,15 +243,34 @@ first verdict is already standing and the AUTHOR — which has no memory and rea
 verdicts as its input — sees both. Name the head revision in the verdict so a reader
 can tell which revision it judged.
 
-**A merge gate you do not own.** Before ACCEPT, check whether any account other than
-yours has a standing `CHANGES_REQUESTED` on this pull request. The run tells you: the
-selection step prints `#<n> merge held by <account>` and passes the list into your
-prompt. Branch protection will refuse the merge while such a review stands, and you
-cannot dismiss it. Do not post an ACCEPT you cannot carry out — on #208 that ACCEPT
-was posted twice, executed neither time, and took the pull request out of the review
-queue for good. Instead: comment naming the account that holds the merge and what it
-asked for, label the pull request `status:needs-decision`, and stop. Judging the
-change is still yours; if it also needs rework, refuse it as usual.
+**Standing refusals hold the merge, including your own.** Branch protection refuses to
+merge while any account's latest review is `CHANGES_REQUESTED`. The selection step
+computes this and hands it to you; do not work it out from the timeline yourself.
+
+*Your own earlier refusal still stands.* Then **post a formal approving review** and
+merge:
+
+```sh
+gh pr review <number> --approve --body "<your ACCEPT verdict>"
+gh pr merge <number> --squash --delete-branch
+```
+
+GitHub reads the latest review per reviewer, so approving supersedes your refusal and
+the gate opens. A verdict posted as a comment does not: on #223 this role verified
+every gate, wrote `Verdict: ACCEPT` in a comment, and could not merge, because its own
+`CHANGES_REQUESTED` from the previous day was still the latest review it had left.
+Twenty-two hours, ended by an operator. The comment form exists for the case where
+GitHub refuses a formal review — it is a fallback, not the default, and it cannot clear
+a refusal.
+
+*Another account’s refusal stands.* That gate is not yours, and you cannot dismiss it.
+Do not post an ACCEPT you cannot carry out — on #208 that ACCEPT was posted twice,
+executed neither time, and took the pull request out of the review queue for good.
+Instead: comment naming the account that holds the merge and what it asked for, label
+the pull request `status:needs-decision`, and stop.
+
+Either way, judging the change is still yours: if it also needs rework, refuse it as
+usual.
 
 **ACCEPT** — allowed only when all of the following hold, and you state each one in
 the merge comment:

--- a/scripts/select_review_target.py
+++ b/scripts/select_review_target.py
@@ -205,26 +205,49 @@ def judges_head(comment, head_sha: str, head_committed_at: str, acceptor: str = 
 
 
 def standing_blockers(comments, acceptor: str = ""):
-    """Accounts other than the ACCEPTOR whose latest formal review still refuses.
+    """Every account whose latest formal review still refuses. Including this role's.
 
     GitHub blocks the merge on the *latest* review per reviewer, so an older refusal
     followed by that same account's approval is not standing. Only formal reviews are
-    read: a comment, whatever it says, has never blocked a merge.
+    read: a comment, whatever it says, has never blocked a merge — which is exactly why
+    the ACCEPTOR's own refusals belong here.
 
-    This decides nothing about eligibility. It exists so a run can name the gate it
-    does not own rather than issue a verdict that cannot execute (#211).
+    The first version of this excluded them, reasoning that it named "a gate this role
+    does not own". That was wrong twice over. The role does not own that gate either:
+    GitHub blocks on a standing refusal whoever left it, and an ACCEPT posted as a
+    comment does not supersede a formal review. And the omission cost the very
+    diagnosis this exists to give — on #223 the run reported "standing refusals: empty"
+    while its own refusal from the previous day was the only thing holding the merge.
+
+    The two cases need different answers, not the same silence, so `split` below tells
+    them apart: a refusal of this role's own is cleared by approving formally, while
+    another account's is not this role's to clear at all.
     """
     latest = {}
     for entry in comments:
         if entry.get("kind") != "review":
             continue
         login = normalize_login(entry.get("author"))
-        if not login or (acceptor and login == normalize_login(acceptor)):
+        if not login:
             continue
         seen = latest.get(login)
         if seen is None or entry.get("createdAt", "") >= seen[0]:
             latest[login] = (entry.get("createdAt", ""), (entry.get("state") or "").upper())
     return sorted(login for login, (_, state) in latest.items() if state == "CHANGES_REQUESTED")
+
+
+def split_blockers(blockers, acceptor: str = ""):
+    """(this role's own refusal stands, other accounts still refusing).
+
+    Kept separate from the reading above so that what the run *says* is decided here
+    rather than by the model comparing logins in a prompt. The role has mistaken its
+    own identity before (#152), and a run that cannot tell whose refusal it is looking
+    at will either sit on a merge it could clear in one call, or try to clear one it
+    cannot.
+    """
+    own = normalize_login(acceptor)
+    others = [login for login in blockers if not own or login != own]
+    return (bool(own) and own in blockers), others
 
 
 def conflicts_with_base(pull) -> bool:
@@ -406,25 +429,36 @@ def main() -> int:
     for number, created_at, ok, reason in sorted(candidates, key=lambda c: c[1]):
         print(f"  #{number} ({created_at}) {'eligible' if ok else 'skipped'}: {reason}")
 
-    # A merge this role cannot perform is worth saying out loud even on pull requests
-    # this run will not touch: it is the only place the deadlock of #211 is visible
-    # before someone goes looking for it.
+    # A merge that cannot execute is worth saying out loud even on pull requests this
+    # run will not touch: it is the only place the deadlock of #211 is visible before
+    # someone goes looking for it. Whose refusal it is decides what can be done, so the
+    # line says which.
     for number, held_by in sorted(blockers.items()):
-        print(f"  #{number} merge held by {', '.join(held_by)} (not this role)")
+        mine, others = split_blockers(held_by, args.acceptor)
+        parts = []
+        if mine:
+            parts.append("your own earlier refusal (clear it by approving formally)")
+        if others:
+            parts.append(f"{', '.join(others)} (not this role's to clear)")
+        print(f"  #{number} merge held by {'; '.join(parts)}")
 
     target = choose(candidates)
     value = str(target) if target else "none"
     print(f"target={value}")
 
-    held = ",".join(blockers.get(target, [])) if target else ""
+    mine, others = split_blockers(blockers.get(target, []) if target else [], args.acceptor)
+    held = ",".join(others)
     if held:
         print(f"blocked_by={held}")
+    if mine:
+        print("self_refusal=true")
 
     output = os.environ.get("GITHUB_OUTPUT")
     if output:
         with open(output, "a", encoding="utf-8") as handle:
             handle.write(f"target={value}\n")
             handle.write(f"blocked_by={held}\n")
+            handle.write(f"self_refusal={'true' if mine else 'false'}\n")
     return 0
 
 

--- a/scripts/tests/test_select_review_target.py
+++ b/scripts/tests/test_select_review_target.py
@@ -435,9 +435,46 @@ class StandingBlockerTests(unittest.TestCase):
         comments = [review("CHANGES_REQUESTED", "2026-09-06T17:59:18Z", "drevendev")]
         self.assertEqual(select.standing_blockers(comments, ACCEPTOR), ["drevendev"])
 
-    def test_the_acceptors_own_refusal_is_not_a_foreign_blocker(self):
-        comments = [review("CHANGES_REQUESTED", "2026-09-06T17:59:18Z", ACCEPTOR)]
-        self.assertEqual(select.standing_blockers(comments, ACCEPTOR), [])
+    def test_the_acceptors_own_refusal_is_reported_too(self):
+        # #223: the run said "standing refusals: empty" while its own refusal from the
+        # previous day was the only thing holding the merge. GitHub blocks on a
+        # standing refusal whoever left it, and an ACCEPT posted as a comment does not
+        # supersede a formal review.
+        comments = [review("CHANGES_REQUESTED", "2026-09-06T22:34:12Z", ACCEPTOR)]
+        self.assertEqual(select.standing_blockers(comments, ACCEPTOR), [ACCEPTOR])
+
+    def test_split_tells_ones_own_refusal_from_another_accounts(self):
+        blockers = [ACCEPTOR, "drevendev"]
+        mine, others = select.split_blockers(blockers, ACCEPTOR)
+        self.assertTrue(mine)
+        self.assertEqual(others, ["drevendev"])
+
+    def test_split_with_no_identity_calls_nothing_its_own(self):
+        # Without --acceptor the run cannot claim a refusal is its own, and guessing
+        # would make it try to clear one it does not own.
+        mine, others = select.split_blockers([ACCEPTOR, "drevendev"], "")
+        self.assertFalse(mine)
+        self.assertEqual(others, [ACCEPTOR, "drevendev"])
+
+    def test_split_recognises_the_bot_spelling_of_its_own_login(self):
+        mine, others = select.split_blockers(["zendev-acceptor"], "zendev-acceptor[bot]")
+        self.assertTrue(mine)
+        self.assertEqual(others, [])
+
+    def test_223_exactly(self):
+        # The ACCEPTOR refused on 09-06, the researcher approved on 09-07, the ACCEPTOR
+        # then accepted by comment and could not merge. Only its own refusal stands.
+        comments = [
+            review("CHANGES_REQUESTED", "2026-09-06T22:34:12Z", ACCEPTOR),
+            review("APPROVED", "2026-09-07T01:01:03Z", "drevendev"),
+            entry("## ACCEPTOR Verdict on 455cacd2\n\n**Verdict: ACCEPT**",
+                  "2026-09-07T18:34:06Z", author=ACCEPTOR),
+        ]
+        mine, others = select.split_blockers(
+            select.standing_blockers(comments, ACCEPTOR), ACCEPTOR
+        )
+        self.assertTrue(mine, "its own standing refusal is what held #223")
+        self.assertEqual(others, [])
 
     def test_only_the_latest_review_per_account_counts(self):
         # GitHub blocks on the latest review per reviewer; an approval after a refusal


### PR DESCRIPTION
Closes #276

## Goal

Stop the ACCEPTOR reporting its own standing refusal as absent, and let it clear that
refusal the only way GitHub allows.

## Evidence

**#223, 2026-09-07 18:34Z.** The role verified every acceptance gate, wrote
`Verdict: ACCEPT` in a comment, tried to merge, was refused by base branch policy, and
reported:

> No standing account review holds this PR (standing refusals: empty).

False. Its own `CHANGES_REQUESTED` from 2026-09-06 22:34Z was still the latest review it
had left. The pull request stood 22 hours and an operator ended it.

## Scope — every changed path

- `scripts/select_review_target.py` — `standing_blockers` no longer excludes the
  ACCEPTOR's own refusals; new `split_blockers`; `self_refusal` output alongside
  `blocked_by`; the per-pull-request log line says whose refusal holds the merge.
- `scripts/tests/test_select_review_target.py` — the old test asserting the exclusion is
  replaced by one asserting the opposite, plus four more including a replay of #223's
  exact review sequence.
- `docs/zendev/ACCEPTOR_RUNBOOK.md` — the two cases split: your own refusal is cleared
  by approving formally, another account's is not yours to clear at all.
- `.github/workflows/zendev-acceptor.yml` — hand `self_refusal` to the prompt.

## Why approving, not dismissing

Nothing is dismissed here, by this role or any other. GitHub reads the latest review per
reviewer, so an approving review supersedes the role's own earlier refusal and the gate
opens. Another account's refusal remains untouchable by the loop — that boundary is the
whole point of #257 and it is unchanged.

## Non-goals

Dismissing reviews. Changing branch protection. Touching what the role may accept.

## Acceptance criteria

- `standing_blockers` reports every refusing account, the role's own included.
- `split_blockers` separates them; with no acceptor identity, nothing is claimed as own.
- `zendev-acceptor[bot]` and `zendev-acceptor` are one identity.
- On ACCEPT with its own refusal standing, the role approves formally and merges.
- Another account's refusal still means: name it, label `status:needs-decision`, stop.

## Verification

```
python -m unittest discover -s scripts/tests   →  Ran 414 tests … OK
```

The #223 replay asserts that of `[acceptor CHANGES_REQUESTED, drevendev APPROVED,
acceptor ACCEPT-by-comment]`, exactly one refusal stands and it is the role's own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)