### PR TITLE
Declare scheme/4: the loop has a third voice

### DIFF
--- a/docs/zendev/schemes.json
+++ b/docs/zendev/schemes.json
@@ -13,7 +13,7 @@
     "descriptor in the tag message, and every telemetry record carries {id, digest} so",
     "a measurement window can be sliced by scheme without knowing any dates."
   ],
-  "active": "scheme/3",
+  "active": "scheme/4",
   "schemes": [
     {
       "id": "scheme/1",
@@ -68,8 +68,8 @@
     },
     {
       "id": "scheme/4",
-      "in_force_from": "",
-      "commit": "",
+      "in_force_from": "2026-09-07T22:53:33Z",
+      "commit": "2057de0",
       "summary": "SLOPSTER joins as an external QA voice with read access only; its findings reach the loop through the intake job.",
       "roles": {
         "author": {"identity": "zendev-author[bot]", "model": "claude-haiku-4-5", "max_budget_usd": 5.0},
@@ -79,12 +79,12 @@
       "verdict_owner": "zendev-acceptor",
       "voices": [
         "EndlessZen as drevendev, owns the specification",
-        "SLOPSTER as AndyDev, read-only: comments and Issues, never a formal review"
+        "SLOPSTER as andy-zen-dev, read-only: comments and Issues, never a formal review"
       ],
       "required_checks": ["build-and-test", "typescript", "policy-guard", "mergeability"],
       "rework_limit": 3,
       "cadence_minutes": 25,
-      "note": "Not in force. Activated when the QA voice's hourly cadence starts."
+      "note": "Activated by a repository variable rather than a merge, so `commit` records where master stood at `in_force_from`: ZENDEV_QA_LOGIN was set at 2026-09-07T22:53:33Z and the intake job cannot run without it. The QA voice began commenting earlier, at 21:48Z, so telemetry records between 21:48Z and 22:53Z say scheme/3 while a third voice was already speaking — two comments, no verdict taken on either. The earlier plan named this account AndyDev; the account is andy-zen-dev."
     }
   ]
 }


### PR DESCRIPTION
Closes #281

## Goal

Record that the setup changed. Every telemetry record since 2026-09-07 21:48Z claims
`scheme/3` while a third voice was in the loop.

## Scope — every changed path

- `docs/zendev/schemes.json` — `active` becomes `scheme/4`; that scheme records
  `in_force_from` 2026-09-07T22:53:33Z and commit `2057de0`; the QA account is named
  `andy-zen-dev`; the note explains both the commit and the contaminated hour.

## Non-goals

Changing any model, ceiling, cadence, gate or identity — the descriptor records what is
already true. Adding the mechanical check that `ZENDEV_QA_LOGIN` matches the active
scheme's voices; that is worth doing and is separate.

## Acceptance criteria

- `active` names `scheme/4`, the account is `andy-zen-dev`.
- The note says why `commit` is a position rather than a cause, and dates the hour in
  which records say `scheme/3` with a third voice already present.
- `scheme/3`'s digest is unchanged.

## Verification

```
python -m unittest discover -s scripts/tests   →  Ran 426 tests … OK
scheme/4 digest 716147834d43 · scheme/3 digest f388453edf68 (unchanged)
```

The `scheme/4` tag is cut after this merges, carrying the descriptor in its message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)