### PR TITLE
Take a run's outcome from what it did, not from how it phrased it

### DIFF
--- a/.github/workflows/zendev-acceptor.yml
+++ b/.github/workflows/zendev-acceptor.yml
@@ -144,6 +144,13 @@ jobs:
       # ledger. Only when a model run is about to happen: a run with no work spends
       # nothing and needs no reading. The token reaches this step and the model step
       # only, and the reading never prints what it read.
+      # The instant the model starts. run_effect asks the forge what this identity
+      # did after it, which is how a run that worked stops depending on how it
+      # phrased its last sentence.
+      - name: Mark when the model started
+        id: started
+        run: echo "at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${GITHUB_OUTPUT}"
+
       - name: Read the subscription windows before the model runs
         if: steps.select.outputs.target != 'none'
         env:
@@ -289,6 +296,21 @@ jobs:
           repositories: zen-telemetry
 
       # Telemetry only. See the note in zendev-author.yml: this never fails the run.
+      # Read from the staged copy, like everything else that runs after the
+      # model: this role rewrites the working tree it would otherwise run from.
+      - name: Read what this run actually did
+        id: effect
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python "${RUNNER_TEMP}/control-plane/run_effect.py" \
+            --repo "${{ github.repository }}" \
+            --role acceptor \
+            --identity "${{ steps.identity.outputs.app-slug }}" \
+            --pull "${{ steps.select.outputs.target }}" \
+            --since "${{ steps.started.outputs.at }}"
+
       - name: Record what this run consumed
         if: always()
         env:
@@ -298,6 +320,7 @@ jobs:
             --execution-file "${{ steps.claude.outputs.execution_file }}" \
             --conclusion "${{ steps.select.outputs.target == 'none' && 'no_work' || steps.claude.outputs.conclusion }}" \
             --role acceptor \
+            --effect "${{ steps.effect.outputs.effect }}" \
             --ledger-repo drevendev/zen-telemetry \
             --run-id "${{ github.run_id }}" \
             --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \

--- a/.github/workflows/zendev-author.yml
+++ b/.github/workflows/zendev-author.yml
@@ -129,11 +129,21 @@ jobs:
           # the working tree it would be whatever the branch under review claims.
           cp scripts/schemes.py "${RUNNER_TEMP}/schemes.py"
           cp docs/zendev/schemes.json "${RUNNER_TEMP}/schemes.json"
+          # The whole control plane too: run_effect below imports its neighbours,
+          # and this role rewrites the working tree it would otherwise run from.
+          cp -r scripts "${RUNNER_TEMP}/control-plane"
 
       # The subscription is metered in rolling windows, not dollars. One reading before
       # the model and one after; the recorder writes the difference to the private
       # ledger. The token reaches this step and the model step only, and the reading
       # never prints what it read.
+      # The instant the model starts. run_effect asks the forge what this identity
+      # did after it, which is how a run that worked stops depending on how it
+      # phrased its last sentence.
+      - name: Mark when the model started
+        id: started
+        run: echo "at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${GITHUB_OUTPUT}"
+
       - name: Read the subscription windows before the model runs
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -227,6 +237,20 @@ jobs:
       # ledger. It never fails the run: a missing token or an unreachable ledger is a
       # warning, because a loop that stops over bookkeeping is worse than a gap in the
       # bookkeeping.
+      # Read from the staged copy, like everything else that runs after the
+      # model: this role rewrites the working tree it would otherwise run from.
+      - name: Read what this run actually did
+        id: effect
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python "${RUNNER_TEMP}/control-plane/run_effect.py" \
+            --repo "${{ github.repository }}" \
+            --role author \
+            --identity "${{ steps.identity.outputs.app-slug }}" \
+            --since "${{ steps.started.outputs.at }}"
+
       - name: Record what this run consumed
         if: always()
         env:
@@ -236,6 +260,7 @@ jobs:
             --execution-file "${{ steps.claude.outputs.execution_file }}" \
             --conclusion "${{ steps.claude.outputs.conclusion }}" \
             --role author \
+            --effect "${{ steps.effect.outputs.effect }}" \
             --ledger-repo drevendev/zen-telemetry \
             --run-id "${{ github.run_id }}" \
             --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \

--- a/scripts/record_usage.py
+++ b/scripts/record_usage.py
@@ -219,13 +219,28 @@ def final_text(messages) -> str:
     return last
 
 
-def classify_outcome(conclusion, text):
+def classify_outcome(conclusion, text, effect=""):
     """(outcome, source). Pure.
+
+    Four sources, consulted in order of how much each one knows.
 
     The workflow's own conclusion is trusted where it is specific: `no_work` means the
     model was never started, and anything that is not success or unknown is a failure.
-    Everything else is read from the run's final message, and the source says so. A
-    handoff or a verdict there means completed, whatever else the message mentions.
+    Then the run's final message, which is a claim about itself: a handoff or a verdict
+    there means completed, whatever else the message mentions.
+
+    `effect` comes last and comes from the forge (`run_effect.py`): what the role's
+    identity actually did in the repository while the model ran. It is consulted only
+    where nothing else knows anything, and that ordering is deliberate in both
+    directions. It rescues the case that used to be `unknown` — on 2026-09-08 an
+    ACCEPTOR run selected #252, spent thirty-two turns, posted a formal
+    `CHANGES_REQUESTED` and was filed as `unknown` because its closing words matched no
+    pattern. And it does not overrule the run's own account of itself: an effect says
+    work happened, not that it went well, so a run that posts a verdict *and* reports
+    being blocked is blocked, which only the run can know.
+
+    What survives as `unknown` is now a run that did nothing observable and claimed
+    nothing — a true statement rather than an artefact of phrasing.
     """
     if conclusion == "no_work":
         return "no_work", "workflow"
@@ -237,6 +252,8 @@ def classify_outcome(conclusion, text):
         return "blocked", "heuristic"
     if NO_WORK.search(text or ""):
         return "no_work", "heuristic"
+    if effect == "completed":
+        return "completed", "forge"
     # A green action and a final message that claims nothing is not a completed run.
     # It used to be recorded as one: on 2026-09-06 an author run met two pull requests
     # it could not merge, spent thirteen turns, said nothing, and was filed as
@@ -333,6 +350,10 @@ def main() -> int:
     parser.add_argument("--execution-file", default="")
     parser.add_argument("--role", required=True)
     parser.add_argument("--conclusion", default="unknown")
+    parser.add_argument(
+        "--effect", default="",
+        help="what the role's identity did in the forge during the run; see run_effect.py",
+    )
     parser.add_argument("--ledger-repo", required=True)
     parser.add_argument("--run-id", default="")
     parser.add_argument("--run-url", default="")
@@ -354,7 +375,9 @@ def main() -> int:
             warn("the execution file names no model; recording null")
 
     # The outcome is read from the run's last word; mentions and rework from everything.
-    outcome, outcome_source = classify_outcome(args.conclusion, final_text(messages))
+    outcome, outcome_source = classify_outcome(
+        args.conclusion, final_text(messages), args.effect
+    )
     before = load_reading(args.usage_before)
     after = load_reading(args.usage_after)
     if before is None or after is None:

--- a/scripts/run_effect.py
+++ b/scripts/run_effect.py
@@ -1,0 +1,166 @@
+"""Ask the forge what a run actually did, so its outcome is not a matter of wording.
+
+`record_usage.classify_outcome` reads the run's final message. That is a claim, and a
+model that finishes with the wrong words makes real work invisible: on 2026-09-08 an
+ACCEPTOR run selected #252, spent thirty-two turns, posted a formal `CHANGES_REQUESTED`,
+and was filed as `unknown`. Three of the 125 runs in the measured day went the same way,
+and one of the day's cleanliness criteria is "no runs with outcome `unknown`" — so a
+three-percent lie about wording fails a criterion about behaviour, and pollutes the cost
+per unit of work in both directions.
+
+This reads the effect instead. Not what the run said: what its identity did in the
+repository between the moment the model started and now.
+
+* **ACCEPTOR** — a verdict on the reviewed pull request, in either shape the runbook
+  allows, or that pull request merged. Reaching a verdict is the whole of its job.
+* **AUTHOR** — a pull request it opened, or a commit it pushed to the head of one it
+  already had. Producing or advancing a branch is the whole of its job.
+
+## Where this sits, and why it does not decide more than it knows
+
+It is consulted last: the workflow's own conclusion first, then the run's own claim of
+completed, blocked or no work, and only then this. So it changes nothing about runs that
+already report something, and rescues exactly the case that reports nothing.
+
+That ordering matters in the other direction too. An effect says work happened, not that
+it went well — a run that posts a verdict *and* says it was blocked is blocked, and the
+run is the only thing that knows that. Facts beat silence here, not testimony.
+
+A run that did nothing observable and claimed nothing stays `unknown`, which is then a
+true statement rather than an artefact of phrasing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+from select_review_target import is_verdict_entry, normalize_login
+
+COMPLETED = "completed"
+NONE = "none"
+
+
+def _gh(args):
+    # UTF-8 explicitly, not by locale: see the note in machine_pr_guard.py.
+    return subprocess.run(
+        ["gh", *args], check=True, capture_output=True, text=True, encoding="utf-8"
+    ).stdout
+
+
+def acceptor_effect(pull, identity: str, since: str):
+    """(effect, reason) for a review run: did this identity reach a verdict?"""
+    if (pull.get("mergedAt") or "") >= since and pull.get("mergedAt"):
+        return COMPLETED, "the reviewed pull request merged during this run"
+
+    for review in pull.get("reviews") or []:
+        submitted = review.get("submittedAt") or ""
+        entry = {
+            "author": (review.get("author") or {}).get("login"),
+            "state": review.get("state"),
+            "body": review.get("body"),
+        }
+        if submitted >= since and is_verdict_entry(entry, identity):
+            return COMPLETED, f"posted a formal {review.get('state')} at {submitted}"
+
+    for comment in pull.get("comments") or []:
+        created = comment.get("createdAt") or ""
+        entry = {
+            "author": (comment.get("author") or {}).get("login"),
+            "state": None,
+            "body": comment.get("body"),
+        }
+        if created >= since and is_verdict_entry(entry, identity):
+            return COMPLETED, f"posted a verdict comment at {created}"
+
+    return NONE, "no verdict from this identity on the reviewed pull request"
+
+
+def author_effect(pulls, identity: str, since: str):
+    """(effect, reason) for an authoring run: did this identity produce or advance one?
+
+    `headCommittedAt` is supplied by the caller per pull request, because `gh pr list`
+    does not carry it. A pull request opened during the run counts even if its head is
+    older, which happens when a branch is pushed first and opened a moment later.
+    """
+    for pull in pulls:
+        if normalize_login((pull.get("author") or {}).get("login")) != normalize_login(identity):
+            continue
+        if (pull.get("createdAt") or "") >= since:
+            return COMPLETED, f"opened #{pull['number']} at {pull['createdAt']}"
+        if (pull.get("headCommittedAt") or "") >= since and pull.get("headCommittedAt"):
+            return COMPLETED, f"pushed to #{pull['number']} at {pull['headCommittedAt']}"
+    return NONE, "no pull request opened or advanced by this identity"
+
+
+def load_pull(repo: str, number: int):
+    return json.loads(
+        _gh(["pr", "view", str(number), "--repo", repo, "--json",
+             "number,mergedAt,reviews,comments"])
+    )
+
+
+def load_author_pulls(repo: str, identity: str, since: str):
+    pulls = json.loads(
+        _gh(["pr", "list", "--repo", repo, "--state", "all", "--limit", "20",
+             "--json", "number,createdAt,author,headRefOid"])
+    )
+    mine = [
+        pull for pull in pulls
+        if normalize_login((pull.get("author") or {}).get("login")) == normalize_login(identity)
+    ]
+    # Only the ones that could plausibly have moved: reading a head commit date is an
+    # API call each, and a run that pushed did so within its own lifetime.
+    for pull in mine:
+        if (pull.get("createdAt") or "") >= since:
+            continue
+        try:
+            commit = json.loads(_gh(["api", f"repos/{repo}/commits/{pull['headRefOid']}"]))
+            pull["headCommittedAt"] = commit["commit"]["committer"]["date"]
+        except (subprocess.CalledProcessError, ValueError, KeyError):
+            pull["headCommittedAt"] = ""
+    return mine
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="owner/name")
+    parser.add_argument("--role", required=True, choices=("author", "acceptor"))
+    parser.add_argument("--identity", required=True, help="the role's login")
+    parser.add_argument("--since", required=True, help="ISO 8601, when the model started")
+    parser.add_argument("--pull", default="", help="the reviewed pull request, ACCEPTOR only")
+    args = parser.parse_args()
+
+    try:
+        if args.role == "acceptor":
+            if not args.pull or args.pull == "none":
+                effect, reason = NONE, "no pull request was selected"
+            else:
+                effect, reason = acceptor_effect(
+                    load_pull(args.repo, int(args.pull)), args.identity, args.since
+                )
+        else:
+            effect, reason = author_effect(
+                load_author_pulls(args.repo, args.identity, args.since),
+                args.identity, args.since,
+            )
+    except (subprocess.CalledProcessError, ValueError) as error:
+        # Never fail the run that hosts this. A missing effect costs the rescue; a red
+        # step here would cost the telemetry record, which is the more valuable thing.
+        print(f"::warning::run-effect: could not read the forge: {type(error).__name__}")
+        effect, reason = NONE, "the forge could not be read"
+
+    print(f"run-effect: {effect} — {reason}")
+
+    import os
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        with open(output, "a", encoding="utf-8") as handle:
+            handle.write(f"effect={effect}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_run_effect.py
+++ b/scripts/tests/test_run_effect.py
@@ -1,0 +1,162 @@
+"""Reading what a run did instead of what it said, and not reading more than that.
+
+The run this replays: on 2026-09-08 an ACCEPTOR selected #252, spent thirty-two turns,
+posted a formal CHANGES_REQUESTED, and was recorded as `unknown` because its closing
+words matched no pattern. One of the measurement's cleanliness criteria is "no runs with
+outcome unknown", so a lie about wording was failing a criterion about behaviour.
+"""
+
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import record_usage  # noqa: E402
+import run_effect  # noqa: E402
+
+ACCEPTOR = "zendev-acceptor"
+AUTHOR = "zendev-author"
+SINCE = "2026-09-08T00:00:37Z"
+DURING = "2026-09-08T00:02:50Z"
+BEFORE = "2026-09-07T22:34:12Z"
+
+
+def review(state, at, who=ACCEPTOR, body=""):
+    return {"state": state, "submittedAt": at, "body": body, "author": {"login": who}}
+
+
+def comment(body, at, who=ACCEPTOR):
+    return {"body": body, "createdAt": at, "author": {"login": who}}
+
+
+def pull(number=252, merged=None, reviews=(), comments=()):
+    return {"number": number, "mergedAt": merged,
+            "reviews": list(reviews), "comments": list(comments)}
+
+
+class AcceptorEffectTests(unittest.TestCase):
+    def test_252_exactly(self):
+        effect, reason = run_effect.acceptor_effect(
+            pull(reviews=[review("CHANGES_REQUESTED", DURING)]), ACCEPTOR, SINCE
+        )
+        self.assertEqual(effect, run_effect.COMPLETED)
+        self.assertIn("CHANGES_REQUESTED", reason)
+
+    def test_a_verdict_posted_as_a_comment_counts(self):
+        # Which shape a verdict takes is an accident of GitHub's same-account rule.
+        effect, _ = run_effect.acceptor_effect(
+            pull(comments=[comment("## ACCEPTOR Verdict: ACCEPT", DURING)]),
+            ACCEPTOR, SINCE,
+        )
+        self.assertEqual(effect, run_effect.COMPLETED)
+
+    def test_a_merge_during_the_run_counts(self):
+        effect, reason = run_effect.acceptor_effect(
+            pull(merged=DURING), ACCEPTOR, SINCE
+        )
+        self.assertEqual(effect, run_effect.COMPLETED)
+        self.assertIn("merged", reason)
+
+    def test_a_verdict_from_before_the_run_is_not_this_runs_work(self):
+        # The whole point is what happened *during* this run. An older refusal standing
+        # on the pull request would otherwise mark every later run as productive.
+        effect, _ = run_effect.acceptor_effect(
+            pull(reviews=[review("CHANGES_REQUESTED", BEFORE)]), ACCEPTOR, SINCE
+        )
+        self.assertEqual(effect, run_effect.NONE)
+
+    def test_another_accounts_verdict_is_not_this_roles_effect(self):
+        effect, _ = run_effect.acceptor_effect(
+            pull(reviews=[review("APPROVED", DURING, who="drevendev")]), ACCEPTOR, SINCE
+        )
+        self.assertEqual(effect, run_effect.NONE)
+
+    def test_a_qa_comment_during_the_run_is_not_this_roles_effect(self):
+        effect, _ = run_effect.acceptor_effect(
+            pull(comments=[comment("## SLOPSTER QA: FINDING", DURING, who="andy-zen-dev")]),
+            ACCEPTOR, SINCE,
+        )
+        self.assertEqual(effect, run_effect.NONE)
+
+    def test_a_run_that_only_talked_has_no_effect(self):
+        effect, _ = run_effect.acceptor_effect(
+            pull(comments=[comment("Looking at this now.", DURING)]), ACCEPTOR, SINCE
+        )
+        self.assertEqual(effect, run_effect.NONE)
+
+
+class AuthorEffectTests(unittest.TestCase):
+    def test_a_pull_request_opened_during_the_run_counts(self):
+        pulls = [{"number": 283, "createdAt": DURING, "author": {"login": "app/" + AUTHOR}}]
+        effect, reason = run_effect.author_effect(pulls, AUTHOR, SINCE)
+        self.assertEqual(effect, run_effect.COMPLETED)
+        self.assertIn("#283", reason)
+
+    def test_a_push_to_an_older_pull_request_counts(self):
+        pulls = [{"number": 252, "createdAt": BEFORE, "headCommittedAt": DURING,
+                  "author": {"login": "app/" + AUTHOR}}]
+        effect, reason = run_effect.author_effect(pulls, AUTHOR, SINCE)
+        self.assertEqual(effect, run_effect.COMPLETED)
+        self.assertIn("pushed", reason)
+
+    def test_an_untouched_older_pull_request_is_not_an_effect(self):
+        pulls = [{"number": 252, "createdAt": BEFORE, "headCommittedAt": BEFORE,
+                  "author": {"login": "app/" + AUTHOR}}]
+        self.assertEqual(run_effect.author_effect(pulls, AUTHOR, SINCE)[0], run_effect.NONE)
+
+    def test_someone_elses_pull_request_is_not_this_roles_effect(self):
+        pulls = [{"number": 283, "createdAt": DURING, "author": {"login": "drevendev"}}]
+        self.assertEqual(run_effect.author_effect(pulls, AUTHOR, SINCE)[0], run_effect.NONE)
+
+    def test_the_apps_two_spellings_are_one_identity(self):
+        pulls = [{"number": 283, "createdAt": DURING,
+                  "author": {"login": "zendev-author[bot]"}}]
+        self.assertEqual(
+            run_effect.author_effect(pulls, "app/zendev-author", SINCE)[0],
+            run_effect.COMPLETED,
+        )
+
+
+class OrderingTests(unittest.TestCase):
+    """Where the effect sits among the things that can decide an outcome."""
+
+    def test_it_rescues_the_run_that_used_to_be_unknown(self):
+        outcome, source = record_usage.classify_outcome("success", "…", effect="completed")
+        self.assertEqual((outcome, source), ("completed", "forge"))
+
+    def test_without_it_that_run_is_still_unknown(self):
+        outcome, source = record_usage.classify_outcome("success", "…")
+        self.assertEqual((outcome, source), ("unknown", "heuristic"))
+
+    def test_it_does_not_overrule_the_runs_own_account_of_itself(self):
+        # An effect says work happened, not that it went well. A run that posts a
+        # verdict and reports being blocked is blocked, and only the run knows that.
+        outcome, source = record_usage.classify_outcome(
+            "success", "## AUTHOR run status update: BLOCKED on a missing decision",
+            effect="completed",
+        )
+        self.assertEqual(source, "heuristic")
+        self.assertNotEqual(outcome, "completed")
+
+    def test_a_workflow_failure_still_wins(self):
+        outcome, source = record_usage.classify_outcome(
+            "failure", "anything", effect="completed"
+        )
+        self.assertEqual((outcome, source), ("failed", "workflow"))
+
+    def test_no_work_from_the_workflow_still_wins(self):
+        # The model was never started, so nothing it might have done is relevant.
+        outcome, source = record_usage.classify_outcome(
+            "no_work", "", effect="completed"
+        )
+        self.assertEqual((outcome, source), ("no_work", "workflow"))
+
+    def test_a_run_with_no_effect_and_no_claim_stays_unknown(self):
+        # Which is now a true statement rather than an artefact of phrasing.
+        outcome, source = record_usage.classify_outcome("success", "…", effect="none")
+        self.assertEqual((outcome, source), ("unknown", "heuristic"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #283

## Goal

Stop a run's recorded outcome depending on the wording of its last sentence.

## Evidence

`2026-09-08T00:00:37Z` — an ACCEPTOR run selected #252, spent 32 turns, posted a formal
`CHANGES_REQUESTED` at 00:02:50Z, and was filed as `outcome: unknown`.

| window | runs | `unknown` |
|---|---:|---:|
| since scheme/3 | 25 | 1 (4%) |
| the measured day, scheme/2 | 125 | 3 (2.4%) |

"No runs with outcome `unknown`" is one of the cleanliness criteria for a measurement
day. At this rate the scheme/4 day fails that criterion for reasons unrelated to
scheme/4, and cost per unit of work is wrong in both directions.

## Scope — every changed path

- `scripts/run_effect.py` — new. Asks the forge what the role's identity did between
  the model starting and now.
- `scripts/tests/test_run_effect.py` — new, 18 tests, including a replay of the #252
  run above.
- `scripts/record_usage.py` — `classify_outcome` takes `effect` and consults it last;
  `--effect` passed through.
- `.github/workflows/zendev-acceptor.yml`, `.github/workflows/zendev-author.yml` — a
  timestamp before the model, the effect read after it, and the value handed to the
  recorder. The author workflow also gains the staged control-plane copy the acceptor
  already had.

## Ordering, which is the whole design

1. the workflow's conclusion — `no_work`, or a failure;
2. the run's own claim — completed, blocked, no work;
3. **the forge** — what the identity actually did;
4. `unknown`.

Consulted last, it changes nothing that already reports something. And it does not
overrule the run's account of itself: an effect says work happened, not that it went
well, so a run that posts a verdict *and* reports being blocked is blocked.

## Non-goals

Removing `unknown`. It should still describe a run that did nothing observable and
claimed nothing — the point is that it becomes true rather than an artefact of phrasing.

## Verification

```
python -m unittest discover -s scripts/tests   →  Ran 444 tests … OK
```

Against the real misfiled run:

```
run_effect.py --role acceptor --identity zendev-acceptor --pull 252 \
  --since 2026-09-08T00:00:37Z
→ run-effect: completed — posted a formal CHANGES_REQUESTED at 2026-09-08T00:02:50Z
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)