### PR TITLE
Never lose a telemetry record to one malformed message

### DIFF
--- a/scripts/record_usage.py
+++ b/scripts/record_usage.py
@@ -180,7 +180,12 @@ def transcript(messages) -> str:
             continue
         if message.get("type") == "result" and isinstance(message.get("result"), str):
             parts.append(message["result"])
-        content = (message.get("message") or {}).get("content")
+        # `message` is usually a dict, and on at least one shape of execution file it
+        # is a plain string. Guarding only the outer envelope let that through, and
+        # `.get` on a str raised several frames from here: run 34173179305 opened
+        # #285 and then lost its whole telemetry record to this line.
+        inner = message.get("message")
+        content = inner.get("content") if isinstance(inner, dict) else None
         if not isinstance(content, list):
             continue
         for block in content:
@@ -206,7 +211,12 @@ def final_text(messages) -> str:
             continue
         if message.get("type") == "result" and isinstance(message.get("result"), str):
             return message["result"]
-        content = (message.get("message") or {}).get("content")
+        # `message` is usually a dict, and on at least one shape of execution file it
+        # is a plain string. Guarding only the outer envelope let that through, and
+        # `.get` on a str raised several frames from here: run 34173179305 opened
+        # #285 and then lost its whole telemetry record to this line.
+        inner = message.get("message")
+        content = inner.get("content") if isinstance(inner, dict) else None
         if not isinstance(content, list):
             continue
         texts = [

--- a/scripts/tests/test_record_usage.py
+++ b/scripts/tests/test_record_usage.py
@@ -313,3 +313,35 @@ class LoadReadingTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class MalformedMessageTests(unittest.TestCase):
+    """A record is the only evidence a run happened; nothing in a transcript may cost it.
+
+    Run 34173179305 opened #285 and then died in `transcript`, because one message
+    carried a plain string where a dict was expected and the guard checked only the
+    outer envelope. The work landed and the ledger never heard about it.
+    """
+
+    MALFORMED = [
+        {"type": "assistant", "message": "a plain string where a dict belongs"},
+        {"type": "assistant", "message": {"content": "not a list"}},
+        {"type": "assistant", "message": None},
+        {"type": "assistant"},
+        "a message that is not a mapping at all",
+        {"type": "assistant", "message": {"content": ["a bare string block"]}},
+        {"type": "result", "result": "## AUTHOR handoff: opened #285"},
+    ]
+
+    def test_transcript_survives_every_shape(self):
+        self.assertIn("#285", rec.transcript(self.MALFORMED))
+
+    def test_final_text_survives_every_shape(self):
+        self.assertEqual(
+            rec.final_text(self.MALFORMED), "## AUTHOR handoff: opened #285"
+        )
+
+    def test_neither_raises_on_the_empty_case(self):
+        self.assertEqual(rec.transcript([]), "")
+        self.assertEqual(rec.final_text(None), "")
+


### PR DESCRIPTION
Closes #286

## Goal

Stop one malformed message in an execution file costing the whole telemetry record.

## Evidence

Run 34173179305 (AUTHOR, 2026-09-08 00:24Z) opened PR #285 and then died recording it:

```
File "/home/runner/work/_temp/record_usage.py", line 183, in transcript
  content = (message.get("message") or {}).get("content")
AttributeError: 'str' object has no attribute 'get'
```

Both `transcript` and `final_text` guard the outer message and then call `.get` on
`message["message"]` unguarded. The run is absent from the ledger entirely — no cost, no
outcome, no scheme — while its pull request is in the queue.

Found by dispatching the loop by hand to watch the new effect reader work. It did work:
`--effect "completed"` was passed correctly, from a run that had genuinely opened a pull
request. This crash is older and unrelated.

## Scope — every changed path

- `scripts/record_usage.py` — both call sites check the inner envelope and skip what
  they cannot read.
- `scripts/tests/test_record_usage.py` — `MalformedMessageTests`: six unusable shapes in
  one transcript, and the assertion that the usable content is still read.

## Non-goals

Guessing what the malformed shape meant. It is skipped, like every other unusable shape.

## Acceptance criteria

- `transcript` and `final_text` survive a `message` that is a string, `None`, absent,
  whose `content` is not a list, and a message that is not a mapping at all.
- A `result` message after the malformed ones is still the final text.
- Neither raises on an empty or `None` list.

## Verification

```
python -m unittest discover -s scripts/tests   →  Ran 447 tests … OK
```

Red-green: the two behavioural tests fail against the current code and pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)