### PR TITLE
Opening a pull request is progress

### DIFF
--- a/scripts/stale_pull_requests.py
+++ b/scripts/stale_pull_requests.py
@@ -79,9 +79,21 @@ def parse_time(value):
 
 
 def last_progress(pull, head_committed_at, acceptor=""):
-    """When this pull request last moved, by the definition in the module docstring."""
+    """When this pull request last moved, by the definition in the module docstring.
+
+    Opening it counts, and that is not a detail. On 2026-09-08 this bound closed #285
+    two minutes after the AUTHOR opened it, reporting "idle 24.3h" — truthfully, because
+    the branch was one the author had abandoned the day before and re-proposed without
+    touching its head. Every other signal was 24 hours old and the arithmetic was right;
+    the meaning was not. A branch nobody has touched is abandoned, but a pull request
+    somebody just opened is a proposal, and this bound exists to end the first, never the
+    second.
+
+    (That the AUTHOR re-proposed a stale head instead of starting from `master`, as the
+    closure of #223 asked it to, is a separate defect and not this module's to correct.)
+    """
     author = select.normalize_login((pull.get("author") or {}).get("login"))
-    moments = [parse_time(head_committed_at)]
+    moments = [parse_time(head_committed_at), parse_time(pull.get("createdAt"))]
 
     for comment in pull.get("comments") or []:
         if select.is_the_authors(

--- a/scripts/tests/test_stale_pull_requests.py
+++ b/scripts/tests/test_stale_pull_requests.py
@@ -22,9 +22,10 @@ RECENT = "2026-09-08T06:00:00Z"  # 6 hours before NOW
 
 
 def pull(number=208, draft=False, labels=(), head_ref="claude/issue-201-config-004",
-         author="app/zendev-author", comments=(), reviews=()):
+         author="app/zendev-author", comments=(), reviews=(), created=OLD):
     return {
         "number": number,
+        "createdAt": created,
         "isDraft": draft,
         "labels": [{"name": name} for name in labels],
         "headRefName": head_ref,
@@ -55,6 +56,21 @@ class ClosesWhatNothingCanReachTests(unittest.TestCase):
 
     def test_242_quietly_superseded_by_a_duplicate(self):
         action, _ = call(pull(number=242, head_ref="claude/issue-240-acceptance-003"))
+        self.assertEqual(action, "close")
+
+    def test_285_a_freshly_opened_pull_request_is_never_stale(self):
+        # #285: the AUTHOR re-proposed a branch it had abandoned the day before,
+        # without touching its head. Every other signal was 24 hours old, the
+        # arithmetic said "idle 24.3h", and this bound closed the pull request two
+        # minutes after it was opened. Opening one is an act.
+        action, reason = call(
+            pull(number=285, created="2026-09-08T11:58:00Z"), committed=OLD
+        )
+        self.assertEqual(action, "keep", reason)
+
+    def test_a_pull_request_opened_long_ago_and_untouched_is_still_stale(self):
+        # The other half: creation is progress once, not forever.
+        action, _ = call(pull(created=OLD), committed=OLD)
         self.assertEqual(action, "close")
 
     def test_the_window_is_measured_from_the_head_not_from_the_opening(self):


### PR DESCRIPTION
Closes #289

## Goal

Stop the staleness bound closing a pull request somebody has just opened.

## Evidence

```
00:30:39Z  AUTHOR opens #285
00:32:43Z  forge: "Closed as unreachable — idle 24.3h and no review run can select it"
```

The arithmetic was right. #285's head is `455cacd2`, the head the closed #223 carried,
on the same branch — the AUTHOR re-proposed an abandoned branch without touching it, so
the head commit, the verdicts and the author's own comments were all a day old.

`last_progress` never looked at the pull request's own `createdAt`. A branch nobody has
touched is abandoned; a pull request somebody just opened is a proposal.

Found by dispatching the loop by hand to watch it work — which is what it is for.

## Scope — every changed path

- `scripts/stale_pull_requests.py` — `last_progress` counts `createdAt`.
- `scripts/tests/test_stale_pull_requests.py` — the #285 replay, and its complement:
  a pull request opened before the window and untouched since still closes.

## Non-goals

Correcting the AUTHOR's behaviour. Re-proposing a stale head instead of starting from
`master`, as the closure of #223 asked, is a separate defect — filed as #290. The bound
must be right either way, and papering over that here would have hidden it.

Permanent immunity. Creation is progress once, at the moment it happens.

## Acceptance criteria

- A pull request opened inside the window is kept, whatever its head's age.
- One opened before the window and untouched since is still closed.
- Every other rule unchanged.

## Verification

```
python -m unittest discover -s scripts/tests   →  Ran 449 tests … OK
```

Red-green: the #285 replay fails against the current code. Dry run against the live
queue: `#288 keep: advanced 0.0h ago, inside the 24h window`, closed 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)