### PR TITLE
Releases are not the roles' to make

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,8 @@ same job, and a run performs exactly one of them.
 
 An AUTHOR run must never merge. An ACCEPTOR run must never implement.
 
+Neither creates a tag or a release. `release-tag.yml` cuts `v0.<milestone>.<patch>` from the ledger, mechanically, and it is the only thing that may: a release is a claim made to everyone outside this repository, and it is gated on a milestone being complete and fully evidenced. A run that tags by hand bypasses both gates — which happened on 2026-09-08, and produced a `v0.2.0` announcing a milestone that was not finished.
+
 ### Voices that are not roles
 
 Other accounts post here. None of them is a role, none has authority over the merge,

--- a/docs/zendev/ACCEPTOR_RUNBOOK.md
+++ b/docs/zendev/ACCEPTOR_RUNBOOK.md
@@ -325,5 +325,6 @@ clear a queue.
 - Never push commits to a pull request branch.
 - Never close an Issue you did not verify.
 - Never close an Issue whose pull request is not in state `MERGED`.
+- **Never create a tag or a GitHub release.** Releasing is mechanical: `.github/workflows/release-tag.yml` cuts `v0.<milestone>.<patch>` from the ledger when every requirement of a milestone reads `IMPLEMENTED`, and refuses when any row lacks its merge commit. On 2026-09-08 a run cut `v0.2.0` by hand at 06:02Z while `REQ-CORE-006` was still `PARTIAL`: the completeness check, the provenance refusal and the coverage digest were all bypassed, and the tag asserted a milestone that was not finished. A release is a claim to everyone outside this repository, and no role makes it.
 - Never post an ACCEPT while another account's `CHANGES_REQUESTED` stands: the merge
   cannot execute, and the verdict takes the pull request out of the queue anyway.

--- a/docs/zendev/AUTHOR_RUNBOOK.md
+++ b/docs/zendev/AUTHOR_RUNBOOK.md
@@ -241,6 +241,8 @@ to release a milestone whose rows still lack it. It was called *optional* here u
 2026-09-07, which is why eleven of twenty-three rows carried nothing and eight of those
 were marked `IMPLEMENTED`. Optional and nobody's job are the same thing.
 
+**Never create a tag or a GitHub release.** The tagger above is the only thing that may, and it is mechanical for a reason: it releases a milestone only when every one of its requirements reads `IMPLEMENTED` and every row carries its merge commit. On 2026-09-08 a run cut `v0.2.0` by hand while `REQ-CORE-006` was still `PARTIAL`, and the tag claimed a milestone nobody had finished. Recording that a row landed is your work; announcing that a milestone shipped is not.
+
 **Quote `EVIDENCE` whenever it contains a comma.** A bare comma splits the row into more
 than the six declared fields; `csv.DictReader` files the surplus where nothing reads it,
 and every consumer sees only the text before that comma. Ten rows were in that state,

--- a/scripts/release_tag.py
+++ b/scripts/release_tag.py
@@ -214,12 +214,50 @@ def parse_tag_listing(listing, milestones):
     return found
 
 
+def foreign_taggers(listing, expected: str):
+    """Release tags this job did not create, as (tag, tagger) pairs.
+
+    It cannot prevent one — anything holding a token with contents write can push a
+    tag, and only a repository ruleset stops that. It can refuse to be the last to
+    know. On 2026-09-08 a model run cut `v0.2.0` by hand at 06:02Z while REQ-CORE-006
+    was still PARTIAL, bypassing the completeness check, the provenance refusal and the
+    coverage digest at once; nothing noticed for ten hours, and only then because
+    someone read the tag list by eye.
+
+    A release is a claim made outside this repository. One made by something that
+    skipped the gates is worth a loud line in the log of the very next run.
+    """
+    out = []
+    for block in (listing or "").split("\x00"):
+        ref, _, tagger = block.partition("\t")
+        ref, tagger = ref.strip(), tagger.strip()
+        if TAG.match(ref) and tagger and tagger != expected:
+            out.append((ref, tagger))
+    return sorted(out)
+
+
 def existing_tags(milestones):
     listing = _git([
         "tag", "--list", "v0.*",
         "--format=%(refname:strip=2)%09%(contents)%00",
     ])
     return parse_tag_listing(listing, milestones)
+
+
+def report_foreign_tags(expected: str) -> None:
+    try:
+        listing = _git(["tag", "--list", "v0.*",
+                        "--format=%(refname:strip=2)%09%(taggername)%00"])
+    except RuntimeError as error:
+        print(f"::warning::release-tag: could not read tag authorship: {error}")
+        return
+    for ref, tagger in foreign_taggers(listing, expected):
+        print(
+            "::warning::release-tag: %s was created by %s, not by this job. A release "
+            "cut outside it has passed none of the gates here — completeness, merge "
+            "provenance, coverage digest — and may name a milestone that is not "
+            "finished." % (ref, tagger)
+        )
 
 
 def main() -> int:
@@ -232,7 +270,13 @@ def main() -> int:
         "--milestones", default=str(root / "docs" / "zendev" / "milestones.json")
     )
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--tagger", default="zendev-machine[bot]",
+        help="the identity that legitimately creates release tags",
+    )
     args = parser.parse_args()
+
+    report_foreign_tags(args.tagger)
 
     document = json.loads(pathlib.Path(args.milestones).read_text(encoding="utf-8"))
     milestones = document["milestones"]

--- a/scripts/tests/test_release_tag.py
+++ b/scripts/tests/test_release_tag.py
@@ -113,6 +113,40 @@ class TagListingTests(unittest.TestCase):
         self.assertEqual(got, {"M0": [], "M1": []})
 
 
+class ForeignTaggerTests(unittest.TestCase):
+    """A release this job did not cut has passed none of its gates."""
+
+    MACHINE = "zendev-machine[bot]"
+
+    def test_a_tag_cut_by_a_model_run_is_reported(self):
+        # v0.2.0, 2026-09-08 06:02Z: cut by hand while REQ-CORE-006 was still PARTIAL,
+        # bypassing the completeness check, the provenance refusal and the digest.
+        listing = ("v0.0.0\tzendev-machine[bot]\x00"
+                   "v0.2.0\tclaude[bot]\x00")
+        self.assertEqual(
+            release_tag.foreign_taggers(listing, self.MACHINE),
+            [("v0.2.0", "claude[bot]")],
+        )
+
+    def test_this_jobs_own_tags_are_not_reported(self):
+        listing = "v0.0.0\tzendev-machine[bot]\x00"
+        self.assertEqual(release_tag.foreign_taggers(listing, self.MACHINE), [])
+
+    def test_scheme_tags_are_not_releases(self):
+        # scheme/N shares the namespace and is cut by the operator by design.
+        listing = "scheme/4\tDreven\x00"
+        self.assertEqual(release_tag.foreign_taggers(listing, self.MACHINE), [])
+
+    def test_a_lightweight_tag_with_no_tagger_is_not_reported(self):
+        # An unannotated tag carries no tagger; reporting every one of those would be
+        # noise that trains the reader to ignore the warning that matters.
+        listing = "v0.3.0\t\x00"
+        self.assertEqual(release_tag.foreign_taggers(listing, self.MACHINE), [])
+
+    def test_an_empty_listing_reports_nothing(self):
+        self.assertEqual(release_tag.foreign_taggers("", self.MACHINE), [])
+
+
 class TheRepositorysOwnMapTests(unittest.TestCase):
     """The map is data about the specification, and the specification changes."""
 


### PR DESCRIPTION
Closes #311

## Goal

Keep releases mechanical, and stop one made outside the tagger going unnoticed for hours.

## Evidence

```
v0.0.0  tagger = zendev-machine[bot]   release-tag.yml
v0.1.0  tagger = zendev-machine[bot]   release-tag.yml
v0.2.0  tagger = claude[bot]           a model run, 06:02:47Z
```

No run of `release-tag.yml` exists between 05:02:33Z and 07:34:34Z. `v0.2.0` released M2
while `REQ-CORE-006` read `PARTIAL` — as it does at every ledger commit today — bypassing
`complete()`, the blank-provenance refusal, and the coverage digest at once.

Ten hours passed before anyone noticed, and only by reading the tag list by eye.

## Scope — every changed path

- `docs/zendev/AUTHOR_RUNBOOK.md`, `docs/zendev/ACCEPTOR_RUNBOOK.md`, `AGENTS.md` — no
  role creates a tag or a release, with the reason and this incident named.
- `scripts/release_tag.py` — `foreign_taggers`, reported on every run.
- `scripts/tests/test_release_tag.py` — 5 tests, including this incident.

## What this does not do

**It does not prevent it.** Anything holding a token with `contents: write` can push a
tag; only a repository ruleset over `refs/tags/v*` naming the machine app as the sole
bypass actor can stop that, and that is a repository setting. This makes the rule
explicit and makes a breach visible within one run of the tagger instead of a working
day.

Deleting `v0.2.0` is a separate operator action.

## Acceptance criteria

- Both runbooks and `AGENTS.md` carry the prohibition and the reason.
- Any `v0.*` tag with an unexpected tagger is reported every run.
- `scheme/N` is not reported — the operator cuts those by design.
- An unannotated tag, carrying no tagger, is not reported: noise there would teach the
  reader to ignore the warning that matters.

## Verification

```
python -m unittest discover -s scripts/tests   →  Ran 457 tests … OK
python scripts/release_tag.py --dry-run
→ ::warning::release-tag: v0.2.0 was created by claude[bot], not by this job.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)