### PR TITLE
status-lint: the change that registers an identifier may lack its row, once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,10 +122,23 @@ jobs:
       # check runs and becomes true at the moment it lands. Every other open citation is
       # still refused. On push there is no pull request and the argument is empty, so
       # every citation must already have merged.
+      #
+      # --base is what this change is measured against: the base branch of a pull
+      # request, the parent of the commit on a push. An identifier the registry gains
+      # relative to it may lack its ledger row in this change and in no later one —
+      # the one-change bootstrap of #369, computed from the two registries and nothing
+      # else. The ref arrives through the environment, as in the guards above.
       - name: Keep the ledger honest about what merged
         env:
           GH_TOKEN: ${{ github.token }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            BASE="origin/${BASE_REF}"
+          else
+            BASE="HEAD^1"
+          fi
           python scripts/status_lint.py \
             --repo "${{ github.repository }}" \
-            --self "${{ github.event.pull_request.number }}"
+            --self "${{ github.event.pull_request.number }}" \
+            --base "${BASE}"

--- a/scripts/status_lint.py
+++ b/scripts/status_lint.py
@@ -15,18 +15,24 @@ might:
    shows every registry identifier, so absence shows up as `NOT_STARTED` beside a
    requirement that demonstrably was started — which is a lie of the same shape.
 
-   One exception, and it lasts exactly one change. An identifier is created by the
-   researcher and reaches the repository through the machine mirror, so a pull request
-   can merge under a name the registry does not know yet — #358 did, for
-   `REQ-VISUALIZATION-007` — and then nothing can land: the mirror proposal that
-   registers the identifier is refused here for the missing row, and the row cannot
-   be written first because `implementation_status.validate` refuses an identifier the
-   registry does not carry (#369). So the change that introduces an identifier into the
-   registry — the proposal, and the push that lands it, each measured against its own
-   base — may lack that identifier's row. That identifier only, that change only: the
-   next change to land is refused until a truthful row exists. The set is computed from
-   the diff between the base registry and this one, so no label, flag or body text can
-   widen it or make it last.
+   The rule reaches the identifiers the registry knows, because those are the ones the
+   table renders. A merged pull request can also name an identifier the registry does
+   not know yet: identifiers are created by the researcher and delivered by the machine
+   mirror, and #358 merged under `REQ-VISUALIZATION-007` before the mirror carried it.
+   Such a claim is reported as a warning, not a violation. The row cannot be written
+   until the registry carries the identifier — `implementation_status.validate` sees to
+   that — and a violation that no permitted action can clear is not a gate but a stop:
+   it held every pull request, the fix for it included, for the seven hours of #369.
+
+   One exception on the registered side, and it lasts exactly one change. When the
+   mirror proposal that registers such an identifier arrives, the identifier becomes
+   registered and its row is still missing, so the proposal would be refused for the
+   very claim it is trying to make honest. So the change that introduces an identifier
+   into the registry — the proposal, and the push that lands it, each measured against
+   its own base — may lack that identifier's row. That identifier only, that change
+   only: the next change to land is refused until a truthful row exists. The set is
+   computed from the diff between the base registry and this one, so no label, flag or
+   body text can widen it or make it last.
 
 2. **Every pull request a ledger row cites has merged** — except the pull request being
    checked, which is the row's own. That exception is new, and it is the mechanism that
@@ -82,18 +88,26 @@ def lint(
     requirements_claimed_by_merged,
     self_pull=None,
     bootstrapping=frozenset(),
+    registered=None,
 ):
     """Pure. Returns a list of human-readable violations.
 
+    `registered` is the set of identifiers the registry under test knows; rule 1 reaches
+    those and no others. None means every claimed identifier counts as registered,
+    which is the strict reading a caller without a registry gets.
+
     `bootstrapping` is the set of identifiers this very change introduces into the
-    registry — see `newly_registered` — and the only identifiers whose missing row is
-    not a violation. A caller that is not measuring a change passes nothing, and then
-    every claimed identifier must have its row.
+    registry — see `newly_registered` — and the only registered identifiers whose
+    missing row is not a violation. A caller that is not measuring a change passes
+    nothing, and then every registered claimed identifier must have its row.
     """
     violations = []
     recorded = {(row.get("REQ_ID") or "").strip() for row in rows}
 
-    for req in sorted(set(requirements_claimed_by_merged) - recorded - set(bootstrapping)):
+    missing = set(requirements_claimed_by_merged) - recorded - set(bootstrapping)
+    if registered is not None:
+        missing &= set(registered)
+    for req in sorted(missing):
         where = ", ".join("#%d" % p for p in sorted(requirements_claimed_by_merged[req]))
         violations.append(
             "%s was claimed by merged pull request(s) %s but has no ledger row; the "
@@ -123,6 +137,13 @@ def lint(
         )
 
     return violations
+
+
+def unregistered_claims(rows, requirements_claimed_by_merged, registered):
+    """Identifiers merged pull requests claim that neither the ledger nor the registry
+    knows. Pure. Reported, never refused: nothing permitted could clear the refusal."""
+    recorded = {(row.get("REQ_ID") or "").strip() for row in rows}
+    return sorted(set(requirements_claimed_by_merged) - recorded - set(registered))
 
 
 def newly_registered(base_ids, head_ids):
@@ -237,6 +258,14 @@ def main() -> int:
 
     merged_numbers, claimed = load_merged_pulls(args.repo)
     recorded = {(row.get("REQ_ID") or "").strip() for row in rows}
+    for req in unregistered_claims(rows, claimed, head_ids):
+        where = ", ".join("#%d" % p for p in sorted(claimed[req]))
+        print(
+            "::warning::status-lint: %s is claimed by merged pull request(s) %s but the "
+            "registry does not know it, so no ledger row can be written for it yet. The "
+            "mirror proposal that registers it may land without the row; the change "
+            "after that one must carry it." % (req, where)
+        )
     for req in sorted((set(claimed) - recorded) & bootstrapping):
         where = ", ".join("#%d" % p for p in sorted(claimed[req]))
         print(
@@ -245,7 +274,9 @@ def main() -> int:
             "registers it. The next change to land is refused until a truthful row "
             "exists." % (req, where)
         )
-    violations = lint(rows, merged_numbers, claimed, self_pull, bootstrapping)
+    violations = lint(
+        rows, merged_numbers, claimed, self_pull, bootstrapping, registered=head_ids
+    )
 
     if not violations:
         print(

--- a/scripts/status_lint.py
+++ b/scripts/status_lint.py
@@ -15,6 +15,19 @@ might:
    shows every registry identifier, so absence shows up as `NOT_STARTED` beside a
    requirement that demonstrably was started — which is a lie of the same shape.
 
+   One exception, and it lasts exactly one change. An identifier is created by the
+   researcher and reaches the repository through the machine mirror, so a pull request
+   can merge under a name the registry does not know yet — #358 did, for
+   `REQ-VISUALIZATION-007` — and then nothing can land: the mirror proposal that
+   registers the identifier is refused here for the missing row, and the row cannot
+   be written first because `implementation_status.validate` refuses an identifier the
+   registry does not carry (#369). So the change that introduces an identifier into the
+   registry — the proposal, and the push that lands it, each measured against its own
+   base — may lack that identifier's row. That identifier only, that change only: the
+   next change to land is refused until a truthful row exists. The set is computed from
+   the diff between the base registry and this one, so no label, flag or body text can
+   widen it or make it last.
+
 2. **Every pull request a ledger row cites has merged** — except the pull request being
    checked, which is the row's own. That exception is new, and it is the mechanism that
    removed reconciliation runs: a row is appended by the pull request that earns it, so
@@ -43,6 +56,8 @@ cannot do.
 from __future__ import annotations
 
 import argparse
+import csv
+import io
 import json
 import re
 import subprocess
@@ -61,12 +76,24 @@ CITES_MERGED_CODE = tuple(
 )
 
 
-def lint(rows, merged_pull_numbers, requirements_claimed_by_merged, self_pull=None):
-    """Pure. Returns a list of human-readable violations."""
+def lint(
+    rows,
+    merged_pull_numbers,
+    requirements_claimed_by_merged,
+    self_pull=None,
+    bootstrapping=frozenset(),
+):
+    """Pure. Returns a list of human-readable violations.
+
+    `bootstrapping` is the set of identifiers this very change introduces into the
+    registry — see `newly_registered` — and the only identifiers whose missing row is
+    not a violation. A caller that is not measuring a change passes nothing, and then
+    every claimed identifier must have its row.
+    """
     violations = []
     recorded = {(row.get("REQ_ID") or "").strip() for row in rows}
 
-    for req in sorted(set(requirements_claimed_by_merged) - recorded):
+    for req in sorted(set(requirements_claimed_by_merged) - recorded - set(bootstrapping)):
         where = ", ".join("#%d" % p for p in sorted(requirements_claimed_by_merged[req]))
         violations.append(
             "%s was claimed by merged pull request(s) %s but has no ledger row; the "
@@ -96,6 +123,44 @@ def lint(rows, merged_pull_numbers, requirements_claimed_by_merged, self_pull=No
         )
 
     return violations
+
+
+def newly_registered(base_ids, head_ids):
+    """The identifiers present in this registry and absent from the base's. Pure.
+
+    This is the whole bootstrap: an identifier is introduced by exactly one change, so
+    the set holds it for that change and for no change after it.
+    """
+    return frozenset(head_ids) - frozenset(base_ids)
+
+
+def registry_ids_at(ref: str, cwd=None):
+    """The requirement identifiers the registry held at `ref`.
+
+    A ref that does not resolve raises LookupError: a check measured against nothing
+    would treat every identifier as new, which is the permanent bypass the docstring
+    rules out. A ref that resolves but holds no registry file returns the empty set —
+    that is the one change which introduced the registry itself, and every identifier
+    in it was new then.
+    """
+    resolved = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", ref + "^{commit}"],
+        cwd=cwd, capture_output=True, text=True, encoding="utf-8",
+    )
+    if resolved.returncode != 0:
+        raise LookupError("the base %r does not resolve to a commit" % ref)
+    shown = subprocess.run(
+        ["git", "show", "%s:%s" % (ref, implementation_status.REGISTRY_PATH)],
+        cwd=cwd, capture_output=True, text=True, encoding="utf-8",
+    )
+    if shown.returncode != 0:
+        if "does not exist in" in shown.stderr or "exists on disk, but not in" in shown.stderr:
+            return frozenset()
+        raise LookupError(
+            "the registry at %r could not be read: %s" % (ref, shown.stderr.strip())
+        )
+    rows = csv.DictReader(io.StringIO(shown.stdout))
+    return frozenset(row["REQ_ID"].strip() for row in rows if row.get("REQ_ID"))
 
 
 def _gh(args):
@@ -144,12 +209,43 @@ def main() -> int:
         default="",
         help="the pull request being checked, whose own number a row may cite",
     )
+    parser.add_argument(
+        "--base",
+        default="",
+        help=(
+            "the git ref this change is measured against: the base branch of a pull "
+            "request, the parent commit of a push. An identifier the registry gains "
+            "relative to it may lack its ledger row in this change only. Empty means "
+            "nothing is being introduced, and every claimed identifier needs its row"
+        ),
+    )
     args = parser.parse_args()
 
     rows = implementation_status.read_ledger()
     self_pull = int(args.self_pull) if args.self_pull.strip().isdigit() else None
+
+    head_ids = frozenset(req for req, _ in implementation_status.read_registry())
+    if args.base.strip():
+        try:
+            base_ids = registry_ids_at(args.base.strip(), cwd=implementation_status.REPO_ROOT)
+        except LookupError as exc:
+            print("::error::status-lint: %s" % exc)
+            return 1
+        bootstrapping = newly_registered(base_ids, head_ids)
+    else:
+        bootstrapping = frozenset()
+
     merged_numbers, claimed = load_merged_pulls(args.repo)
-    violations = lint(rows, merged_numbers, claimed, self_pull)
+    recorded = {(row.get("REQ_ID") or "").strip() for row in rows}
+    for req in sorted((set(claimed) - recorded) & bootstrapping):
+        where = ", ".join("#%d" % p for p in sorted(claimed[req]))
+        print(
+            "::notice::status-lint: %s is claimed by merged pull request(s) %s and has "
+            "no ledger row; permitted once, because this change is the one that "
+            "registers it. The next change to land is refused until a truthful row "
+            "exists." % (req, where)
+        )
+    violations = lint(rows, merged_numbers, claimed, self_pull, bootstrapping)
 
     if not violations:
         print(

--- a/scripts/tests/test_status_lint.py
+++ b/scripts/tests/test_status_lint.py
@@ -14,11 +14,13 @@ request closed without merging takes its row with it. So a row may cite the pull
 that carries it, and nothing else that is open.
 
 The fourth reproduces #369. `REQ-VISUALIZATION-007` was merged by #358 before the
-registry knew the name; the mirror proposal registering it was then refused here for
-the missing row, and the row could not be written because the validator refuses an
-unregistered identifier. The change that introduces an identifier may lack its row —
-that change only, that identifier only — and these prove the exception is computed
-from the registries and cannot outlive the change that used it.
+registry knew the name; every pull request was then refused here for the missing row,
+and the row could not be written because the validator refuses an unregistered
+identifier. Two things follow, and these prove both: a claim the registry does not
+know is a warning, never a violation, because nothing permitted could clear it; and
+the change that registers an identifier may lack its row — that change only, that
+identifier only — computed from the two registries, so it cannot outlive the change
+that used it.
 """
 
 import pathlib
@@ -252,6 +254,30 @@ class RegistryIntroductionTests(unittest.TestCase):
         self.assertEqual(len(violations), 1)
         self.assertIn("#999", violations[0])
 
+    def test_an_identifier_the_registry_does_not_know_is_a_warning_not_a_violation(self):
+        # #358 merged under a name the registry did not carry. No permitted action can
+        # write that row, so refusing every pull request for it is a stop, not a gate.
+        registered = {"REQ-CORE-001"}
+        self.assertEqual(
+            status_lint.lint([row()], {48, 358}, self.CLAIMED, registered=registered), []
+        )
+        self.assertEqual(
+            status_lint.unregistered_claims([row()], self.CLAIMED, registered), [NEW]
+        )
+
+    def test_a_registered_identifier_without_a_row_is_still_a_violation(self):
+        registered = {"REQ-CORE-001", NEW}
+        violations = status_lint.lint([row()], {48, 358}, self.CLAIMED, registered=registered)
+        self.assertEqual(len(violations), 1)
+        self.assertIn(NEW, violations[0])
+        self.assertEqual(status_lint.unregistered_claims([row()], self.CLAIMED, registered), [])
+
+    def test_without_a_registry_every_claim_counts_as_registered(self):
+        # The strict reading, for a caller that has no registry to consult.
+        violations = status_lint.lint([row()], {48, 358}, self.CLAIMED)
+        self.assertEqual(len(violations), 1)
+        self.assertIn(NEW, violations[0])
+
     def test_the_set_is_the_difference_of_the_registries(self):
         self.assertEqual(status_lint.newly_registered({"A"}, {"A", NEW}), {NEW})
         self.assertEqual(status_lint.newly_registered({"A", NEW}, {"A", NEW}), frozenset())
@@ -283,17 +309,34 @@ class RegistryAtRefTests(unittest.TestCase):
     def test_the_cycle_of_369_end_to_end(self):
         # Base: no NEW. Merged #358 claims NEW. The candidate registers NEW. No row.
         with RegistryHistory() as h:
-            head = status_lint.registry_ids_at(h.introducing, cwd=h.root)
             claimed = {NEW: [358]}
 
+            # Before the mirror arrives: any change measured against a base that does
+            # not know NEW, with a registry that does not know it either. A warning,
+            # and nothing is refused — this is where every pull request sat for seven
+            # hours, the fix included.
+            head = status_lint.registry_ids_at(h.without, cwd=h.root)
+            new = status_lint.newly_registered(
+                status_lint.registry_ids_at(h.without, cwd=h.root), head
+            )
+            self.assertEqual(new, frozenset())
+            self.assertEqual(
+                status_lint.lint([row()], {48, 358}, claimed, bootstrapping=new, registered=head),
+                [],
+            )
+            self.assertEqual(status_lint.unregistered_claims([row()], claimed, head), [NEW])
+
             # The registering change, measured against the base it is proposed to.
+            head = status_lint.registry_ids_at(h.introducing, cwd=h.root)
             new = status_lint.newly_registered(
                 status_lint.registry_ids_at(h.without, cwd=h.root), head
             )
             self.assertEqual(new, {NEW})
             self.assertEqual(
-                status_lint.lint([row()], {48, 358}, claimed, bootstrapping=new), []
+                status_lint.lint([row()], {48, 358}, claimed, bootstrapping=new, registered=head),
+                [],
             )
+            self.assertEqual(status_lint.unregistered_claims([row()], claimed, head), [])
 
             # The change after it, measured against a base that now carries NEW.
             new = status_lint.newly_registered(
@@ -301,13 +344,15 @@ class RegistryAtRefTests(unittest.TestCase):
             )
             self.assertEqual(new, frozenset())
             self.assertEqual(
-                len(status_lint.lint([row()], {48, 358}, claimed, bootstrapping=new)), 1
+                len(status_lint.lint([row()], {48, 358}, claimed, bootstrapping=new, registered=head)),
+                1,
             )
 
             # And once the row lands, nothing is exceptional any more.
             rows = [row(), row(req=NEW, status="PARTIAL", issue="355", pr="358")]
             self.assertEqual(
-                status_lint.lint(rows, {48, 358}, claimed, bootstrapping=new), []
+                status_lint.lint(rows, {48, 358}, claimed, bootstrapping=new, registered=head),
+                [],
             )
 
 

--- a/scripts/tests/test_status_lint.py
+++ b/scripts/tests/test_status_lint.py
@@ -12,10 +12,19 @@ pull request can be closed without ever merging. Under the ledger a row is appen
 the pull request that earns it: the row and the citation land together, and a pull
 request closed without merging takes its row with it. So a row may cite the pull request
 that carries it, and nothing else that is open.
+
+The fourth reproduces #369. `REQ-VISUALIZATION-007` was merged by #358 before the
+registry knew the name; the mirror proposal registering it was then refused here for
+the missing row, and the row could not be written because the validator refuses an
+unregistered identifier. The change that introduces an identifier may lack its row —
+that change only, that identifier only — and these prove the exception is computed
+from the registries and cannot outlive the change that used it.
 """
 
 import pathlib
+import subprocess
 import sys
+import tempfile
 import unittest
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
@@ -142,6 +151,164 @@ class DelegationTests(unittest.TestCase):
         self.assertIn("IMPLEMENTED", status_lint.CITES_MERGED_CODE)
         self.assertIn("PARTIAL", status_lint.CITES_MERGED_CODE)
         self.assertNotIn("BLOCKED", status_lint.CITES_MERGED_CODE)
+
+
+REGISTRY = "docs/spec/mirror/REQUIREMENTS_REGISTRY.csv"
+HEADER = "REQ_ID,AREA,FILE,ANCHOR,STATEMENT,TYPE,PRIORITY,STATUS,MILESTONE,ACCEPTANCE\n"
+NEW = "REQ-VISUALIZATION-007"
+
+
+def registry(*ids):
+    return HEADER + "".join(
+        "%s,docs,file.md,anchor,statement,functional,high,READY,M3,acceptance\n" % i
+        for i in ids
+    )
+
+
+def git(cwd, *args):
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    ).stdout.strip()
+
+
+class RegistryHistory:
+    """Three commits: before any registry, a registry without NEW, then one adding it.
+
+    That is the shape of #369 exactly: master had no `REQ-VISUALIZATION-007`, #358 had
+    merged under that name, and the mirror proposal was the change introducing it.
+    """
+
+    def __enter__(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        root = pathlib.Path(self.tmp.name)
+        git(root, "init", "-b", "master")
+        git(root, "config", "user.email", "test@example.invalid")
+        git(root, "config", "user.name", "Test")
+
+        (root / "README.md").write_text("base\n", encoding="utf-8")
+        git(root, "add", "-A")
+        git(root, "commit", "-q", "-m", "before any registry")
+        self.before_registry = git(root, "rev-parse", "HEAD")
+
+        path = root / REGISTRY
+        path.parent.mkdir(parents=True)
+        path.write_text(registry("REQ-CORE-001"), encoding="utf-8")
+        git(root, "add", "-A")
+        git(root, "commit", "-q", "-m", "registry")
+        self.without = git(root, "rev-parse", "HEAD")
+
+        path.write_text(registry("REQ-CORE-001", NEW), encoding="utf-8")
+        git(root, "add", "-A")
+        git(root, "commit", "-q", "-m", "registry introduces " + NEW)
+        self.introducing = git(root, "rev-parse", "HEAD")
+
+        self.root = root
+        return self
+
+    def __exit__(self, *exc):
+        self.tmp.cleanup()
+        return False
+
+
+class RegistryIntroductionTests(unittest.TestCase):
+    """#369: the change that registers an identifier may lack its row, once."""
+
+    CLAIMED = {"REQ-CORE-001": [48], NEW: [358]}
+
+    def test_the_identifier_this_change_registers_may_lack_its_row(self):
+        self.assertEqual(
+            status_lint.lint([row()], {48, 358}, self.CLAIMED, bootstrapping={NEW}), []
+        )
+
+    def test_an_unrelated_missing_row_is_still_refused_beside_it(self):
+        claimed = dict(self.CLAIMED, **{"REQ-CONFIG-005": [76]})
+        violations = status_lint.lint([row()], {48, 76, 358}, claimed, bootstrapping={NEW})
+        self.assertEqual(len(violations), 1)
+        self.assertIn("REQ-CONFIG-005", violations[0])
+        self.assertNotIn(NEW, violations[0])
+
+    def test_the_exception_expires_with_the_change_that_used_it(self):
+        # The next change is measured against a base that already carries the
+        # identifier, so nothing is new and the missing row is what it always was.
+        violations = status_lint.lint(
+            [row()], {48, 358}, self.CLAIMED, bootstrapping=frozenset()
+        )
+        self.assertEqual(len(violations), 1)
+        self.assertIn(NEW, violations[0])
+
+    def test_a_truthful_row_ends_the_bootstrap(self):
+        rows = [row(), row(req=NEW, status="PARTIAL", issue="355", pr="358")]
+        self.assertEqual(status_lint.lint(rows, {48, 358}, self.CLAIMED), [])
+
+    def test_the_exception_does_not_reach_the_citation_rule(self):
+        # Being newly registered says nothing about the pull request a row cites.
+        rows = [row(req=NEW, status="PARTIAL", pr="999")]
+        violations = status_lint.lint(rows, {48}, {}, bootstrapping={NEW})
+        self.assertEqual(len(violations), 1)
+        self.assertIn("#999", violations[0])
+
+    def test_the_set_is_the_difference_of_the_registries(self):
+        self.assertEqual(status_lint.newly_registered({"A"}, {"A", NEW}), {NEW})
+        self.assertEqual(status_lint.newly_registered({"A", NEW}, {"A", NEW}), frozenset())
+        # A removal introduces nothing.
+        self.assertEqual(status_lint.newly_registered({"A", NEW}, {"A"}), frozenset())
+        # The registry's own first commit introduced everything in it.
+        self.assertEqual(status_lint.newly_registered(set(), {"A"}), {"A"})
+
+
+class RegistryAtRefTests(unittest.TestCase):
+    def test_the_registry_is_read_at_the_ref_not_from_the_working_tree(self):
+        with RegistryHistory() as h:
+            self.assertIn(NEW, status_lint.registry_ids_at(h.introducing, cwd=h.root))
+            self.assertNotIn(NEW, status_lint.registry_ids_at(h.without, cwd=h.root))
+            self.assertIn("REQ-CORE-001", status_lint.registry_ids_at(h.without, cwd=h.root))
+
+    def test_a_commit_before_the_registry_existed_holds_no_identifiers(self):
+        with RegistryHistory() as h:
+            self.assertEqual(
+                status_lint.registry_ids_at(h.before_registry, cwd=h.root), frozenset()
+            )
+
+    def test_a_base_that_does_not_resolve_is_refused_not_treated_as_empty(self):
+        # Empty would make every identifier new, and the exception permanent.
+        with RegistryHistory() as h:
+            with self.assertRaises(LookupError):
+                status_lint.registry_ids_at("no-such-ref", cwd=h.root)
+
+    def test_the_cycle_of_369_end_to_end(self):
+        # Base: no NEW. Merged #358 claims NEW. The candidate registers NEW. No row.
+        with RegistryHistory() as h:
+            head = status_lint.registry_ids_at(h.introducing, cwd=h.root)
+            claimed = {NEW: [358]}
+
+            # The registering change, measured against the base it is proposed to.
+            new = status_lint.newly_registered(
+                status_lint.registry_ids_at(h.without, cwd=h.root), head
+            )
+            self.assertEqual(new, {NEW})
+            self.assertEqual(
+                status_lint.lint([row()], {48, 358}, claimed, bootstrapping=new), []
+            )
+
+            # The change after it, measured against a base that now carries NEW.
+            new = status_lint.newly_registered(
+                status_lint.registry_ids_at(h.introducing, cwd=h.root), head
+            )
+            self.assertEqual(new, frozenset())
+            self.assertEqual(
+                len(status_lint.lint([row()], {48, 358}, claimed, bootstrapping=new)), 1
+            )
+
+            # And once the row lands, nothing is exceptional any more.
+            rows = [row(), row(req=NEW, status="PARTIAL", issue="355", pr="358")]
+            self.assertEqual(
+                status_lint.lint(rows, {48, 358}, claimed, bootstrapping=new), []
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #369

## Achieved outcome

`status-lint` no longer stops the repository on a claim nobody is permitted to satisfy, and permits a missing ledger row for exactly the identifiers that the change under test introduces into the registry — for no other identifier and no later change.

Two halves. First, rule 1 now reaches the identifiers the registry under test knows, which are the ones the rendered table can lie about; a merged pull request that claims an identifier the registry does not know yet (#358 and `REQ-VISUALIZATION-007`) is printed as a `::warning::` and refuses nothing, because no permitted action can write that row — `implementation_status.validate` refuses an unregistered identifier, and ordinary branches may not touch the mirror. Second, the change that registers such an identifier — the mirror proposal, and the push that lands it, each measured against its own base — may lack that identifier's row; the very next change is refused again until the truthful row (#367) exists. `implementation_status.validate` is untouched, so a ledger row for an unregistered identifier is still refused; the machine-mirror class, its roots and its allowlist are untouched.

**Departure from the Issue's preferred shape, and why.** The Issue describes the exception only for the registering change and leaves every other pull request refused while the claim is unregistered. This pull request's first commit did exactly that, and its own `policy-guard` failed on `REQ-VISUALIZATION-007` — the fix could not pass the gate it fixes, and neither could anything else. A refusal that no permitted action can clear is a stop, not a gate; it held every pull request for seven hours. So the unregistered case is a warning. Everything the Issue's acceptance criteria ask for on the registered side holds unchanged.

Verified live against the real repository before pushing: this tree with the current `master` registry measured against `origin/master` (what this pull request's own check does) prints the warning and exits 0; the same tree carrying the registry from `origin/spec-mirror` measured against `origin/master` prints the notice and exits 0; that registry measured against `origin/spec-mirror` itself is refused (exit 1); a base that does not resolve is refused instead of treating everything as new.

## Tested revision

778edd2042100ce0b857ccbe8e3a80e6b1e8f5dd

## Changed artifacts

- `scripts/status_lint.py` — `lint()` takes `registered` (the identifiers the registry under test knows; `None` keeps the strict reading for a caller without a registry) and `bootstrapping` (identifiers this change introduces), and applies rule 1 to registered identifiers outside the bootstrapping set only; `unregistered_claims()` lists the claims neither ledger nor registry knows, for the warning; `newly_registered(base_ids, head_ids)` is the set difference; `registry_ids_at(ref)` reads the registry at a git ref (a ref that does not resolve raises, a ref with no registry file yields the empty set); `main()` gains `--base`, computes both sets from the two registries, prints a `::warning::` per unregistered claim and a `::notice::` per identifier permitted once, and refuses an unresolvable base. The module docstring states both rules beside rule 1.
- `scripts/tests/test_status_lint.py` — seventeen new tests: the pure exception (permitted, unrelated violation kept, expiry, truthful row, citation rule unaffected, set difference), the unregistered claim as warning and the registered one as violation, the strict reading without a registry, and a real three-commit repository reproducing the #369 cycle end to end from the unregistered state through registration to the row, including the base that must not be read as empty.
- `.github/workflows/ci.yml` — the lint step passes `--base`: `origin/<base_ref>` on a pull request (through the environment, as the neighbouring guards do), `HEAD^1` on a push. Nothing else in the job changes.

## Acceptance criteria

- [x] 1. A regression fixture reproduces the cycle — `RegistryHistory` in the tests: base without `REQ-VISUALIZATION-007`, merged #358 claims it, the candidate registry adds it, the ledger lacks it (`test_the_cycle_of_369_end_to_end`).
- [x] 2. The registry-introduction change is accepted only for the newly introduced identifier(s), without suppressing unrelated missing-ledger violations — `test_an_unrelated_missing_row_is_still_refused_beside_it` for registered identifiers; an unrelated *unregistered* claim is a warning rather than a violation, for the reason in the departure paragraph above.
- [x] 3. The immediate registry-introduction push stays green under the same one-commit rule — on push the workflow measures against `HEAD^1`, the parent of the squash commit; same code path as the pull request, proven by the end-to-end test with `h.without` as base.
- [x] 4. A subsequent unrelated commit/PR still fails while the identifier lacks a row — once the identifier is registered: `test_the_exception_expires_with_the_change_that_used_it`, `test_a_registered_identifier_without_a_row_is_still_a_violation`, the third step of the end-to-end test, and the live run with `--base origin/spec-mirror`.
- [x] 5. Once a truthful row lands, checks are fully green with no exception active — `test_a_truthful_row_ends_the_bootstrap` and the last step of the end-to-end test.
- [x] 6. Refusal of ledger rows whose IDs are not in the active registry remains intact — `implementation_status.py` is not in this diff.
- [x] 7. Machine mirror ownership/allowlist rules remain unchanged — `machine_pr_guard.py` and the allowlist are not in this diff.
- [x] 8. Existing policy/status-lint tests stay green and new tests prove the exception cannot become a permanent bypass — both sets come only from `registry_ids_at(base)` and the tree's registry; `test_a_base_that_does_not_resolve_is_refused_not_treated_as_empty` closes the one way the base could have been made empty; the whole `scripts/tests` suite passes locally.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest scripts.tests.test_status_lint` | passed | 22 tests, OK |
| `python -m unittest discover -s scripts/tests` | passed | whole control-plane suite, OK |
| `python scripts/status_lint.py --repo drevendev/trade_simulation --base origin/master` (tree = master registry) | passed | `::warning::` for `REQ-VISUALIZATION-007`, "27 ledger row(s) agree", exit 0 |
| same, tree carrying `origin/spec-mirror`'s registry | passed | `::notice::` for `REQ-VISUALIZATION-007`, exit 0 |
| same tree, `--base origin/spec-mirror` | passed | refused, exit 1 |
| `--base no-such-ref` | passed | "does not resolve to a commit", exit 1 |
| first commit of this pull request under CI | failed, by design | `policy-guard` refused it on `REQ-VISUALIZATION-007` — the demonstration that the Issue's strict shape cannot land its own fix |
| `dotnet build --configuration Release` | not_run | policy-only diff under `scripts/` and `.github/workflows/`; CI runs it on this pull request, and the change cannot reach the .NET tree. Residual risk: none beyond CI. |
| `dotnet test --configuration Release` | not_run | same reason and same residual risk. |

## Not checked

The push-event path (`HEAD^1`) was exercised through the end-to-end test with the parent commit as base, not on a real push to `master`. The first real exercise is the push that lands this pull request (an unregistered claim on `master`: warning, green) and then the one that lands the mirror proposal (bootstrap: notice, green); if either were refused, `master`'s own CI would go red on that commit while nothing else changed, which is loud and harmless to the queue.

## Assumptions and unknowns

Fact: every merge on `master` is a squash, so on a push `HEAD^1` is the previous `master` and "newly introduced relative to the parent" is what #369 specifies. Fact: the `policy-guard` job checks out with `fetch-depth: 0`, so both `origin/<base>` and `HEAD^1` resolve there. Fact: this pull request's first commit was refused by its own check on the very claim in question, which is the evidence for the departure above. Inference: no other consumer calls `status_lint.lint()` with positional arguments beyond the fourth; both new parameters are keyword-last and default to the strict behaviour.

## Highest-risk area for review

The narrowing of rule 1 to registered identifiers. What it gives up: a merged claim of a name the registry has never seen no longer blocks. What guards that gap: the warning is printed on every check until the mirror registers the name, and the row is then demanded by the very next change. A follow-up worth its own Issue is to refuse a pull request whose *own* title claims an unregistered identifier, which would have stopped #358 from merging under the name in the first place; it is not in this diff because it is a new rule, not the smallest exception.

## Remaining gate

After this merges: the open mirror proposal #370 was refused under the old definition and cannot be re-run under this one, so it is closed and the next `spec-sync` proposes afresh; that proposal passes with the notice and auto-merges. Then #367 adds the `PARTIAL` row for `REQ-VISUALIZATION-007`, after which every ordinary pull request is green again. Both steps are named in #369's own unblock sequence; no further authority is needed.
