### PR TITLE
record_usage: a crashed model step is a failed run, not an unknown one

### DIFF
--- a/scripts/record_usage.py
+++ b/scripts/record_usage.py
@@ -229,7 +229,7 @@ def final_text(messages) -> str:
     return last
 
 
-def classify_outcome(conclusion, text, effect=""):
+def classify_outcome(conclusion, text, effect="", execution_file=True):
     """(outcome, source). Pure.
 
     Four sources, consulted in order of how much each one knows.
@@ -251,10 +251,21 @@ def classify_outcome(conclusion, text, effect=""):
 
     What survives as `unknown` is now a run that did nothing observable and claimed
     nothing — a true statement rather than an artefact of phrasing.
+
+    `execution_file` says whether the model step left its output file at all. A step
+    that crashed — six runs did on 2026-09-08, `SDK execution error` inside the action —
+    ends with an *empty* conclusion and no file. That is neither of the conclusions the
+    workflow is trusted for above, so it fell through to the text heuristic, found no
+    final message, and was filed as `unknown` — the word reserved for a run that
+    produced output and claimed nothing. A crash is a `failed` run, and the workflow is
+    the source that knows it (#346). An empty conclusion *with* a file keeps the run's
+    own account: the step wrote something, so its last word still decides.
     """
     if conclusion == "no_work":
         return "no_work", "workflow"
     if conclusion not in (None, "", "unknown", "success"):
+        return "failed", "workflow"
+    if conclusion in (None, "") and not execution_file:
         return "failed", "workflow"
     if COMPLETED.search(text or ""):
         return "completed", "heuristic"
@@ -386,7 +397,11 @@ def main() -> int:
 
     # The outcome is read from the run's last word; mentions and rework from everything.
     outcome, outcome_source = classify_outcome(
-        args.conclusion, final_text(messages), args.effect
+        args.conclusion,
+        final_text(messages),
+        args.effect,
+        execution_file=bool(args.execution_file)
+        and pathlib.Path(args.execution_file).is_file(),
     )
     before = load_reading(args.usage_before)
     after = load_reading(args.usage_after)

--- a/scripts/tests/test_record_usage.py
+++ b/scripts/tests/test_record_usage.py
@@ -187,6 +187,36 @@ class OutcomeTests(unittest.TestCase):
         text = "## AUTHOR blocker\n\nGate: the registry names no READY row. status:blocked set."
         self.assertEqual(rec.classify_outcome("success", text), ("blocked", "heuristic"))
 
+    def test_a_crashed_step_with_no_execution_file_is_failed(self):
+        # 2026-09-08 22:31-23:41Z: six runs in a row died with `SDK execution error`
+        # inside the action. The step's conclusion was empty and it wrote no file; the
+        # heuristic then read an empty final message and filed each one as `unknown`,
+        # which made a measurement day look nine percent confused instead of having had
+        # one outage (#346).
+        for conclusion in ("", None):
+            with self.subTest(conclusion=conclusion):
+                self.assertEqual(
+                    rec.classify_outcome(conclusion, "", execution_file=False),
+                    ("failed", "workflow"),
+                )
+
+    def test_an_empty_conclusion_with_a_file_keeps_the_run_s_own_account(self):
+        # The step wrote something, so its last word still decides.
+        handoff = "## AUTHOR handoff\n\nPull request: #163"
+        self.assertEqual(
+            rec.classify_outcome("", handoff, execution_file=True), ("completed", "heuristic")
+        )
+        self.assertEqual(rec.classify_outcome("", "", execution_file=True), ("unknown", "heuristic"))
+
+    def test_the_crash_rule_reaches_no_other_conclusion(self):
+        # `no_work` and an explicit failure are decided before the file is consulted,
+        # and a step that concluded — green or `unknown` — did not crash: the signature
+        # of a crash is the empty conclusion, and `unknown` keeps its meaning elsewhere.
+        self.assertEqual(rec.classify_outcome("no_work", "", execution_file=False), ("no_work", "workflow"))
+        self.assertEqual(rec.classify_outcome("failure", "", execution_file=False), ("failed", "workflow"))
+        self.assertEqual(rec.classify_outcome("success", "", execution_file=False), ("unknown", "heuristic"))
+        self.assertEqual(rec.classify_outcome("unknown", "", execution_file=False), ("unknown", "heuristic"))
+
 
 class FinalTextTests(unittest.TestCase):
     def test_the_result_text_is_the_final_word(self):


### PR DESCRIPTION
Closes #346

## Achieved outcome

A run whose model step crashed — an empty workflow conclusion and no execution file — is recorded as `failed` with source `workflow`, not as `unknown`. `unknown` keeps the meaning #283 gave it: a run that produced output, claimed nothing and left no observable effect. An empty conclusion *with* an execution file keeps today's behaviour, and `no_work` and every explicit failure conclusion are unchanged.

## Tested revision

cd5fbb9421faecf9b36b0e54ac85c2b8ad8660e1

## Changed artifacts

- `scripts/record_usage.py` — `classify_outcome` takes `execution_file` (default `True`, so every existing caller keeps today's semantics); an empty conclusion without a file returns `("failed", "workflow")`, checked right after the explicit-failure rule and before any text heuristic. `main` derives the flag from whether the `--execution-file` path names an existing file. The docstring says why.
- `scripts/tests/test_record_usage.py` — three tests: the crash (empty and `None` conclusion, no file) is `failed`; an empty conclusion with a file still reads the run's own account (handoff → `completed`, nothing → `unknown`); the rule reaches no other conclusion (`no_work`, `failure`, `success`, `unknown` unchanged without a file).

## Acceptance criteria

- [x] 1. An empty conclusion with no execution file is `failed`, source `workflow` — `test_a_crashed_step_with_no_execution_file_is_failed`.
- [x] 2. An empty conclusion with an execution file keeps today's behaviour — `test_an_empty_conclusion_with_a_file_keeps_the_run_s_own_account`.
- [x] 3. `no_work` and every explicit failure conclusion are unchanged — `test_the_crash_rule_reaches_no_other_conclusion`, plus the existing outcome tests untouched.
- [x] 4. `unknown` keeps its #283 meaning for a run that produced output and claimed nothing — same test, `success` and `unknown` conclusions; existing `test_a_run_that_claims_nothing_is_unknown_not_completed` untouched.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest scripts.tests.test_record_usage` | passed | OK |
| `python -m unittest discover -s scripts/tests` | passed | whole control-plane suite, OK |
| `dotnet build --configuration Release` | not_run | policy-only diff under `scripts/`; CI runs it on this pull request, and the change cannot reach the .NET tree. Residual risk: none beyond CI. |
| `dotnet test --configuration Release` | not_run | same reason and same residual risk. |

## Not checked

No model step has crashed since the incident, so the new branch has not fired on a live run. The flag's derivation in `main` uses the same existence test `read_messages` already applies to the same path, so the two cannot disagree about whether a file was there.

## Assumptions and unknowns

Fact: the six crashed runs of 2026-09-08 22:31–23:41Z carry `conclusion: ""` in the ledger, so the empty conclusion is the crash's signature. Fact, per the Issue's non-goals: those six records are not rewritten. Inference: the action also leaves no execution file when it dies with `SDK execution error`; the six records carry `usage_source: unavailable`, which is what `read_messages` returns when the file is absent.

## Highest-risk area for review

The single new line in `classify_outcome` and its position: after the explicit-failure rule, before the heuristics. Moving it below the heuristics would let a crashed run with a stray final message be read as something it was not.

## Remaining gate

None. The change alters telemetry semantics, which is why the operator deferred it to the model rollout; that rollout is what this lands ahead of.
