### PR TITLE
roles: the model pin and cost ceiling come from repository variables

### DIFF
--- a/.github/workflows/zendev-acceptor.yml
+++ b/.github/workflows/zendev-acceptor.yml
@@ -180,6 +180,15 @@ jobs:
           # bill. The model is part of what governs a run, so it is declared here and
           # recorded in the telemetry ledger for every run.
           #
+          # The pin and the ceiling are read from repository variables, with the values
+          # written beside them as the fallback when a variable is unset. A model change
+          # is a new scheme (docs/zendev/schemes.json, tag scheme/N); as a line in this
+          # file it was a policy pull request with a full CI cycle each way, and as a
+          # variable the switch and the rollback take seconds and leave the definition
+          # untouched. What actually ran is still recorded per run, and record_usage
+          # marks a run whose model differs from the active scheme's declaration, so a
+          # variable set without a scheme shows up in the ledger rather than passing.
+          #
           # Circuit breaker, not a budget. A hard stop here is ungraceful — the run is
           # cut mid-work and cannot report its own blocker, and what it leaves behind
           # is an open branch nobody explains — so the ceiling is deliberately generous
@@ -193,7 +202,7 @@ jobs:
           # is the subscription window, where the whole loop occupies about three
           # points of a five-hour block, and a run approaching this figure is a defect
           # to read in the ledger rather than a budget being used up.
-          claude_args: --model claude-haiku-4-5 --max-budget-usd 3.00
+          claude_args: --model ${{ vars.ZENDEV_ACCEPTOR_MODEL || 'claude-haiku-4-5' }} --max-budget-usd ${{ vars.ZENDEV_ACCEPTOR_BUDGET_USD || '3.00' }}
           settings: |
             {
               "permissions": {

--- a/.github/workflows/zendev-author.yml
+++ b/.github/workflows/zendev-author.yml
@@ -172,6 +172,15 @@ jobs:
           # bill. The model is part of what governs a run, so it is declared here and
           # recorded in the telemetry ledger for every run.
           #
+          # The pin and the ceiling are read from repository variables, with the values
+          # written beside them as the fallback when a variable is unset. A model change
+          # is a new scheme (docs/zendev/schemes.json, tag scheme/N); as a line in this
+          # file it was a policy pull request with a full CI cycle each way, and as a
+          # variable the switch and the rollback take seconds and leave the definition
+          # untouched. What actually ran is still recorded per run, and record_usage
+          # marks a run whose model differs from the active scheme's declaration, so a
+          # variable set without a scheme shows up in the ledger rather than passing.
+          #
           # Circuit breaker, not a budget. A hard stop here is ungraceful — the run is
           # cut mid-work and cannot report its own blocker, and what it leaves behind
           # is an open branch nobody explains — so the ceiling is deliberately generous
@@ -185,7 +194,7 @@ jobs:
           # is the subscription window, where the whole loop occupies about three
           # points of a five-hour block, and a run approaching this figure is a defect
           # to read in the ledger rather than a budget being used up.
-          claude_args: --model claude-haiku-4-5 --max-budget-usd 5.00
+          claude_args: --model ${{ vars.ZENDEV_AUTHOR_MODEL || 'claude-haiku-4-5' }} --max-budget-usd ${{ vars.ZENDEV_AUTHOR_BUDGET_USD || '5.00' }}
           settings: |
             {
               "permissions": {

--- a/docs/zendev/SCHEDULING.md
+++ b/docs/zendev/SCHEDULING.md
@@ -93,6 +93,32 @@ $0.96 and an acceptor run $0.42, so halving the interval roughly doubles the cei
 An idle acceptor is cheap (about $0.07); an idle author is not, because an empty queue
 sends it to create one ready Issue rather than to stop.
 
+## Models and ceilings
+
+The model each role runs, and the per-run cost ceiling that stops a runaway, are
+repository variables read by the two role workflows. When a variable is unset the
+workflow falls back to the value written beside it in the workflow file.
+
+| Variable | Role | Fallback |
+| --- | --- | --- |
+| `ZENDEV_AUTHOR_MODEL` | AUTHOR | `claude-haiku-4-5` |
+| `ZENDEV_AUTHOR_BUDGET_USD` | AUTHOR | `5.00` |
+| `ZENDEV_ACCEPTOR_MODEL` | ACCEPTOR | `claude-haiku-4-5` |
+| `ZENDEV_ACCEPTOR_BUDGET_USD` | ACCEPTOR | `3.00` |
+
+A change to any of them is a change of scheme: add the descriptor to
+`docs/zendev/schemes.json`, make it `active`, tag `scheme/N`, and only then set the
+variable, so that no run is recorded under a descriptor that does not describe it.
+`record_usage` compares the model a run actually used with the active scheme's
+declaration and marks the record when they differ, so a variable set without a scheme
+shows up in the ledger rather than passing silently. The ceiling is a circuit breaker,
+not a budget: over the measured day of 2026-09-08/09 the author's costliest run was
+$1.30 against $5.00 and the acceptor's $0.59 against $3.00.
+
+```sh
+gh variable set ZENDEV_AUTHOR_MODEL -R drevendev/trade_simulation --body "claude-haiku-4-5"
+```
+
 ## External timer
 
 GitHub cron delivery has been unreliable for this repository, and the watchdog runs on


### PR DESCRIPTION
Closes #372

## Achieved outcome

The model each role runs and its per-run cost ceiling are read from repository variables — `ZENDEV_AUTHOR_MODEL`, `ZENDEV_AUTHOR_BUDGET_USD`, `ZENDEV_ACCEPTOR_MODEL`, `ZENDEV_ACCEPTOR_BUDGET_USD` — with today's literals as the fallback when a variable is unset. Switching a model and rolling it back are now a variable change that takes seconds and leaves the workflow definition untouched. The four variables are already set to today's values, so the first run after this merges passes exactly the `claude_args` the last run before it did. Nothing in what a run records changes: `record_usage` still writes the model actually used and still marks a run whose model differs from the active scheme's declaration.

## Tested revision

eb282d825146e873650c97f1564f4b7f425ccf20

## Changed artifacts

- `.github/workflows/zendev-author.yml` — `claude_args` reads `vars.ZENDEV_AUTHOR_MODEL || 'claude-haiku-4-5'` and `vars.ZENDEV_AUTHOR_BUDGET_USD || '5.00'`; the comment above it says why the values live in variables and how a variable set without a scheme is caught.
- `.github/workflows/zendev-acceptor.yml` — the same for `ZENDEV_ACCEPTOR_MODEL || 'claude-haiku-4-5'` and `ZENDEV_ACCEPTOR_BUDGET_USD || '3.00'`.
- `docs/zendev/SCHEDULING.md` — a "Models and ceilings" section beside the other loop variables: the four names, their fallbacks, and the order of operations for a model change (descriptor, `active`, tag, then variable).

## Acceptance criteria

- [x] 1. With the variables unset the workflows pass exactly today's `claude_args` — the `||` fallbacks are the literals removed from the same lines.
- [x] 2. With the variables set the workflows pass the variables' values — the expression is the action input itself; the four variables were set with `gh variable set` before this pull request was opened and hold today's values.
- [x] 3. `record_usage` still records the model a run used and still marks drift against the active scheme — nothing under `scripts/` is in this diff.
- [x] 4. The variables are documented with their fallbacks and the order of operations for a model change — `docs/zendev/SCHEDULING.md`.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest scripts.tests.test_loop_identities scripts.tests.test_repository_name_is_data scripts.tests.test_rework_limit scripts.tests.test_workflow_bookkeeping` | passed | the tests that read the two workflow files, OK |
| `python -m unittest discover -s scripts/tests` | passed | whole control-plane suite, OK |
| `dotnet build --configuration Release` | not_run | policy-only diff under `.github/workflows/` and `docs/zendev/`; CI runs it on this pull request. Residual risk: none beyond CI. |
| `dotnet test --configuration Release` | not_run | same reason and same residual risk. |

## Not checked

The expression has not yet been evaluated by a live run; the first dispatched run after merge is the check, and its telemetry record must carry `claude-haiku-4-5-20251001` with no drift mark, exactly as the run before it. The expression form `${{ vars.X || 'literal' }}` inside an action input is the documented one and is already used by this repository for `vars.ZENDEV_ENABLED`.

## Assumptions and unknowns

Fact: `vars` are set by repository administrators only, so reading them in an expression is not the attacker-controllable-text case the neighbouring comments warn about. Fact: the descriptor in `docs/zendev/schemes.json` is unchanged because no model or ceiling changes here; scheme/4 stays in force and its digest stays the same.

## Highest-risk area for review

The two `claude_args` lines. A typo in a variable name silently takes the fallback, which is today's value — the safe direction — and a typo in a fallback would only show once the variable were unset.

## Remaining gate

None for this change. The model switch itself is a separate decision: a new scheme in `docs/zendev/schemes.json`, tagged, and then the two model variables.
