### PR TITLE
status-lint: the merged listing is a window, and the repository outgrew it

### DIFF
--- a/scripts/status_lint.py
+++ b/scripts/status_lint.py
@@ -196,6 +196,14 @@ def _gh(args):
     ).stdout
 
 
+# The listing is a window over the newest merges. It was 200 until 2026-09-10, when the
+# repository passed two hundred merges: #24 fell out of the window between the check on
+# #397 and the check on its merge, and rule 2 refused every push for a correct row
+# (#398). The limit is now far above the repository, and `cited_but_unlisted`
+# below asks the forge about any cited number the window still misses.
+MERGED_LISTING_LIMIT = 2000
+
+
 def load_merged_pulls(repo: str):
     """Return (merged numbers, {REQ-ID: [pull numbers]}) from merged pull titles."""
     raw = _gh(
@@ -207,7 +215,7 @@ def load_merged_pulls(repo: str):
             "--state",
             "merged",
             "--limit",
-            "200",
+            str(MERGED_LISTING_LIMIT),
             "--json",
             "number,title",
         ]
@@ -219,6 +227,26 @@ def load_merged_pulls(repo: str):
         for req in REQ_ID.findall(pull.get("title") or ""):
             claimed.setdefault(req, []).append(pull["number"])
     return numbers, claimed
+
+
+def cited_but_unlisted(rows, merged_pull_numbers):
+    """Pull numbers the ledger cites that the merged listing does not carry. Pure.
+
+    A window says nothing about what lies outside it, so each of these is asked about
+    individually before rule 2 may call it unmerged.
+    """
+    cited = set()
+    for row in rows:
+        pull = (row.get("PR") or "").strip()
+        if pull.isdigit() and int(pull) not in merged_pull_numbers:
+            cited.add(int(pull))
+    return sorted(cited)
+
+
+def is_merged(repo: str, number: int) -> bool:
+    """One pull request's state from the forge: the listing is a window, this is not."""
+    raw = _gh(["pr", "view", str(number), "--repo", repo, "--json", "state"])
+    return (json.loads(raw).get("state") or "").upper() == "MERGED"
 
 
 def main() -> int:
@@ -257,6 +285,11 @@ def main() -> int:
         bootstrapping = frozenset()
 
     merged_numbers, claimed = load_merged_pulls(args.repo)
+    for number in cited_but_unlisted(rows, merged_numbers):
+        if number == self_pull:
+            continue
+        if is_merged(args.repo, number):
+            merged_numbers.add(number)
     recorded = {(row.get("REQ_ID") or "").strip() for row in rows}
     for req in unregistered_claims(rows, claimed, head_ids):
         where = ", ".join("#%d" % p for p in sorted(claimed[req]))

--- a/scripts/tests/test_status_lint.py
+++ b/scripts/tests/test_status_lint.py
@@ -28,6 +28,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
@@ -153,6 +154,36 @@ class DelegationTests(unittest.TestCase):
         self.assertIn("IMPLEMENTED", status_lint.CITES_MERGED_CODE)
         self.assertIn("PARTIAL", status_lint.CITES_MERGED_CODE)
         self.assertNotIn("BLOCKED", status_lint.CITES_MERGED_CODE)
+
+
+class MergedListingWindowTests(unittest.TestCase):
+    """The merged listing is a window over the newest merges, not the whole history.
+
+    On 2026-09-10 the repository passed two hundred merges. #24 fell out of the window
+    between the check on #397 and the check on its merge, and rule 2 refused every push
+    for a row that was correct. A window says nothing about what lies outside it.
+    """
+
+    def test_a_cited_number_the_listing_does_not_carry_is_singled_out(self):
+        rows = [row(req="REQ-MIGRATION-001", pr="24"), row(req="REQ-CORE-002", pr="48")]
+        self.assertEqual(status_lint.cited_but_unlisted(rows, {48}), [24])
+
+    def test_rows_without_a_numeric_citation_are_left_alone(self):
+        rows = [row(status="BLOCKED", pr=""), row(req="REQ-CORE-002", pr="n/a")]
+        self.assertEqual(status_lint.cited_but_unlisted(rows, set()), [])
+
+    def test_the_listing_asks_for_far_more_than_the_repository_holds(self):
+        with mock.patch.object(status_lint, "_gh", return_value="[]") as gh:
+            status_lint.load_merged_pulls("owner/name")
+        args = gh.call_args[0][0]
+        self.assertIn("--limit", args)
+        self.assertGreaterEqual(int(args[args.index("--limit") + 1]), 1000)
+
+    def test_a_number_outside_the_window_is_asked_about_individually(self):
+        with mock.patch.object(status_lint, "_gh", return_value='{"state": "MERGED"}'):
+            self.assertTrue(status_lint.is_merged("owner/name", 24))
+        with mock.patch.object(status_lint, "_gh", return_value='{"state": "OPEN"}'):
+            self.assertFalse(status_lint.is_merged("owner/name", 24))
 
 
 REGISTRY = "docs/spec/mirror/REQUIREMENTS_REGISTRY.csv"


### PR DESCRIPTION
Closes #398

## Achieved outcome

`status-lint` stays correct past two hundred merged pull requests. The merged listing it reads is now capped at 2000 rather than 200, and any pull request the ledger cites that the listing still does not carry is asked about individually before rule 2 may call it unmerged. A row citing a merged pull request older than the window is not a violation; a row citing an open one still is; rule 1 still reads every merged title the listing returns. This is the refusal that turned `master` red at 17:24Z today on `REQ-MIGRATION-001` citing #24, merged on 2026-09-03.

## Tested revision

056869a86463088389a1ea8f81de3518a721b367

## Changed artifacts

- `scripts/status_lint.py` — `MERGED_LISTING_LIMIT = 2000` with the reason beside it; `cited_but_unlisted(rows, merged)` selects the cited numbers the window misses; `is_merged(repo, number)` asks the forge about one; `main()` folds the merged ones into the set before linting, skipping the pull request under check, which rule 2 already exempts.
- `scripts/tests/test_status_lint.py` — `MergedListingWindowTests`: the selection, the rows without a numeric citation, the limit the listing asks for (with the forge mocked), and the per-number lookup for a merged and an open state.

## Acceptance criteria

- [x] 1. A row citing a merged pull request older than the listing window is not a violation — live: this tree measured against `origin/master` on the current ledger passes, where the tree on `master` fails on #24.
- [x] 2. A row citing an open pull request older than the window is still a violation — `test_a_number_outside_the_window_is_asked_about_individually`, the open case, and rule 2 unchanged.
- [x] 3. Rule 1 still reads every merged title the listing returns — `load_merged_pulls` is unchanged apart from the limit.
- [x] 4. The control-plane suite stays green — passes locally.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -m unittest scripts.tests.test_status_lint` | passed | OK |
| `python -m unittest discover -s scripts/tests` | passed | whole control-plane suite, OK |
| `python scripts/status_lint.py --repo drevendev/trade_simulation --base origin/master` on this tree | passed | "29 ledger row(s) agree", exit 0 |
| the same command with the `master` version of the script | failed, as on CI | refuses `REQ-MIGRATION-001` citing #24 |
| `dotnet build --configuration Release` | not_run | policy-only diff under `scripts/`; CI runs it on this pull request. Residual risk: none beyond CI. |
| `dotnet test --configuration Release` | not_run | same reason and same residual risk. |

## Not checked

The per-number lookup against a real pull request older than 2000 merges; none exists yet. It is exercised with the forge mocked, and the live run above exercises the listing path.

## Assumptions and unknowns

Fact: `gh pr list` pages through GraphQL internally, so a limit of 2000 costs at most twenty requests and today costs three. Judgement: rule 1 cannot see claims made by merged pull requests older than the listing; at 2000 that is years away at today's pace, and a claim that old either has its row or predates the registry.

## Highest-risk area for review

`main()` skipping `self_pull` in the fold: the row citing the pull request under check must keep its exemption from rule 2 rather than be asked about, which would report it as open.

## Remaining gate

None. `master`'s next push is the live check; it is currently refused on every push and pull request until this lands.
