### PR TITLE
schemes: scheme/5, both roles on Sonnet 5

### DIFF
--- a/docs/zendev/schemes.json
+++ b/docs/zendev/schemes.json
@@ -13,7 +13,7 @@
     "descriptor in the tag message, and every telemetry record carries {id, digest} so",
     "a measurement window can be sliced by scheme without knowing any dates."
   ],
-  "active": "scheme/4",
+  "active": "scheme/5",
   "schemes": [
     {
       "id": "scheme/1",
@@ -85,6 +85,26 @@
       "rework_limit": 3,
       "cadence_minutes": 25,
       "note": "Activated by a repository variable rather than a merge, so `commit` records where master stood at `in_force_from`: ZENDEV_QA_LOGIN was set at 2026-09-07T22:53:33Z and the intake job cannot run without it. The QA voice began commenting earlier, at 21:48Z, so telemetry records between 21:48Z and 22:53Z say scheme/3 while a third voice was already speaking — two comments, no verdict taken on either. The earlier plan named this account AndyDev; the account is andy-zen-dev."
+    },
+    {
+      "id": "scheme/5",
+      "in_force_from": "",
+      "commit": "",
+      "summary": "Both roles move from Haiku 4.5 to Sonnet 5; everything else exactly as scheme/4.",
+      "roles": {
+        "author": {"identity": "zendev-author[bot]", "model": "claude-sonnet-5", "max_budget_usd": 5.0},
+        "acceptor": {"identity": "zendev-acceptor[bot]", "model": "claude-sonnet-5", "max_budget_usd": 3.0},
+        "machine": {"identity": "zendev-machine[bot]", "model": null}
+      },
+      "verdict_owner": "zendev-acceptor",
+      "voices": [
+        "EndlessZen as drevendev, owns the specification",
+        "SLOPSTER as andy-zen-dev, read-only: comments and Issues, never a formal review"
+      ],
+      "required_checks": ["build-and-test", "typescript", "policy-guard", "mergeability"],
+      "rework_limit": 3,
+      "cadence_minutes": 25,
+      "note": "The experiment decided on 2026-09-09: does a stronger model need fewer rework rounds per requirement, so that the cost of a landed requirement grows by less than the 2x per-token price? Measured against the scheme/4 day of 2026-09-08 21:24Z to 2026-09-09 21:24Z: $27.47 per day, author mean $0.445 and max $1.30, acceptor mean $0.128 and max $0.59, 22 merges, one pull request closed by the rework bound. Forecast at equal volume about $55 per day. Ceilings unchanged on purpose: the costliest runs reached 26% and 20% of them. Effort is the CLI's default; no effort flag is passed. Activated by the two model variables (ZENDEV_AUTHOR_MODEL, ZENDEV_ACCEPTOR_MODEL) after this descriptor is active and the tag is cut, so `in_force_from` and `commit` are filled after activation, which does not change the digest. The queue at activation is the M3 tail: four PARTIAL rows under rework and one blocked, with M4's fifteen rows indexed and waiting on the M3 gate."
     }
   ]
 }


### PR DESCRIPTION
Closes #400

## Achieved outcome

`docs/zendev/schemes.json` carries scheme/5 and names it `active`: both roles on `claude-sonnet-5`, everything else exactly as scheme/4 — identities, ceilings $5.00 and $3.00, verdict owner, voices, required checks, rework limit 3, cadence 25. The note records the question the scheme exists to answer, the measured scheme/4 day it is compared against, the forecast, and why the ceilings stay. Nothing runs differently until the two model variables are set; that is the activation step, done right after this merges and the tag is cut, in the order `docs/zendev/SCHEDULING.md` prescribes. Until then every run keeps recording scheme/5's digest against a Haiku run and would be marked as drift, which is why the variables follow within the same minute.

## Tested revision

ffc36e47a372d37720dce0aa13e26cf926ce3775

## Changed artifacts

- `docs/zendev/schemes.json` — `active` moves to `scheme/5`; one appended descriptor. `in_force_from` and `commit` are empty and are filled after activation, as scheme/4's were; neither is a descriptive key, so filling them does not change the digest.

## Acceptance criteria

- [x] 1. The document parses and `schemes.active()` returns the scheme/5 descriptor — checked locally, digest printed in the checks.
- [x] 2. scheme/5 differs from scheme/4 in the two model fields and nothing else — the entry is scheme/4's text with the models replaced.
- [x] 3. The control-plane suite stays green with the new active scheme — `python -m unittest discover -s scripts/tests`.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -c "import schemes; ..."` | passed | active is scheme/5, digest 40649161be97 |
| `python -m unittest scripts.tests.test_schemes` | passed | OK |
| `python -m unittest discover -s scripts/tests` | passed | whole control-plane suite, OK |
| `dotnet build --configuration Release` | not_run | a policy document only; CI runs it on this pull request. Residual risk: none beyond CI. |
| `dotnet test --configuration Release` | not_run | same reason and same residual risk. |

## Not checked

The first Sonnet run itself; it is the activation step's evidence, read from the telemetry record: model `claude-sonnet-5-…`, scheme `scheme/5` with this digest, no drift mark, and its cost against the forecast.

## Assumptions and unknowns

Fact, verified on 2026-09-10 against the API reference: the model id is `claude-sonnet-5`, priced $2 and $10 per million tokens, context 1M, adaptive thinking and effort levels supported. Fact: `record_usage` accepts a dated model id as matching the declared bare id. Unknown: whether the harness fills more context on a 1M-context model; if `cache_read_input_tokens` per run grows beyond twice Haiku's in the first hours, that is the first thing to read.

## Highest-risk area for review

The order of operations after merge. Tag, then variables, within the same minute and away from the :00/:30 acceptor and :10/:40 author slots; a run landing between the merge and the variables is recorded as drift, harmless but noisy.

## Remaining gate

The owner's decision to activate, already given on 2026-09-10 in the operator session. After activation: a follow-up fills `in_force_from` and `commit`.
