### PR TITLE
schemes: scheme/5 took effect at 2026-09-10T17:41:04Z on 23765df

### DIFF
--- a/docs/zendev/schemes.json
+++ b/docs/zendev/schemes.json
@@ -88,8 +88,8 @@
     },
     {
       "id": "scheme/5",
-      "in_force_from": "",
-      "commit": "",
+      "in_force_from": "2026-09-10T17:41:04Z",
+      "commit": "23765df",
       "summary": "Both roles move from Haiku 4.5 to Sonnet 5; everything else exactly as scheme/4.",
       "roles": {
         "author": {"identity": "zendev-author[bot]", "model": "claude-sonnet-5", "max_budget_usd": 5.0},


### PR DESCRIPTION
Closes #400

## Achieved outcome

scheme/5's descriptor records the moment it took effect: `in_force_from` is the second the two model variables were set to `claude-sonnet-5`, and `commit` is where `master` stood at that moment, exactly as scheme/4's were recorded. Neither key is descriptive, so the digest every telemetry record carries is unchanged (`40649161be97`), and no record moves between schemes.

## Tested revision

33b492dc27c9c0b059ccc19785fc2cb9d0a9753b

## Changed artifacts

- `docs/zendev/schemes.json` — two fields of the scheme/5 entry filled; nothing else.

## Acceptance criteria

- [x] 1. The first run after activation records model `claude-sonnet-5-…`, scheme `scheme/5`, no drift mark — the ACCEPTOR run recorded at 18:06:17Z: model `claude-sonnet-5`, scheme `scheme/5` digest `40649161be97`, no drift mark, outcome completed, $0.91, 35 turns.
- [x] 2. Cadence, outcomes and cost are read from the same telemetry script as the base, after 24 hours — the script and the base are recorded in the operator's notes; the 24-hour reading is due at 2026-09-11T17:41:04Z.
- [x] 3. A rollback is the two variables set back to `claude-haiku-4-5` plus a scheme/6 descriptor — documented in `docs/zendev/SCHEDULING.md`, Models and ceilings.

## Checks

| Check | Outcome | Evidence |
| --- | --- | --- |
| `python -c "import schemes; ..."` | passed | digest unchanged, `40649161be97` |
| `python -m unittest discover -s scripts/tests` | passed | whole control-plane suite, OK |
| `dotnet build --configuration Release` | not_run | a policy document only; CI runs it on this pull request. Residual risk: none beyond CI. |
| `dotnet test --configuration Release` | not_run | same reason and same residual risk. |

## Not checked

Nothing beyond the fields themselves; the activation is already live and its first record is cited above.

## Assumptions and unknowns

Fact: the activation moment is the variable-set time printed by the operator's own command, and `commit` is `origin/master` fetched in the same second. The tag `scheme/5` on that commit carries the same descriptor and the same two values in its message.

## Highest-risk area for review

None; a two-field documentation change on a non-descriptive part of the descriptor.

## Remaining gate

None. The measured day runs from `in_force_from`; the comparison is the operator's work after it.
